### PR TITLE
Add note that openSUSE only supports "zypper dup" one release at a time.

### DIFF
--- a/doc/zypper.8
+++ b/doc/zypper.8
@@ -745,6 +745,10 @@ uses only the specified repositories, while with --from
 zypper can also use the rest of the enabled repositories to
 satisfy package dependencies.
 
+Note: distribution upgrades in openSUSE are currently only supported between
+consecutive releases. To upgrade multiple releases, upgrade each consecutive
+release one at a time.
+
 .TP
 \fI\ \ \ \ \-\-from\fR <alias|name|#|URI>
 Restricts the upgrade to the specified repositories (the option can be used


### PR DESCRIPTION
Add note to the man page that openSUSE only supports "zypper dup" one release at a time.
