### PR TITLE
Out of bounds read in mbs iterator

### DIFF
--- a/src/utils/text.h
+++ b/src/utils/text.h
@@ -122,9 +122,17 @@ namespace mbs
     {
       if ( !atEnd() )
       {
-	_tpos += _tread;
-	_trest -= _tread;
+        _tpos += _tread;
+        _trest -= _tread;
+
+        //we hit the end
+        if ( _trest == 0 ) {
+          setToEnd();
+          return *this;
+        }
+
 	_tread = ::mbrtowc( &_wc, _tpos, _trest, &_mbstate );
+
 	_cols = size_t(-1);
 
 	if ( _tread >= (size_t)-2 )
@@ -134,7 +142,7 @@ namespace mbs
 	  memset( &_mbstate, 0, sizeof(_mbstate) );
 	  _tread = 1;
 	  MbToWc c( *_tpos );
-	  while ( c.add( *(_tpos+_tread) ) )
+	  while ( ( _tread < _trest ) && c.add( *(_tpos+_tread) ) )
 	    _tread += 1;
 	  _wc = c._wc;
 	}
@@ -146,8 +154,7 @@ namespace mbs
 // 	    _tread = 0;
 // 	    // fall through
 	  case 0:
-	    _trest = 0;	// atEnd
-	    _wc = L'\0';
+	    setToEnd();
 	    break;
 
 	  default:
@@ -187,6 +194,12 @@ namespace mbs
 	  ret = p+1 - pos_r;
       }
       return ret;
+    }
+
+    void setToEnd ()
+    {
+      _trest = 0;	// atEnd
+      _wc = L'\0';
     }
 
     boost::string_ref	_text;


### PR DESCRIPTION
Fix one possible and one definitive out of bounds read in MbsIterator:

Out of bounds read happens in that case:
-> previous read reads last char 
-> current read advances pos and sets _trest to 0 
-> mbrtowc will return error -2 ( because max read bytes is 0 ? )
-> we enter if ( _tread >= (size_t)-2 ) 
-> sets _tread to 1 
-> while loop will continue behind the last char with _tpos+_tread

Also added a testcase that triggers that behaviour by setting up a teststring that has 
multibyte continuation characters after a \0. 
