### PR TITLE
avoid blocking+malloc below signal_handler (bnc#929826)

### DIFF
--- a/src/Zypper.cc
+++ b/src/Zypper.cc
@@ -149,8 +149,6 @@ Zypper::Ptr & Zypper::instance()
 
   if (!_instance)
     _instance.reset(new Zypper());
-  else
-    XXX << "Got an existing instance." << endl;
 
   return _instance;
 }
@@ -5202,8 +5200,6 @@ void Zypper::doCommand()
 
 void Zypper::cleanup()
 {
-  MIL << "START" << endl;
-
   // remove the additional repositories specified by --plus-repo
   for (list<RepoInfo>::const_iterator it = _rdata.additional_repos.begin();
          it != _rdata.additional_repos.end(); ++it)

--- a/src/main.cc
+++ b/src/main.cc
@@ -35,16 +35,15 @@ void signal_handler(int sig)
     }
     else*/
     {
-      // translators: this will show up if you press ctrl+c twice (but outside of zypper shell)
-      cerr << endl << _("OK OK! Exiting immediately...") << endl;
+      cerr << endl << "OK OK! Exiting immediately..." << endl;
       zypper.cleanup();
-      exit(ZYPPER_EXIT_ON_SIGNAL);
+      _exit(ZYPPER_EXIT_ON_SIGNAL);
     }
   }
   else if (zypper.runtimeData().waiting_for_input)
   {
     zypper.cleanup();
-    exit(ZYPPER_EXIT_ON_SIGNAL);
+    _exit(ZYPPER_EXIT_ON_SIGNAL);
   }
   else
   {

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <signal.h>
+#include <fcntl.h>
 //#include <readline/readline.h>
 
 #include <zypp/base/LogTools.h>
@@ -19,6 +20,15 @@
 
 using namespace std;
 
+static void set_zypper_cleanup_marker()
+{
+  int fd = open("/var/cache/zypp/cleanup-needed", O_WRONLY|O_CREAT|O_TRUNC, 0644);
+  if (fd >= 0)
+  {
+    close(fd);
+  }
+}
+
 void signal_handler(int sig)
 {
   Zypper & zypper = *Zypper::instance();
@@ -35,14 +45,14 @@ void signal_handler(int sig)
     }
     else*/
     {
+      set_zypper_cleanup_marker();
       cerr << endl << "OK OK! Exiting immediately..." << endl;
-      zypper.cleanup();
       _exit(ZYPPER_EXIT_ON_SIGNAL);
     }
   }
   else if (zypper.runtimeData().waiting_for_input)
   {
-    zypper.cleanup();
+    set_zypper_cleanup_marker();
     _exit(ZYPPER_EXIT_ON_SIGNAL);
   }
   else


### PR DESCRIPTION
the old code would deadlock and block until killed with kill -9

https://bugzilla.opensuse.org/show_bug.cgi?id=929826

see also
http://pubs.opengroup.org/onlinepubs/009695399/functions/xsh_chap02_04.html#tag_02_04_03
for a list of signal-safe functions
