### PR TITLE
Disable repository operations when searching installed packages (bsc#1084525)

### DIFF
--- a/src/Zypper.cc
+++ b/src/Zypper.cc
@@ -4569,6 +4569,9 @@ void Zypper::doCommand()
       }
     }
 
+    if ( cOpts().count("installed-only") )
+      globalOptsNoConst().no_refresh = true;
+
     // load system data...
     if ( defaultLoadSystem() != ZYPPER_EXIT_OK )
       return;


### PR DESCRIPTION
This disables the refresh of system repositories when --installed-only is passed. There is no need to refresh them in that case.