### PR TITLE
Fix regexp in update bnc#725872

### DIFF
--- a/src/RequestFeedback.cc
+++ b/src/RequestFeedback.cc
@@ -73,8 +73,10 @@ string SolverRequester::Feedback::asUserString(
 
   case NOT_INSTALLED:
     if (_reqpkg.orig_str.find_first_of("?*") != string::npos) // wildcards used
-      return str::form(
-        _("No package matching '%s' are installed."), _reqpkg.orig_str.c_str());
+      // Do not return anything for regexes as solver report for every matched
+      // package if it is installed or not resulting in multiple useless
+      // messages see BNC#725872
+      return "";
     else
       return str::form(
         _("Package '%s' is not installed."), _reqpkg.orig_str.c_str());


### PR DESCRIPTION
So from previous result

```
zypper up *lib
No package matching 'lib*' are installed.
490 repetitions
```

is now

```
Loading repository data...
Reading installed packages...
No update candidate for 'cracklib-2.9.0-1.4.x86_64'. The highest available version is already installed.
No update candidate for 'dbus-1-glib-0.100.2-1.4.x86_64'. The highest available version is already installed.
No update candidate for 'python-xlib-0.14-104.3.x86_64'. The highest available version is already installed.
Resolving package dependencies...

Nothing to do.
```
