### PR TITLE
Suggest setting a non-default repo priority.

### DIFF
--- a/src/Zypper.cc
+++ b/src/Zypper.cc
@@ -4816,11 +4816,35 @@ void Zypper::doCommand()
 
     if (!copts.count("repo") && !copts.count("from")
         && repoManager().knownRepositories().size() > 1)
+    {
       out().warning(str::form(_(
         "You are about to do a distribution upgrade with all enabled"
         " repositories. Make sure these repositories are compatible before you"
         " continue. See '%s' for more information about this command."),
         "man zypper"));
+
+      // check to see if all repos have the default priority
+      bool defaultPriority = true;
+      RepoInfoList repos = repoManager().knownRepositories();
+      for ( RepoInfoList::iterator it = repos.begin(); it != repos.end(); ++it )
+      {
+        RepoInfo & nrepo( *it );
+        if ( nrepo.priority() != RepoInfo::defaultPriority() )
+        {
+          defaultPriority = false;
+          break;
+        }
+      }
+
+      if ( defaultPriority )
+      {
+        out().warning(_(
+          "All repositories have the default priority."
+          " Use \"zypper modifyrepo --priority <integer> ...\" to set priorities,"
+          " lower numbers for repositories that replace default packages and higher"
+          " for missing packages."));
+      }
+    }
 
     init_target(*this);
     init_repos(*this);

--- a/src/repos.cc
+++ b/src/repos.cc
@@ -1755,6 +1755,13 @@ void add_repo(Zypper & zypper, RepoInfo & repo)
     // translators: property name; short; used like "Name: value"
     p.add( _("URI"),		repo.baseUrlsBegin(), repo.baseUrlsEnd() );
     s << p;
+
+    if ( repo.priority() == RepoInfo::defaultPriority() )
+    {
+      s << endl << "  " <<
+        _("(use \"zypper addrepo --priority <integer> ...\" to ensure repositories are utilized as desired,"
+          " lower numbers for repositories that replace default packages and higher for missing packages)");
+    }
   }
   zypper.out().info(s.str());
 


### PR DESCRIPTION
Encourage discovery of repository priorities which are important for maintaining
a stable system in general and especially when using Tumbleweed as many users
dup regularly. The messages do not interfere with normal behavior, but instead
focus on discovery rather than annoying prompts.

Messages are displayed:
- after `zypper addrepo` when using default priority
- before `zypper dup` with all default priorities

This is similar to the various helpful suggestions `git` makes. For example:

```
$ git status
On branch master
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

        modified:   README.txt

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

        modified:   benchmarks.rb
```

I tried to keep the wording as condensed as possible since these are just tips and the man pages should be consulted for more detail. From the man page:

```
           -p, --priority positive-integer
               Set priority of the repository. Priority of 1 is the highest, the higher the number the lower the priority. Default
               priority is 99. Packages from repositories with higher priority will be preferred even in case there is a higher
               installable version available in the repository with a lower priority.
```

Which seems sufficient. If desired I can followup by adding some example situations to the man pages to make it clearer.
