### PR TITLE
tests/lib: Fix name of boost_thread library being linked

### DIFF
--- a/tests/lib/CMakeLists.txt
+++ b/tests/lib/CMakeLists.txt
@@ -3,4 +3,4 @@ ADD_LIBRARY(zypper_test_utils
 )
 
 SET_TARGET_PROPERTIES(zypper_test_utils PROPERTIES LINKER_LANGUAGE CXX)
-TARGET_LINK_LIBRARIES(zypper_test_utils ${ZYPP_LIBRARY} boost_thread-mt)
+TARGET_LINK_LIBRARIES(zypper_test_utils ${ZYPP_LIBRARY} boost_thread)


### PR DESCRIPTION
The tests fail to build and run on Fedora and OpenSUSE without the library name being fixed, since `libboost_thread-mt.so` doesn't exist anymore.