### PR TITLE
only use ANSI codes on terminals (bnc#925678)

### DIFF
--- a/src/utils/ansi.h
+++ b/src/utils/ansi.h
@@ -210,6 +210,8 @@ namespace ansi
 #else
       static const std::string _reset( "\033[0m" );
 #endif
+      static const std::string _noreset( "" );
+      if(!do_colors()) return _noreset;
       return _reset;
     }
 


### PR DESCRIPTION
https://bugzilla.opensuse.org/show_bug.cgi?id=925678
reported that in non-terminal cases ANSI color-codes
were left out, but color-reset codes still appeared