### PR TITLE
Provide priority option on addrepo command.

### DIFF
--- a/src/Zypper.cc
+++ b/src/Zypper.cc
@@ -1694,6 +1694,7 @@ void Zypper::processCommandOptions()
       {"check", no_argument, 0, 'c'},
       {"no-check", no_argument, 0, 'C'},
       {"name", required_argument, 0, 'n'},
+      {"priority", required_argument, 0, 'p'},
       {"keep-packages", no_argument, 0, 'k'},
       {"no-keep-packages", no_argument, 0, 'K'},
       {"gpgcheck", no_argument, 0, 'g'},
@@ -1711,17 +1712,18 @@ void Zypper::processCommandOptions()
       " or can be read from specified .repo file (even remote).\n"
       "\n"
       "  Command options:\n"
-      "-r, --repo <file.repo>  Just another means to specify a .repo file to read.\n"
-      "-t, --type <type>       Type of repository (%s).\n"
-      "-d, --disable           Add the repository as disabled.\n"
-      "-c, --check             Probe URI.\n"
-      "-C, --no-check          Don't probe URI, probe later during refresh.\n"
-      "-n, --name <name>       Specify descriptive name for the repository.\n"
-      "-k, --keep-packages     Enable RPM files caching.\n"
-      "-K, --no-keep-packages  Disable RPM files caching.\n"
-      "-g, --gpgcheck          Enable GPG check for this repository.\n"
-      "-G, --no-gpgcheck       Disable GPG check for this repository.\n"
-      "-f, --refresh           Enable autorefresh of the repository.\n"
+      "-r, --repo <file.repo>    Just another means to specify a .repo file to read.\n"
+      "-t, --type <type>         Type of repository (%s).\n"
+      "-d, --disable             Add the repository as disabled.\n"
+      "-c, --check               Probe URI.\n"
+      "-C, --no-check            Don't probe URI, probe later during refresh.\n"
+      "-n, --name <name>         Specify descriptive name for the repository.\n"
+      "-p, --priority <integer>  Set priority of the repository.\n"
+      "-k, --keep-packages       Enable RPM files caching.\n"
+      "-K, --no-keep-packages    Disable RPM files caching.\n"
+      "-g, --gpgcheck            Enable GPG check for this repository.\n"
+      "-G, --no-gpgcheck         Disable GPG check for this repository.\n"
+      "-f, --refresh             Enable autorefresh of the repository.\n"
     ), "yast2, rpm-md, plaindir");
     break;
   }


### PR DESCRIPTION
- refactor priority parsing into parse_priority()
- add priority to addrepo for both by repo file and url cases

I have desired this feature for quite a while, since it seems the only proper way to add repositories is with a priority, but that requires adding then modifying. That makes documentation on how to add a repo cumbersome in addition to usage.

This has been discussed on mailing list a few times including http://lists.opensuse.org/opensuse-factory/2015-07/msg00377.html thread.

Semi-related it seem like a good idea for repositories on obs to include a priority in their `.repo` file relevant to their intended usage. Most likely this would be best done with string priorities as suggested in the todo in `repos.cc`. I may implement that next after this pull request has been accepted.