### PR TITLE
aptitude: simulate is non-interactive (boo#1028119)

### DIFF
--- a/tools/aptitude
+++ b/tools/aptitude
@@ -33,7 +33,7 @@ my @zopt;
 my @zopt2;
 foreach(@options) {
 	shift @ARGV;
-	if($_ eq "-s" || $_ eq "--simulate") {push @zopt2, "--dry-run"}
+	if($_ eq "-s" || $_ eq "--simulate") {push @zopt2, "--dry-run -y"}
 	if($_ eq "-d" || $_ eq "--download-only") {push @zopt2, "--download-only"}
 	if($_ eq "-y" || $_ eq "--assume-yes") {push @zopt, "--non-interactive"}
 	if($_ eq "-q" || $_ eq "--quiet") {push @zopt, "--quiet"}


### PR DESCRIPTION
https://bugzilla.opensuse.org/show_bug.cgi?id=1028119

puppet-agent expects apt-get -s upgrade to be non-interactive