### PR TITLE
Sort search results by multiple columns (bsc#1066215)

### DIFF
--- a/src/Zypper.cc
+++ b/src/Zypper.cc
@@ -4829,16 +4829,16 @@ void Zypper::doCommand()
         if ( command() == ZypperCommand::RUG_PATCH_SEARCH )
         {
           if ( copts.count("sort-by-repo") )
-            t.sort( 1 );
+            t.sort( { 0, 1, Table::UserData } );
           else
-            t.sort( 3 ); // sort by name
+            t.sort( { 1, Table::UserData } ); // sort by name
         }
         else if ( _copts.count("details") )
         {
           if ( copts.count("sort-by-repo") )
-            t.sort( 5 );
+            t.sort( { 5, 1, Table::UserData } );
           else
-            t.sort( 1 ); // sort by name
+            t.sort( { 1, Table::UserData } ); // sort by name
         }
         else
         {

--- a/src/repos.cc
+++ b/src/repos.cc
@@ -1101,7 +1101,7 @@ static void print_repo_list( Zypper & zypper, const std::list<RepoInfo> & repos 
     th << _("Priority");
     ++index;
     if ( zypper.cOpts().count("sort-by-priority") || ( list_cols.find("P") != std::string::npos && !sort_override ) )
-      sort_index = Table::Nsidx;
+      sort_index = Table::UserData;
   }
 
   // type
@@ -1158,8 +1158,8 @@ static void print_repo_list( Zypper & zypper, const std::list<RepoInfo> & repos 
       tr << repoAutorefreshStr( repo );
     // priority
     if ( all || showprio )
-      // output flush right; use numerical sort index as coloring will break lex. sort
-      ( tr << repoPriorityNumber( repo.priority(), 4 ) ).nsidx( repo.priority() );
+      // output flush right; use custom sort index as coloring will break lex. sort
+      ( tr << repoPriorityNumber( repo.priority(), 4 ) ).userData( repo.priority() );
     // type
     if ( all )
       tr << repo.type().asString();

--- a/src/search.cc
+++ b/src/search.cc
@@ -121,7 +121,10 @@ bool FillSearchTableSolvable::operator()( const PoolItem & pi_r ) const
        ? (std::string("(") + _("System Packages") + ")")
        : pi_r->repository().asUserString() );
 
+  row.userData( SolvableCSI(pi_r.satSolvable(), sel->picklistPos(pi_r)));
+
   *_table << row;
+
   return true;	// actually added a row
 }
 

--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -26,7 +26,7 @@ BuildRequires:  boost-devel >= 1.33.1
 BuildRequires:  cmake >= 2.4.6
 BuildRequires:  gcc-c++ >= 4.7
 BuildRequires:  gettext-devel >= 0.15
-BuildRequires:  libzypp-devel >= 17.3.2
+BuildRequires:  libzypp-devel >= 17.5.2
 BuildRequires:  readline-devel >= 5.1
 BuildRequires:  libxml2-devel
 Requires:       procps


### PR DESCRIPTION
This patch allows us to sort a table by multiple columns and a per row user value