### PR TITLE
Ma broken search

### DIFF
--- a/src/Zypper.cc
+++ b/src/Zypper.cc
@@ -4757,7 +4757,10 @@ void Zypper::doCommand()
 	    callback( it );
 	}
 	else
-	  invokeOnEach( query.selectableBegin(), query.selectableEnd(), callback );
+	{
+	  for ( const auto & slv : query )
+	    callback( slv );
+	}
       }
       else
       {

--- a/src/Zypper.cc
+++ b/src/Zypper.cc
@@ -228,13 +228,36 @@ namespace cli
     }
     if ( fail )
     {
-      // translator: %1% is a list of command line options
       zypper.out().error( errorMutuallyExclusiveOptions( dashdash(failDetail) ) );
       zypper.setExitCode( ZYPPER_EXIT_ERR_INVALID_ARGS );
       ZYPP_THROW( ExitRequestException("invalid args") );
     }
     return ret;
   }
+
+  /** Make sure only one of \a args_r options is specified on the command line.
+   * \throw ExitRequestException if multiple args are specified
+   * \return the cli arg or \c nullptr
+   */
+  const char * assertMutuallyExclusiveArgs( Zypper & zypper, const std::initializer_list<const char *> & args_r  )
+  {
+    const char * ret = nullptr;
+    for ( const char * arg : args_r )
+    {
+      if ( copts.count(arg) )
+      {
+	if ( ret )
+	{
+	  zypper.out().error( errorMutuallyExclusiveOptions( text::join( dashdash(ret), dashdash(arg) ) ) );
+	  zypper.setExitCode( ZYPPER_EXIT_ERR_INVALID_ARGS );
+	  ZYPP_THROW( ExitRequestException("invalid args") );
+	}
+	ret = arg;
+      }
+    }
+    return ret;
+  }
+
 } // namespace cli
 ///////////////////////////////////////////////////////////////////
 

--- a/src/search.h
+++ b/src/search.h
@@ -14,37 +14,25 @@
 #include "Zypper.h"
 #include "Table.h"
 
-/**
- * Functor for filling search output table in rug style.
- */
+///////////////////////////////////////////////////////////////////
+/// \class FillSearchTableSolvable
+/// \brief Functor for filling a detailed search output table.
+///////////////////////////////////////////////////////////////////
 struct FillSearchTableSolvable
 {
-  // the table used for output
-  Table * _table;
-  /** Aliases of repos specified as --repo */
-  std::set<std::string> _repos;
-  TriBool _inst_notinst;
+  FillSearchTableSolvable( Table & table_r, TriBool instNotinst_r = indeterminate );
 
-  FillSearchTableSolvable(
-      Table & table,
-      TriBool inst_notinst = indeterminate );
+  /** Add this PoolItem if no filter applies */
+  bool operator()( const PoolItem & pi_r ) const;
+  /** Add this Solvable if no filter applies */
+  bool operator()( const sat::Solvable & solv_r ) const;
+  /** PoolQuery iterator provides info about matches */
+  bool operator()( const PoolQuery::const_iterator & it_r ) const;
 
-  /** Add all items within this Selectable */
-  bool operator()( const ui::Selectable::constPtr & sel ) const;
-  /** Add this PoolItem */
-  bool operator()( const PoolItem & pi ) const;
-  /** Add this Solvable */
-  bool operator()( sat::Solvable solv ) const;
-  /** PoolQuery iterator provides info about matches*/
-  bool operator()( const PoolQuery::const_iterator & it ) const;
-
-  /** Helper to add a table row for \a sel's picklist item \c pi
-   * \return whether a row was actually added.
-   * \note picklist item means that \a pi must not be an installed
-   * item in \a sel, if there is an identical available one. The
-   * code relies on this.
-   */
-  bool addPicklistItem( const ui::Selectable::constPtr & sel, const PoolItem & pi ) const;
+private:
+  Table * _table;		//!< The table used for output
+  std::set<std::string> _repos;	//!< Filter --repo
+  TriBool _instNotinst;		//!< Filter --[not-]installed
 };
 
 struct FillSearchTableSelectable


### PR DESCRIPTION
See [Bug 907538](https://bugzilla.opensuse.org/show_bug.cgi?id=907538) - zypper shell search parsing minus (and duplicates).

The  desired behavior is to use the match-mode provided as CLI arg. If no match mode is explicitly requested, we use globbing if an argument contains globbing chars, regex if the pattern is enclosed in '/'es, else substring.

A name-argument containing one or 2 '-'es ("n-v" or "n-v-r"), should also match a package with this name and version (exact match!), i.e. the same as `se -x 'n = v'` or `se -x 'n = v-r '`.

Additionally a detailed search result (-s) must not list items without a match, like it did

    $ zypper se -sx 'libzypp = 17.1.1'
    S | Name    | Type    | Version    | Arch   | Repository       
    --+---------+---------+------------+--------+------------------
    i | libzypp | package | 17.1.1-1.2 | x86_64 | (System Packages)
    v | libzypp | package | 17.3.0-1.1 | x86_64 | tw-oss           
    v | libzypp | package | 17.3.0-1.1 | i586   | tw-oss           
