### PR TITLE
Add Debian apt compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ INSTALL(
 
 # zypper-aptitude compat tool
 INSTALL(
-  PROGRAMS tools/aptitude tools/apt-get
+  PROGRAMS tools/aptitude tools/apt-get tools/apt
   DESTINATION ${INSTALL_PREFIX}/bin
 )
 INSTALL(

--- a/package/zypper.changes
+++ b/package/zypper.changes
@@ -27,6 +27,11 @@ Thu Nov 23 12:34:53 CET 2017 - ma@suse.de
 - version 1.14.0
 
 -------------------------------------------------------------------
+Fri Nov 17 08:55:57 UTC 2017 - bwiedemann@suse.com
+
+- Add apt alias for compat with new debian package management
+
+-------------------------------------------------------------------
 Thu Oct  5 18:17:58 CEST 2017 - ma@suse.de
 
 - Add summary hint if product is better updated by a different

--- a/tools/apt
+++ b/tools/apt
@@ -1,0 +1,1 @@
+aptitude

--- a/tools/aptitude
+++ b/tools/aptitude
@@ -56,6 +56,7 @@ if($prog eq "aptitude") {
 
 # install, remove are the same
 if($action eq "show") {$action="info"}
+elsif($action eq "list") {$action="search"}
 elsif($action eq "purge") {$action="remove"}
 elsif($action eq "hold") {$action="addlock"}
 elsif($action eq "unhold") {$action="removelock"}

--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -179,6 +179,7 @@ rm -rf "$RPM_BUILD_ROOT"
 %defattr(-,root,root)
 %{_bindir}/aptitude
 %{_bindir}/apt-get
+%{_bindir}/apt
 %dir %{_sysconfdir}/zypp/apt-packagemap.d/
 %config(noreplace) %{_sysconfdir}/zypp/apt-packagemap.d/*
 


### PR DESCRIPTION
newer Debian versions use 'apt' as their preferred package management
tool - using mostly the same CLI as previous apt-get and aptitude.

Note: not tested