### PR TITLE
fix "it's" typo

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -1172,7 +1172,7 @@ msgstr[1] "Hierdie pakkette moet geïnstalleer word:"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Hierdie pakkette moet geïnstalleer word:"

--- a/po/ar.po
+++ b/po/ar.po
@@ -1471,7 +1471,7 @@ msgstr[5] "%d من التطبيقات التالية ستغير بائعها:"
 
 #: src/Summary.cc:1151
 #, boost-format, c-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "لا يوجد معلومات دعم من المزود لعدد %d من الحزم التالية:"

--- a/po/ast.po
+++ b/po/ast.po
@@ -1186,7 +1186,7 @@ msgstr[1] ""
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Va REINSTALASE'l paquete de darréu:"

--- a/po/be.po
+++ b/po/be.po
@@ -1199,7 +1199,7 @@ msgstr[2] ""
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -1174,7 +1174,7 @@ msgstr[1] "Пропускане на %s: вече е инсталиран"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Пропускане на %s: вече е инсталиран"

--- a/po/bn.po
+++ b/po/bn.po
@@ -1197,7 +1197,7 @@ msgstr[1] "নিম্নলিখিত vpnc VPN সংযোগ তৈরি 
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "নিম্নলিখিত vpnc VPN সংযোগ তৈরি করা হবে:"

--- a/po/bs.po
+++ b/po/bs.po
@@ -1228,7 +1228,7 @@ msgstr[2] ""
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -1253,7 +1253,7 @@ msgstr[1] "Les següents %d aplicacions canviaran de proveïdor:"
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "El paquet següent no té informació de suport del seu proveïdor:"

--- a/po/cs.po
+++ b/po/cs.po
@@ -1309,7 +1309,7 @@ msgstr[2] "%d aplikací změní dodavatele:"
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Vydavatel neposkytl informace o podpoře tohoto balíčku:"

--- a/po/cy.po
+++ b/po/cy.po
@@ -1336,7 +1336,7 @@ msgstr[4] ""
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] ""

--- a/po/da.po
+++ b/po/da.po
@@ -1232,7 +1232,7 @@ msgstr[1] "Følgende %d programmer vil skifte leverandør:"
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] ""

--- a/po/de.po
+++ b/po/de.po
@@ -1293,7 +1293,7 @@ msgstr[1] "Die folgenden %d Anwendungen werden den Anbieter ändern:"
 
 #: src/Summary.cc:1151
 #, boost-format, c-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Das folgende Paket  wird vom Anbieter nicht unterstützt:"

--- a/po/el.po
+++ b/po/el.po
@@ -1252,7 +1252,7 @@ msgstr[1] "Οι ακόλουθες εφαρμογές %d θα αλλάξουν �
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Το ακόλουθο πακέτο δεν υποστηρίζεται από τον προμηθευτή του:"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1181,7 +1181,7 @@ msgstr[1] "The following packages will be updated:\n"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "The following packages will be updated:\n"

--- a/po/es.po
+++ b/po/es.po
@@ -1271,7 +1271,7 @@ msgstr[1] "Las siguientes %d aplicaciones  cambiaran de proveedor:"
 
 #: src/Summary.cc:1151
 #, boost-format, c-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] ""

--- a/po/et.po
+++ b/po/et.po
@@ -1183,7 +1183,7 @@ msgstr[1] "Uuendatakse järgnevad paketid:"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Uuendatakse järgnevad paketid:"

--- a/po/fi.po
+++ b/po/fi.po
@@ -1242,7 +1242,7 @@ msgstr[1] "Seuraavat %d ohjelmistoryhmää vaihtavat toimittajaa:"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Seuraava paketti ei ole toimittajan tukema:"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1283,7 +1283,7 @@ msgstr[1] "Les %d applications suivantes vont changer de fournisseur :"
 
 #: src/Summary.cc:1151
 #, boost-format, c-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Le paquet suivant n'est pas supporté par son fournisseur :"

--- a/po/gl.po
+++ b/po/gl.po
@@ -1200,7 +1200,7 @@ msgstr[1] "Vaise cambiar o vendedor dos seguintes patróns:"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "O seguinte paquete non é soportado por este fornecedor:"

--- a/po/gu.po
+++ b/po/gu.po
@@ -1194,7 +1194,7 @@ msgstr[1] " નીચેના vpnc VPN જોડાણ બનાવાશે:"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] " નીચેના vpnc VPN જોડાણ બનાવાશે:"

--- a/po/he.po
+++ b/po/he.po
@@ -1189,7 +1189,7 @@ msgstr[1] ""
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -1196,7 +1196,7 @@ msgstr[1] "निम्नांकित vpnc VPN संबंधन बना�
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "निम्नांकित vpnc VPN संबंधन बनायी जाएगी:"

--- a/po/hr.po
+++ b/po/hr.po
@@ -1229,7 +1229,7 @@ msgstr[2] "Slijedeći paketi će biti nadograđeni:"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Slijedeći paketi će biti skinuti:"

--- a/po/hu.po
+++ b/po/hu.po
@@ -1259,7 +1259,7 @@ msgstr[1] "A következő %d alkalmazás módosítja a gyártót:"
 
 #: src/Summary.cc:1151
 #, boost-format, c-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "A következő csomagot nem támogatja a gyártója:"

--- a/po/id.po
+++ b/po/id.po
@@ -1189,7 +1189,7 @@ msgstr[0] "%d Aplikasi berikut ini akan diubah vendornya:"
 
 #: src/Summary.cc:1151
 #, boost-format, c-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Paket berikut %d tidak memiliki informasi pendukung dari vendornya:"

--- a/po/it.po
+++ b/po/it.po
@@ -1286,7 +1286,7 @@ msgstr[1] "Le seguenti %d applicazioni cambieranno fornitore:"
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -1182,7 +1182,7 @@ msgstr[0] "以下 %d 個のアプリケーションのベンダを変更しま�
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] ""

--- a/po/ka.po
+++ b/po/ka.po
@@ -1102,7 +1102,7 @@ msgstr[0] "უნდა განახლდეს შემდეგი პა
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "უნდა განახლდეს შემდეგი პაკეტები:"

--- a/po/km.po
+++ b/po/km.po
@@ -1123,7 +1123,7 @@ msgstr[0] "លំនាំ​ដូច​ខាង​ក្រោម​នឹង
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "កញ្ចប់​ដូច​ខាងក្រោម​មិន​ត្រូវ​បាន​គាំទ្រ​ដោយ​ក្រុមហ៊ុន​លក់​របស់​វា ៖"

--- a/po/ko.po
+++ b/po/ko.po
@@ -1151,7 +1151,7 @@ msgstr[0] "다음 응용 프로그램의 제조업체가 변경됩니다."
 
 #: src/Summary.cc:1151
 #, boost-format, c-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "다음 %d 패키지는 제조업체에서 지원하지 않습니다."

--- a/po/ku.po
+++ b/po/ku.po
@@ -1168,7 +1168,7 @@ msgstr[1] "Ew pakêt hewce ne ku bên sazkirin:"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Ew pakêt hewce ne ku bên sazkirin:"

--- a/po/lt.po
+++ b/po/lt.po
@@ -1345,7 +1345,7 @@ msgstr[3] "Bus pakeistas %d programos gamintojas:"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "%d paketo nepalaiko jo gamintojas:"

--- a/po/mr.po
+++ b/po/mr.po
@@ -1193,7 +1193,7 @@ msgstr[1] "ह्या पॅकेजना संस्थापित कर
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "ह्या पॅकेजना संस्थापित करण्याची आवश्यकता"

--- a/po/nb.po
+++ b/po/nb.po
@@ -1213,7 +1213,7 @@ msgstr[1] "Følgende mønstre vil endre produsent:"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Følgende pakke støttes ikke av produsenten:"

--- a/po/nl.po
+++ b/po/nl.po
@@ -1289,7 +1289,7 @@ msgstr[1] "De volgende %d toepassingen zullen de leverancier wijzigen:"
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] ""

--- a/po/nn.po
+++ b/po/nn.po
@@ -1225,7 +1225,7 @@ msgstr[1] "Desse %d programma vil endra leverandør:"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Denne pakken er ikkje støtta av leverandøren:"

--- a/po/pa.po
+++ b/po/pa.po
@@ -1171,7 +1171,7 @@ msgstr[1] "ਹੇਠ ਦਿੱਤੇ ਪੈਕੇਜ ਅੱਪਡੇਟ ਕੀ�
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "ਹੇਠ ਦਿੱਤੇ ਪੈਕੇਜ ਅੱਪਡੇਟ ਕੀਤੇ ਜਾਣਗੇ:\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1348,7 +1348,7 @@ msgstr[2] "Zostanie zmieniony dostawca następujących %d aplikacji:"
 
 #: src/Summary.cc:1151
 #, boost-format, c-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Poniższy pakiet nie zawiera informacji o wsparciu dostawcy:"

--- a/po/pt.po
+++ b/po/pt.po
@@ -1234,7 +1234,7 @@ msgstr[1] "Os seguintes padrões irão mudar de fornecedor:"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "O seguinte pacote não é suportado por este fornecedor:"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1260,7 +1260,7 @@ msgstr[1] "Os seguintes %d aplicativos irão alterar de fornecedor:"
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] ""

--- a/po/ro.po
+++ b/po/ro.po
@@ -1325,7 +1325,7 @@ msgstr[2] ""
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -1310,7 +1310,7 @@ msgstr[2] "%d приложений изменят поставщика:"
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "%d пакет не поддерживается поставщиком:"

--- a/po/sk.po
+++ b/po/sk.po
@@ -1299,7 +1299,7 @@ msgstr[2] "Nasledujúcich %d aplikácií zmení dodávateľa:"
 
 #: src/Summary.cc:1151
 #, boost-format, c-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -1292,7 +1292,7 @@ msgstr[3] ""
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -1230,7 +1230,7 @@ msgstr[2] ""
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -1235,7 +1235,7 @@ msgstr[1] "Följande %d program kommer att byta leverantör:"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Följande paket stöds inte av dess leverantör:"

--- a/po/ta.po
+++ b/po/ta.po
@@ -1194,7 +1194,7 @@ msgstr[1] "பின்வரும் விபிஎன்சி விபி�
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "பின்வரும் விபிஎன்சி விபிஎன் இணைப்பு உருவாக்கப்படும்"

--- a/po/th.po
+++ b/po/th.po
@@ -1111,7 +1111,7 @@ msgstr[0] "ชุดรูปแบบเหล่านี้จะเปลี
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "แพกเกจต่อไปนี้ไม่ได้ถูกสนับสนุนโดยผู้จัดจำหน่ายของพวกมัน:"

--- a/po/tr.po
+++ b/po/tr.po
@@ -1153,7 +1153,7 @@ msgstr[0] "Belirtilen paketler güncellenecek:"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Belirtilen paketler güncellenecek:"

--- a/po/uk.po
+++ b/po/uk.po
@@ -1312,7 +1312,7 @@ msgstr[2] "Буде змінено постачальника %d таких пр
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Наступний пакунок на підтримується його постачальником:"

--- a/po/wa.po
+++ b/po/wa.po
@@ -1173,7 +1173,7 @@ msgstr[1] "Ces pakets divèt esse astalés:"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Ces pakets divèt esse astalés:"

--- a/po/xh.po
+++ b/po/xh.po
@@ -1172,7 +1172,7 @@ msgstr[1] "Le mibekelelo kufuneka ihlohliwe:"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Le mibekelelo kufuneka ihlohliwe:"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1132,7 +1132,7 @@ msgstr[0] "将改变以下 %d 个应用程序的厂商："
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "以下 %d 个软件包没有来自其厂商的支援信息："

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1127,7 +1127,7 @@ msgstr[0] "下列 %d 個應用將會變更供應商："
 
 #: src/Summary.cc:1151
 #, boost-format, c-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "下列 %d 個套件沒有其供應商的支援資訊："

--- a/po/zu.po
+++ b/po/zu.po
@@ -1198,7 +1198,7 @@ msgstr[1] "La maphakheji kudingeka afakwe (installed):"
 
 #: src/Summary.cc:1151
 #, fuzzy, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "La maphakheji kudingeka afakwe (installed):"

--- a/po/zypper.pot
+++ b/po/zypper.pot
@@ -1083,7 +1083,7 @@ msgstr[1] ""
 
 #: src/Summary.cc:1151
 #, c-format, boost-format
-msgid "The following package has no support information from it's vendor:"
+msgid "The following package has no support information from its vendor:"
 msgid_plural "The following %d packages have no support information from their vendor:"
 msgstr[0] ""
 msgstr[1] ""

--- a/src/Summary.cc
+++ b/src/Summary.cc
@@ -1148,7 +1148,7 @@ void Summary::writeSupportUnknown( std::ostream & out )
     // we only look at vendor support in packages
     if ( it->first == ResKind::package )
       label = PL_(
-        "The following package has no support information from it's vendor:",
+        "The following package has no support information from its vendor:",
         "The following %d packages have no support information from their vendor:",
         it->second.size() );
     label = str::form( label.c_str(), it->second.size() );


### PR DESCRIPTION
"it's" is always short for "it is".  Here the word is in the possessive form, so there is no apostrophe.

https://en.oxforddictionaries.com/usage/its-or-it-s