### PR TITLE
add apt-get alias for aptitude

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ INSTALL(
 
 # zypper-aptitude compat tool
 INSTALL(
-  PROGRAMS tools/aptitude
+  PROGRAMS tools/aptitude tools/apt-get
   DESTINATION ${INSTALL_PREFIX}/bin
 )
 INSTALL(

--- a/tools/apt-get
+++ b/tools/apt-get
@@ -1,0 +1,1 @@
+aptitude

--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -179,6 +179,7 @@ rm -rf "$RPM_BUILD_ROOT"
 %files aptitude
 %defattr(-,root,root)
 %{_bindir}/aptitude
+%{_bindir}/apt-get
 %dir %{_sysconfdir}/zypp/apt-packagemap.d/
 %config(noreplace) %{_sysconfdir}/zypp/apt-packagemap.d/*
 


### PR DESCRIPTION
using a symlink
This allows more Debian CLI examples to be used verbatim.