### PR TITLE
Adds support to enable/disable language support in zypper

### DIFF
--- a/doc/zypper.8.txt
+++ b/doc/zypper.8.txt
@@ -1438,6 +1438,53 @@ Package locks serve the purpose of preventing changes to the set of installed pa
 	+
 	This command looks for locks that do not currently (with regard to repositories used) lock any package and for each such lock it asks user whether to remove it.
 
+Locale Management
+~~~~~~~~~~~~~~~~~~~
+These commands give information about requested locales and the possibilty to manage those. A locale is defined by a language code. For many packages there are locale dependent packages available which provide translations or dictionaries. To get these installed, the locale for the desired language must be marked as requested by the package manager library.
+
+*locales* (*lloc*) [OPTIONS] [LOCALE] ...::
+ List requested locales. Called without argument, lists the locales which are already marked as requested. Specifying certain locale(s) prints information only for this(these).
++
+--
+ *-a*, *--all*::
+ List all available locales.
+
+ *-p*, *--packages*::
+ Show corresponding packages.
+--
+
+*add-locale* (*aloc*) [OPTIONS] <LOCALE> ...::
+ Add specified locale(s) to the list of requested locales..
++
+--
+ *-n*, *--no-packages*::
+ Do not install corresponding packages.
+--
+
+*remove-locale* (*rloc*) [OPTIONS] <LOCALE> ...::
+ Remove specified locale(s) from the list of requested locales..
++
+--
+ *-n*, *--no-packages*::
+ Do not remove corresponding packages.
+--
+
+Examples: :: {nop}
+
+	$ *zypper locales*;;
+	List requested locales.
+
+	$ *zypper locales --packages de en*;;
+	Get the lists of packages which are available for 'de' and 'en' (exact match).
+
+	$ *zypper locales en_*;;
+	Get all locales with lang code 'en' that have their own country code, excluding the fallback 'en'.
+
+	$ *zypper locales en**;;
+	Get all locales with lang code 'en' with or without country code.	
+	
+	$ *zypper aloc --packages de_CH* ;;
+	Request *de_CH* and install language dependent packages.
 
 Other Commands
 ~~~~~~~~~~~~~~

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ SET (zypper_HEADERS
   Command.h
   Config.h
   repos.h
+  locales.h
   misc.h
   search.h
   info.h
@@ -93,6 +94,9 @@ SET (zypper_HEADERS
   commands/help.h
   commands/configtest.h
   commands/subcommand.h
+  commands/locale/localescmd.h
+  commands/locale/addlocalecmd.h
+  commands/locale/removelocalecmd.h
 )
 
 SET( zypper_SRCS
@@ -100,6 +104,7 @@ SET( zypper_SRCS
   Command.cc
   Config.cc
   repos.cc
+  locales.cc
   misc.cc
   search.cc
   info.cc
@@ -166,6 +171,9 @@ SET( zypper_SRCS
   commands/help.cc
   commands/subcommand.cc
   commands/configtest.cc
+  commands/locale/localescmd.cc
+  commands/locale/addlocalecmd.cc
+  commands/locale/removelocalecmd.cc
   ${zypper_HEADERS}
 )
 

--- a/src/Command.cc
+++ b/src/Command.cc
@@ -37,6 +37,9 @@
 #include "commands/shell.h"
 #include "commands/help.h"
 #include "commands/subcommand.h"
+#include "commands/locale/localescmd.h"
+#include "commands/locale/addlocalecmd.h"
+#include "commands/locale/removelocalecmd.h"
 
 using namespace zypp;
 
@@ -148,6 +151,10 @@ namespace
       makeCmd<ListLocksCmd> ( ZypperCommand::LIST_LOCKS_e , std::string(), { "locks", "ll", "lock-list" } ),
       makeCmd<CleanLocksCmd> ( ZypperCommand::CLEAN_LOCKS_e , std::string(), { "cleanlocks" , "cl", "lock-clean" } ),
 
+      makeCmd<LocalesCmd>   ( ZypperCommand::LOCALES_e , _("Locale Management:"), { "locales", "lloc" } ),
+      makeCmd<AddLocaleCmd> ( ZypperCommand::ADD_LOCALE_e , std::string(), { "addlocale", "aloc" } ),
+      makeCmd<RemoveLocaleCmd> ( ZypperCommand::REMOVE_LOCALE_e , std::string(), { "remove-locale", "rloc" } ),
+
       makeCmd<VersionCompareCmd> ( ZypperCommand::VERSION_CMP_e , _("Other Commands:"), { "versioncmp", "vcmp" } ),
       makeCmd<TargetOSCmd> ( ZypperCommand::TARGET_OS_e , std::string(), { "targetos", "tos" } ),
       makeCmd<LicensesCmd> ( ZypperCommand::LICENSES_e , std::string(), { "licenses" } ),
@@ -250,6 +257,10 @@ DEF_ZYPPER_COMMAND( RUG_PATTERN_INFO );
 DEF_ZYPPER_COMMAND( RUG_PRODUCT_INFO );
 DEF_ZYPPER_COMMAND( RUG_PATCH_SEARCH );
 DEF_ZYPPER_COMMAND( RUG_PING );
+
+DEF_ZYPPER_COMMAND( LOCALES );
+DEF_ZYPPER_COMMAND( ADD_LOCALE );
+DEF_ZYPPER_COMMAND( REMOVE_LOCALE );
 
 DEF_ZYPPER_COMMAND( NEEDS_REBOOTING );
 

--- a/src/Command.h
+++ b/src/Command.h
@@ -99,6 +99,10 @@ struct ZypperCommand
 
   static const ZypperCommand NEEDS_REBOOTING;
 
+  static const ZypperCommand LOCALES;
+  static const ZypperCommand ADD_LOCALE;
+  static const ZypperCommand REMOVE_LOCALE;
+
   enum Command
   {
     NONE_e,
@@ -166,6 +170,10 @@ struct ZypperCommand
     RUG_PRODUCT_INFO_e,
     RUG_PATCH_SEARCH_e,
     RUG_PING_e,
+
+    LOCALES_e,
+    ADD_LOCALE_e,
+    REMOVE_LOCALE_e,
 
     NEEDS_REBOOTING_e
   };

--- a/src/commands/basecommand.cc
+++ b/src/commands/basecommand.cc
@@ -161,15 +161,20 @@ int ZypperBaseCommand::defaultSystemSetup( Zypper &zypper, SetupSystemFlags flag
   }
 
   DtorReset _tmp( zypper.configNoConst().disable_system_resolvables );
-  if ( flags_r.testFlag( LoadResolvables ) ) {
-    if ( flags_r.testFlag( NoSystemResolvables ) ) {
-      zypper.configNoConst().disable_system_resolvables = true;
-    }
-
-    load_resolvables( zypper );
-    if ( zypper.exitCode() != ZYPPER_EXIT_OK )
-      return zypper.exitCode();
+  if ( flags_r.testFlag( NoSystemResolvables ) ) {
+    zypper.configNoConst().disable_system_resolvables = true;
   }
+
+  if ( flags_r.testFlag( LoadResolvables ) ) {
+    load_resolvables( zypper );
+  } else if ( flags_r.testFlag( LoadRepoResolvables ) ) {
+    load_repo_resolvables( zypper );
+  } else if ( flags_r.testFlag( LoadTargetResolvables ) ) {
+    load_target_resolvables( zypper );
+  }
+
+  if ( zypper.exitCode() != ZYPPER_EXIT_OK )
+    return zypper.exitCode();
 
   if ( flags_r.testFlag ( Resolve ) ) {
     // have REPOS and TARGET

--- a/src/commands/basecommand.h
+++ b/src/commands/basecommand.h
@@ -51,8 +51,10 @@ enum SetupSystemBits
  InitTarget		= (1 << 2),		//< Initialize the target
  InitRepos		= (1 << 3),		//< Initialize repositories
  NoSystemResolvables    = (1 << 4),             //< Disable the loading of system resolvables
- LoadResolvables        = (1 << 5),             //< Load resolvables
- Resolve                = (1 << 6),             //< compute status of PPP
+ LoadTargetResolvables  = (1 << 5),
+ LoadRepoResolvables    = (1 << 6),
+ LoadResolvables        = LoadTargetResolvables |  LoadRepoResolvables,            //< Load resolvables
+ Resolve                = (1 << 9),             //< compute status of PPP
  DefaultSetup           = ResetRepoManager | InitTarget | InitRepos | LoadResolvables | Resolve
 };
 ZYPP_DECLARE_FLAGS( SetupSystemFlags, SetupSystemBits );

--- a/src/commands/commandhelpformatter.h
+++ b/src/commands/commandhelpformatter.h
@@ -61,6 +61,14 @@ struct CommandHelpFormater
   CommandHelpFormater & synopsis( const str::Format & text_r )
   { return synopsis( boost::string_ref(text_r.str()) ); }
 
+  /** Multiline text block
+     * \code
+     * "<multiline text_r>"
+     * \endcode
+     */
+  CommandHelpFormater & multiLineText( const std::string &text_r )
+  { _mww.writePar( text_r ); return *this; }
+
 
   /** Description block with leading gap
    * \code
@@ -69,7 +77,7 @@ struct CommandHelpFormater
    * \endcode
    */
   CommandHelpFormater & description( boost::string_ref text_r )
-  { _mww.gotoNextPar(); _mww.writePar( text_r ); return *this; }
+  { _mww.gotoNextPar(); return multiLineText(text_r.to_string()); }
   /** \overload const char * text */
   CommandHelpFormater & description( const char * text_r )
   { return description( boost::string_ref(text_r) ); }
@@ -85,6 +93,22 @@ struct CommandHelpFormater
   { // translator: %s is an other command: "This is an alias for 'zypper info -t patch'."
     return description( str::Format(_("This is an alias for '%s'.")) % command_r ); }
 
+  /** Extra section title
+     * \code
+     * ""
+     * "  <text_r:>"
+     * ""
+     * \endcode
+     */
+  CommandHelpFormater & extraSection( boost::string_ref text_r )
+  { _mww.gotoNextPar(); _mww.writePar( text_r, 2 ); _mww.gotoNextPar(); return *this; }
+
+  CommandHelpFormater & examplesSection()
+  { return optionSection(_("Examples:") ); }
+
+  CommandHelpFormater & argumentsSection()
+  { return optionSection(_("Arguments:") ); }
+
   /** Option section title
    * \code
    * ""
@@ -93,7 +117,7 @@ struct CommandHelpFormater
    * \endcode
    */
   CommandHelpFormater & optionSection( boost::string_ref text_r )
-  { _mww.gotoNextPar(); _mww.writePar( text_r, 2 ); _mww.gotoNextPar(); return *this; }
+  { return extraSection(text_r); }
 
   CommandHelpFormater & optionSectionCommandOptions()
   { return optionSection(_("Command options:") ); }

--- a/src/commands/locale/addlocalecmd.cc
+++ b/src/commands/locale/addlocalecmd.cc
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------*\
+                          ____  _ _ __ _ __  ___ _ _
+                         |_ / || | '_ \ '_ \/ -_) '_|
+                         /__|\_, | .__/ .__/\___|_|
+                             |__/|_|  |_|
+\*---------------------------------------------------------------------------*/
+#include "addlocalecmd.h"
+#include "utils/flags/flagtypes.h"
+#include "utils/messages.h"
+#include "commands/commandhelpformatter.h"
+#include "locales.h"
+
+using namespace zypp;
+
+AddLocaleCmd::AddLocaleCmd(std::vector<std::string> &&commandAliases_r)
+  : ZypperBaseCommand (
+      std::move( commandAliases_r ),
+      // translators: command synopsis; do not translate lowercase words
+      _( "addlocale (aloc) [OPTIONS] <LOCALE> ..." ),
+      _( "Add locale(s) to requested locales." ),
+      _( "Add given locale(s) to the list of requested locales." ),
+      ResetRepoManager| InitTarget | InitRepos | LoadResolvables
+    )
+{
+  doReset();
+}
+
+zypp::ZyppFlags::CommandGroup AddLocaleCmd::cmdOptions() const
+{
+  auto &that = *const_cast<AddLocaleCmd *>(this);
+  return {{
+    { "no-packages", 'n', ZyppFlags::NoArgument, ZyppFlags::BoolCompatibleType( that._packages, ZyppFlags::StoreFalse ), _("Do not install corresponding packages for given locale(s).") },
+  }};
+}
+
+void AddLocaleCmd::doReset()
+{
+  _packages = true;
+}
+
+int AddLocaleCmd::execute(Zypper &zypper, const std::vector<std::string> &positionalArgs )
+{
+  addLocales( zypper, positionalArgs, _packages );
+  return zypper.exitCode();
+}
+
+
+std::string AddLocaleCmd::help()
+{
+  CommandHelpFormater hlp;
+  hlp << ZypperBaseCommand::help();
+
+  hlp.argumentsSection()
+    .multiLineText(
+      str::form(
+        _( "Specify locale which shall be supported by the language code.\n"
+           "Get a list of all available locales by calling '%s'."), "zypper locales --all" )
+    );
+
+  return hlp;
+}

--- a/src/commands/locale/addlocalecmd.h
+++ b/src/commands/locale/addlocalecmd.h
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------*\
+                          ____  _ _ __ _ __  ___ _ _
+                         |_ / || | '_ \ '_ \/ -_) '_|
+                         /__|\_, | .__/ .__/\___|_|
+                             |__/|_|  |_|
+\*---------------------------------------------------------------------------*/
+#ifndef ZYPPER_COMMANDS_LOCALE_ADDLOCALECMD_INCLUDED
+#define ZYPPER_COMMANDS_LOCALE_ADDLOCALECMD_INCLUDED
+
+#include "commands/basecommand.h"
+#include "utils/flags/zyppflags.h"
+
+class AddLocaleCmd : public ZypperBaseCommand
+{
+public:
+   AddLocaleCmd( std::vector<std::string> &&commandAliases_r );
+
+ private:
+   bool _packages;
+
+   // ZypperBaseCommand interface
+public:
+   std::string help() override;
+protected:
+   zypp::ZyppFlags::CommandGroup cmdOptions() const override;
+   void doReset() override;
+   int execute(Zypper &zypper, const std::vector<std::string> &positionalArgs) override;
+};
+
+#endif

--- a/src/commands/locale/localescmd.cc
+++ b/src/commands/locale/localescmd.cc
@@ -1,0 +1,108 @@
+/*---------------------------------------------------------------------------*\
+                          ____  _ _ __ _ __  ___ _ _
+                         |_ / || | '_ \ '_ \/ -_) '_|
+                         /__|\_, | .__/ .__/\___|_|
+                             |__/|_|  |_|
+\*---------------------------------------------------------------------------*/
+
+#include "localescmd.h"
+#include "utils/flags/flagtypes.h"
+#include "commands/commandhelpformatter.h"
+#include "locales.h"
+
+LocalesCmd::LocalesCmd( std::vector<std::string> &&commandAliases_r )
+  : ZypperBaseCommand (
+      std::move( commandAliases_r ),
+      // translators: command synopsis; do not translate lowercase words
+      _( "locales (lloc) [OPTIONS] [LOCALE] ..." ),
+      _( "List requested locales (languages codes)." ),
+      str::form ( _( "List requested locales and corresponding packages.\n"
+            "\n"
+            "Called without arguments, lists the requested locales. If the\n"
+            "locale packages for a requested language are not yet on the system, they can\n"
+            "be installed by calling '%s'.\n" ), "zypper aloc <LOCALE>" ) ,
+      DisableAll
+
+  )
+{
+  doReset();
+}
+
+zypp::ZyppFlags::CommandGroup LocalesCmd::cmdOptions() const
+{
+  auto &that = *const_cast<LocalesCmd *>(this);
+  return {{
+    { "packages", 'p', ZyppFlags::NoArgument, ZyppFlags::BoolCompatibleType( that._packages, ZyppFlags::StoreTrue ), _("Show corresponding packages.") },
+    { "all", 'a', ZyppFlags::NoArgument, ZyppFlags::BoolCompatibleType( that._all, ZyppFlags::StoreTrue ), _("List all available locales.") }
+  }};
+}
+
+void LocalesCmd::doReset()
+{
+  _packages = false;
+  _all = false;
+}
+
+int LocalesCmd::execute(Zypper &zypper, const std::vector<std::string> &positionalArgs)
+{
+  if ( _all && positionalArgs.size() ) {
+    zypper.out().warning( _("Ignoring positional arguments because --all argument was provided.") );
+  }
+
+  SetupSystemFlags flags = ResetRepoManager | InitTarget | LoadTargetResolvables;
+
+  //need to InitRepos if we want to list all, see info about packages or have a search string
+  if ( _packages || _all || positionalArgs.size() ) {
+    flags = flags | InitRepos | LoadRepoResolvables;
+  }
+
+  int code = defaultSystemSetup( zypper, flags  );
+  if ( code != ZYPPER_EXIT_OK )
+    return code;
+
+  if ( _packages )
+    localePackages( zypper, positionalArgs, _all );
+  else
+    listLocales( zypper, positionalArgs, _all );
+  return zypper.exitCode();
+}
+
+std::string LocalesCmd::help()
+{
+  CommandHelpFormater hlp;
+  hlp << ZypperBaseCommand::help();
+  hlp.argumentsSection()
+    .multiLineText(
+      _("The locale(s) for which the information shall be printed.")
+    )
+    .examplesSection()
+    .multiLineText(
+      _("Get all locales with lang code 'en' that have their own country code, excluding the fallback 'en':")
+    )
+    .multiLineText(
+      "zypper locales 'en_'"
+    )
+    .gap()
+    .multiLineText(
+      _("Get all locales with lang code 'en' with or without country code:")
+    )
+    .multiLineText(
+      "zypper locales 'en*'"
+    )
+    .gap()
+    .multiLineText(
+      _("Get the locale matching the argument exactly: ")
+    )
+    .multiLineText(
+      "zypper locales 'en'"
+    )
+    .gap()
+    .multiLineText(
+      _("Get the list of packages which are available for 'de' and 'en':")
+    )
+    .multiLineText(
+      "zypper locales --packages de en"
+    );
+
+  return hlp;
+}

--- a/src/commands/locale/localescmd.h
+++ b/src/commands/locale/localescmd.h
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------*\
+                          ____  _ _ __ _ __  ___ _ _
+                         |_ / || | '_ \ '_ \/ -_) '_|
+                         /__|\_, | .__/ .__/\___|_|
+                             |__/|_|  |_|
+\*---------------------------------------------------------------------------*/
+#ifndef ZYPPER_COMMANDS_LOCALE_LOCALES_INCLUDED
+#define ZYPPER_COMMANDS_LOCALE_LOCALES_INCLUDED
+
+#include "commands/basecommand.h"
+#include "utils/flags/zyppflags.h"
+
+class LocalesCmd : public ZypperBaseCommand
+{
+public:
+  LocalesCmd( std::vector<std::string> &&commandAliases_r );
+
+private:
+  bool _packages;
+  bool _all;
+
+  // ZypperBaseCommand interface
+public:
+  std::string help() override;
+protected:
+  zypp::ZyppFlags::CommandGroup cmdOptions() const override;
+  void doReset() override;
+  int execute(Zypper &zypper, const std::vector<std::string> &positionalArgs) override;
+};
+
+#endif

--- a/src/commands/locale/removelocalecmd.cc
+++ b/src/commands/locale/removelocalecmd.cc
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------*\
+                          ____  _ _ __ _ __  ___ _ _
+                         |_ / || | '_ \ '_ \/ -_) '_|
+                         /__|\_, | .__/ .__/\___|_|
+                             |__/|_|  |_|
+\*---------------------------------------------------------------------------*/
+#include "removelocalecmd.h"
+#include "utils/flags/flagtypes.h"
+#include "utils/messages.h"
+#include "commands/commandhelpformatter.h"
+#include "locales.h"
+
+RemoveLocaleCmd::RemoveLocaleCmd(std::vector<std::string> &&commandAliases_r)
+  : ZypperBaseCommand (
+      std::move( commandAliases_r ),
+      // translators: command synopsis; do not translate lowercase words
+      _( "remove-locale (rloc) [OPTIONS] <LOCALE> ..." ),
+      _( "Remove locale(s) from requested locales." ),
+      _( "Remove given locale(s) from the list of supported languages." ),
+      ResetRepoManager| InitTarget | LoadResolvables
+    )
+{
+  doReset();
+}
+
+std::string RemoveLocaleCmd::help()
+{
+  CommandHelpFormater hlp;
+  hlp << ZypperBaseCommand::help();
+
+  hlp.argumentsSection()
+    .multiLineText(
+      str::form(
+         _("Specify locales which shall be removed by the the language code.\n"
+           "Get the list of requested locales by calling '%s'."), "zypper locales"
+      )
+    );
+
+  return hlp;
+}
+
+zypp::ZyppFlags::CommandGroup RemoveLocaleCmd::cmdOptions() const
+{
+  auto &that = *const_cast<RemoveLocaleCmd *>(this);
+  return {{
+    { "no-packages", 'n', ZyppFlags::NoArgument, ZyppFlags::BoolCompatibleType( that._packages, ZyppFlags::StoreFalse ), _("Do not remove corresponding packages for given locale(s).") },
+  }};
+}
+
+void RemoveLocaleCmd::doReset()
+{
+  _packages = true;
+}
+
+int RemoveLocaleCmd::execute ( Zypper &zypper, const std::vector<std::string> &positionalArgs )
+{
+  if ( positionalArgs.empty() )
+  {
+    report_required_arg_missing( zypper.out(), help() );
+    return (ZYPPER_EXIT_ERR_INVALID_ARGS);
+  }
+  removeLocales( zypper, positionalArgs, _packages );
+  return zypper.exitCode();
+}

--- a/src/commands/locale/removelocalecmd.h
+++ b/src/commands/locale/removelocalecmd.h
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------*\
+                          ____  _ _ __ _ __  ___ _ _
+                         |_ / || | '_ \ '_ \/ -_) '_|
+                         /__|\_, | .__/ .__/\___|_|
+                             |__/|_|  |_|
+\*---------------------------------------------------------------------------*/
+#ifndef ZYPPER_COMMANDS_LOCALE_REMOVELOCALECMD_INCLUDED
+#define ZYPPER_COMMANDS_LOCALE_REMOVELOCALECMD_INCLUDED
+
+#include "commands/basecommand.h"
+#include "utils/flags/zyppflags.h"
+
+class RemoveLocaleCmd : public ZypperBaseCommand
+{
+public:
+  RemoveLocaleCmd( std::vector<std::string> &&commandAliases_r );
+
+private:
+  bool _packages;
+
+  // ZypperBaseCommand interface
+public:
+  std::string help() override;
+
+protected:
+  zypp::ZyppFlags::CommandGroup cmdOptions() const override;
+  void doReset() override;
+  int execute(Zypper &zypper, const std::vector<std::string> &positionalArgs) override;
+};
+
+#endif

--- a/src/locales.cc
+++ b/src/locales.cc
@@ -1,0 +1,368 @@
+/*---------------------------------------------------------------------------*\
+                          ____  _ _ __ _ __  ___ _ _
+                         |_ / || | '_ \ '_ \/ -_) '_|
+                         /__|\_, | .__/ .__/\___|_|
+                             |__/|_|  |_|
+\*---------------------------------------------------------------------------*/
+
+#include <iostream>
+#include <fstream>
+#include <iterator>
+#include <list>
+
+#include <zypp/ZYpp.h>
+#include <zypp/base/Logger.h>
+#include <zypp/base/IOStream.h>
+#include <zypp/base/String.h>
+#include <zypp/base/Flags.h>
+#include <zypp/ui/Selectable.h>
+#include <zypp/base/Regex.h>
+#include <zypp/sat/LocaleSupport.h>
+
+#include "output/Out.h"
+#include "main.h"
+#include "getopt.h"
+#include "Table.h"
+#include "utils/messages.h"
+#include "utils/misc.h" // for xml_encode
+#include "locales.h"
+#include "solve-commit.h"
+
+#include "Zypper.h"
+
+extern ZYpp::Ptr God;
+
+struct LocaleWithState {
+  enum State {
+    NotRequested,
+    Requested,
+    Fallback
+  };
+
+  Locale locale;
+  State  state;
+
+  bool operator<(const LocaleWithState &other ) const {
+    return this->locale < other.locale;
+  }
+};
+
+using LocaleWithStateSet = std::set<LocaleWithState>;
+
+static std::string isRequestedState( LocaleWithState::State state )
+{
+  switch ( state ) {
+    case LocaleWithState::Requested:
+      return _("Requested");
+    case LocaleWithState::NotRequested:
+      return _("No");
+    case LocaleWithState::Fallback:
+      return _("Fallback");
+  };
+  return "";
+}
+
+static bool isRequestedFallbackLocale ( const Locale &locale )
+{
+  for ( const Locale &loc : God->pool().getRequestedLocales() ) {
+    Locale locFallback = loc.fallback();
+    while ( locFallback != Locale::noCode ) {
+      if ( locFallback == locale  ) {
+        return true;
+      }
+      locFallback = locFallback.fallback();
+    }
+  }
+  return false;
+}
+
+static void printLocaleList( Zypper & zypper, const LocaleWithStateSet &locales )
+{
+  Table tbl;
+  // header
+  TableHeader th;
+
+  // translators: header of table column - the language code, e.g. en_US
+  th << _("Code");
+  // translators: header of table column - the language, e.g. English (United States)
+  th << _("Language");
+  // translators: header of table column - is the language requested? (Yes/No)
+  th << _("Requested");
+
+  tbl << th;
+
+  for_( it, locales.begin(), locales.end() )
+  {
+    TableRow tr(3);
+
+    tr << (*it).locale.code();
+    tr << (*it).locale.name();
+    tr << isRequestedState(it->state);
+    tbl << tr;
+  }
+
+  tbl.sort(1);
+
+  cout << tbl;
+}
+
+#if 0
+static void printXmlLocaleList( Zypper & zypper, const zypp::LocaleSet &locales )
+{
+
+}
+#endif
+
+static void printLocalePackages( Zypper & zypper, const zypp::sat::LocaleSupport & myLocale )
+{
+  Table tbl;
+  TableHeader th;
+
+  // translators: header of table column - S is for 'Status' (package installed or not)
+  th << _("S");
+  // translators: header of table column - the name of the package
+  th << _("Name");
+  // translators: header of table column - the package summary
+  th << _("Description");
+
+  tbl << th;
+
+  for_( it, myLocale.selectableBegin(), myLocale.selectableEnd() )
+  {
+    TableRow tr(3);
+    zypp::ui::Status status = (*it)->status();
+
+    if ( status == zypp::ui::S_KeepInstalled || status == zypp::ui::S_Protected )
+      tr << "i";
+    else
+      tr << " ";
+    tr << (*it)->name();
+    tr << (*it)->theObj()->summary();
+
+    tbl << tr;
+  }
+
+  tbl.sort(1);
+
+  cout << tbl;
+}
+
+static zypp::LocaleSet relevantLocales( const std::vector<std::string> &localeArgs, bool relaxed )
+{
+  const zypp::LocaleSet & availableLocales( God->pool().getAvailableLocales() );
+
+  zypp::LocaleSet resultSet;
+
+  for_( it, availableLocales.begin(), availableLocales.end() )
+  {
+    if ( localeArgs.empty() )
+    {
+      // without argument take only requested locales
+      if ( God->pool().isRequestedLocale(*it) )
+      {
+        resultSet.insert(*it);
+      }
+    }
+    else
+    {
+      // take given locales (if available)
+      for_( loc, localeArgs.begin(), localeArgs.end() )
+      {
+        if ( relaxed ) {
+
+          size_t strSize = loc->size();
+
+          //match all starting with the given country code but exclude the fallback one
+          bool underscoreMatch = str::endsWith( *loc, "_" );
+
+          //match all starting with the given country code including the fallback one
+          bool asteriskMatch = str::endsWith( *loc, "*" );
+
+          if ( asteriskMatch || underscoreMatch )  {
+            if ( strSize < 2 ) {
+              WAR << "Ignoring too short argument " << *loc << endl;
+              continue;
+            }
+            std::string langCode = loc->substr( 0, strSize - 1 );
+            if ( it->language().code() == langCode ) {
+              if ( underscoreMatch && it->country() != CountryCode::noCode )
+                resultSet.insert(*it);
+              else if ( asteriskMatch )
+                resultSet.insert(*it);
+            }
+            continue;
+          }
+        }
+
+        //exact match
+        if ( *loc == (*it).code().c_str() ) {
+          resultSet.insert(*it);
+        }
+      }
+    }
+  }
+
+  return resultSet;
+}
+
+/**
+ * Adds fallbacks if not already in the set and flags each entry with
+ * the state it is currently in
+ */
+static LocaleWithStateSet addMissingInfo ( const zypp::LocaleSet &locales, bool insertMissingFallbacks )
+{
+  LocaleWithStateSet result;
+
+  auto insertOrOverwrite = [&result]( LocaleWithState::State state, const Locale &newElem ) {
+    auto inserted = result.insert( LocaleWithState{ newElem, state } );
+    if ( !inserted.second && inserted.first->state != state) {
+
+      // if we were not able to insert the value, there is already a existing element
+      // try to override it, but first check if that is allowed:
+      // REQ -> ( REQ, NREQ, FB )
+      // NR  -> ()
+      // FB  -> ( NREQ, FB )
+
+      const LocaleWithState &existing = *inserted.first;
+      bool canOverride =   state == LocaleWithState::Requested || //requested always wins
+                         ( state == LocaleWithState::Fallback && existing.state == LocaleWithState::NotRequested );
+
+      if ( canOverride ) {
+        result.erase( inserted.first );
+        if ( ! result.insert( LocaleWithState{ newElem, state } ).second ) {
+          WAR << "Unable to insert locale: "<< newElem << " into the result set " << endl;
+        }
+      }
+    }
+  };
+
+  for ( const Locale &loc : locales ) {
+
+    LocaleWithState::State state = LocaleWithState::NotRequested;
+    if ( God->pool().isRequestedLocale( loc ) ) {
+      state = LocaleWithState::Requested;
+    } else if ( isRequestedFallbackLocale( loc ) ) {
+      state = LocaleWithState::Fallback;
+    }
+
+    insertOrOverwrite( state, loc );
+
+    if ( insertMissingFallbacks ) {
+      Locale locFallback = loc.fallback();
+      while ( locFallback != Locale::noCode ) {
+        insertOrOverwrite( isRequestedFallbackLocale( locFallback ) ? LocaleWithState::Fallback : LocaleWithState::NotRequested, locFallback );
+        locFallback = locFallback.fallback();
+      }
+    }
+  }
+
+  return result;
+}
+
+void listLocales( Zypper & zypper, const std::vector<std::string> &localeArgs, bool showAll )
+{
+  zypp::LocaleSet locales;
+
+  if ( showAll ) {
+    const auto &avail = God->pool().getAvailableLocales();
+    const auto &req = God->pool().getRequestedLocales();
+    std::merge( avail.begin(), avail.end(), req.begin(), req.end(), std::inserter( locales, locales.begin() ) );
+  } else {
+    locales = relevantLocales( localeArgs, true );
+  }
+
+#if 0
+  // print xml output
+  if ( zypper.out().type() == Out::TYPE_XML )
+    printXmlLocaleList(zypper, locales);
+  else
+#endif
+  printLocaleList( zypper, addMissingInfo( locales, showAll || localeArgs.size() == 0 ) );
+}
+
+void localePackages( Zypper &zypper, const std::vector<std::string> &localeArgs, bool showAll )
+{
+   zypp::LocaleSet locales;
+
+   if ( showAll ) {
+     const auto &avail = God->pool().getAvailableLocales();
+     const auto &req = God->pool().getRequestedLocales();
+     std::merge( avail.begin(), avail.end(), req.begin(), req.end(), std::inserter( locales, locales.begin() ) );
+   } else {
+    locales = relevantLocales( localeArgs, true );
+   }
+
+  LocaleWithStateSet locs = addMissingInfo( locales, showAll || localeArgs.size() == 0  );
+
+  std::list<LocaleWithState> sortedLocales ( locs.begin(), locs.end() );
+  sortedLocales.sort( [] ( const LocaleWithState &l, const LocaleWithState &r ) {
+    return l.locale.code() < r.locale.code();
+  });
+
+  for_( it, sortedLocales.begin(), sortedLocales.end() )
+  {
+    const zypp::sat::LocaleSupport & myLocale((*it).locale);
+    cout << endl;
+    zypper.out().info( str::form( _("Packages for %s (locale '%s', requested: %s):"),
+      it->locale.name().c_str(), it->locale.code().c_str(), isRequestedState(it->state).c_str() ) );
+    cout << endl;
+    printLocalePackages( zypper, myLocale );
+  }
+}
+
+void addLocales( Zypper &zypper, const std::vector<std::string> &localeArgs_r, bool packages, std::map<std::string, bool> *result )
+{
+  const zypp::LocaleSet locales = relevantLocales( localeArgs_r, false );
+
+  for_( it, locales.begin(), locales.end() ) {
+    bool success = false;
+
+    if ( !God->pool().isRequestedLocale(*it) ) {
+      success = God->pool().addRequestedLocale( *it );
+      if ( success ) {
+        zypper.out().info( str::form( _("Added locale: %s"), (*it).code().c_str() ) );
+        if ( result ) ( *result )[(*it).code().c_str()] = true;
+      } else {
+        zypper.out().error( str::form( _("ERROR: cannot add %s"), (*it).code().c_str() ) );
+        if ( result ) ( *result )[(*it).code().c_str()] = false;
+      }
+    } else {
+      zypper.out().info( str::form( _(" %s is already requested."), (*it).code().c_str() ) );
+      if ( result ) ( *result )[(*it).code().c_str()] = false;
+    }
+  }
+
+  if ( packages ) {
+    solve_and_commit( zypper, Summary::DEFAULT, DownloadMode::DownloadDefault );
+  } else {
+    God->commit( ZYppCommitPolicy() );
+  }
+}
+
+void removeLocales( Zypper &zypper, const std::vector<std::string> &localeArgs, bool packages, std::map<std::string, bool> *result )
+{
+  for_( it, localeArgs.begin(), localeArgs.end() ) {
+    bool success = false;
+
+    zypp::Locale loc( *it );
+    if ( God->pool().isRequestedLocale( loc ) ) {
+      success = God->pool().eraseRequestedLocale( loc );
+      if ( success ) {
+        zypper.out().info( str::form( _("Removed locale: %s"), (*it).c_str() ) );
+        ( *result )[(*it)] = true;
+      } else {
+        zypper.out().error( str::form( _("ERROR: cannot remove %s"), (*it).c_str() ) ) ;
+        ( *result )[(*it)] = false;
+      }
+    } else {
+      zypper.out().info( str::form( _("%s was not requested."), (*it).c_str() ) );
+      ( *result )[(*it)] = false;
+    }
+  }
+
+  if ( packages ) {
+    solve_and_commit( zypper, Summary::DEFAULT, DownloadMode::DownloadDefault );
+  } else {
+    God->commit( ZYppCommitPolicy() );
+  }
+}

--- a/src/locales.h
+++ b/src/locales.h
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------*\
+                          ____  _ _ __ _ __  ___ _ _
+                         |_ / || | '_ \ '_ \/ -_) '_|
+                         /__|\_, | .__/ .__/\___|_|
+                             |__/|_|  |_|
+\*---------------------------------------------------------------------------*/
+
+#ifndef LOCALES_H
+#define LOCALES_H
+
+#include <vector>
+#include <string>
+#include <map>
+
+class Zypper;
+
+void listLocales( Zypper & zypper, const std::vector<std::string> &localeArgs, bool showAll );
+
+void localePackages( Zypper & zypper, const std::vector<std::string> &localeArgs, bool showAll );
+
+void addLocales( Zypper & zypper_r, const std::vector<std::string> &localeArgs_r, bool packages, std::map<std::string, bool> *result = nullptr );
+
+void removeLocales( Zypper & zypper, const std::vector<std::string> &localeArgs, bool packages, std::map<std::string, bool> *result = nullptr );
+
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,3 +16,4 @@ ADD_CUSTOM_TARGET( ctest
 ADD_TESTS( PackageArgs )
 ADD_TESTS( SolverRequester )
 ADD_TESTS( ZyppFlags )
+ADD_TESTS( Locales )

--- a/tests/Locales_test.cc
+++ b/tests/Locales_test.cc
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------------------------*\
+                          ____  _ _ __ _ __  ___ _ _
+                         |_ / || | '_ \ '_ \/ -_) '_|
+                         /__|\_, | .__/ .__/\___|_|
+                             |__/|_|  |_|
+\*---------------------------------------------------------------------------*/
+
+#include "TestSetup.h"
+#include "locales.h"
+#include "repos.h"
+
+using namespace std;
+using namespace zypp;
+
+static TestSetup test( Arch_x86_64 );
+
+extern ZYpp::Ptr God;
+
+BOOST_AUTO_TEST_CASE( setup )
+{
+  zypp::base::LogControl::instance().logfile( "./zypper_test.log" );
+
+  MIL << "*** Starting locale tests" << endl;
+
+  try
+  {
+    God = zypp::getZYpp();
+  }
+  catch ( const ZYppFactoryException & excpt_r )
+  {
+    ZYPP_CAUGHT (excpt_r);
+    cerr <<
+      "Could not access the package manager engine."
+      " This usually happens when you have another application (like YaST)"
+      " using it at the same time. Close the other applications and try again.";
+  }
+  catch ( const Exception & excpt_r)
+  {
+    ZYPP_CAUGHT (excpt_r);
+    cerr << excpt_r.msg() << endl;
+  }
+  
+  test.loadRepo(TESTS_SRC_DIR "/data/openSUSE-11.1", "main");
+
+  init_target( test.zypper() );
+}
+
+BOOST_AUTO_TEST_CASE( add_locales )
+{
+  vector<string> localeArgs;
+  localeArgs.push_back( "de" );
+  localeArgs.push_back( "en" );
+  localeArgs.push_back( "invalid" );
+
+  // try to add locales "de", "en" and "invalid"
+  std::map<std::string, bool> result;
+  addLocales( test.zypper(), localeArgs, false, &result );
+
+  BOOST_CHECK( (result.find("de") != result.end()) && result["de"] );
+  BOOST_CHECK( (result.find("en") != result.end()) && result["en"] );
+  BOOST_CHECK( result.find("invalid") == result.end() ); // not in result, sorted out
+
+  // try to add "de" again
+  result.clear();
+  localeArgs.clear();
+  localeArgs.push_back("de");
+  addLocales( test.zypper(), localeArgs, false, &result );
+
+  BOOST_CHECK( (result.find("de") != result.end()) && !result["de"] );
+}
+
+BOOST_AUTO_TEST_CASE( remove_locales )
+{
+  vector<string> localeArgs;
+  localeArgs.push_back( "de" );
+  localeArgs.push_back( "cs" );
+  // remove "de" and "cs"
+  std::map<std::string, bool> result;
+  removeLocales( test.zypper(), localeArgs, false, &result );
+
+  BOOST_CHECK( (result.find("de") != result.end()) && result["de"] );
+  BOOST_CHECK( (result.find("cs") != result.end()) && !result["cs"] );
+
+  result.clear();
+}


### PR DESCRIPTION
Rebased the original PR #27 on top of current master, this adds support to enable/disable languages that are used to decide which translation packages are installed.  