### PR TITLE
build zypp-refresh wrapper with PIE

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,8 @@ INSTALL(  FILES
 # zypp-refresh utility
 ADD_EXECUTABLE( zypp-refresh zypp-refresh.cc )
 TARGET_LINK_LIBRARIES( zypp-refresh ${ZYPP_LIBRARY} )
+SET_TARGET_PROPERTIES( zypp-refresh PROPERTIES LINK_FLAGS "-pie -Wl,-z,relro,-z,now")
+SET_TARGET_PROPERTIES( zypp-refresh PROPERTIES COMPILE_FLAGS "-fwhole-program -fpie -fPIE")
 INSTALL(
   TARGETS zypp-refresh
   RUNTIME DESTINATION ${INSTALL_PREFIX}/sbin


### PR DESCRIPTION
The attached patch builds zypp-refresh wrapper with PIE , see opensuse-factory list for details.
