### PR TITLE
Build with -fvisibility-inlines-hidden

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
 ADD_DEFINITIONS( -D_FILE_OFFSET_BITS=64 )
 ADD_DEFINITIONS( -DVERSION="${VERSION}" )
 
-SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O2 -Wall -Woverloaded-virtual -Wnon-virtual-dtor -fstack-protector -std=c++0x" )
+SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O2 -Wall -Woverloaded-virtual -Wnon-virtual-dtor -fstack-protector -std=c++0x -fvisibility-inlines-hidden" )
 SET( CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -g -O2 -Wall -fstack-protector" )
 
 GENERATE_PACKAGING(${PACKAGE} ${VERSION})


### PR DESCRIPTION
This shirks the executable size on a few hundreds of kilobytes and will likely make it a little bit faster.
