### PR TITLE
Check for root privileges in zypper verify and si (bsc#1066215)

### DIFF
--- a/src/Zypper.cc
+++ b/src/Zypper.cc
@@ -4541,6 +4541,14 @@ void Zypper::doCommand()
       return;
     }
 
+    // check root user
+    if ( geteuid() != 0 && !globalOpts().changedRoot )
+    {
+      out().error(_("Root privileges are required for installing or uninstalling packages.") );
+      setExitCode( ZYPPER_EXIT_ERR_PRIVILEGES );
+      return;
+    }
+
     initRepoManager();
     init_target( *this );
     init_repos( *this );
@@ -4567,6 +4575,14 @@ void Zypper::doCommand()
     {
       report_too_many_arguments( _command_help );
       setExitCode( ZYPPER_EXIT_ERR_INVALID_ARGS );
+      return;
+    }
+
+    // check root user
+    if ( geteuid() != 0 && !globalOpts().changedRoot )
+    {
+      out().error(_("Root privileges are required for installing or uninstalling packages.") );
+      setExitCode( ZYPPER_EXIT_ERR_PRIVILEGES );
       return;
     }
 


### PR DESCRIPTION
Currently zypper verify and source-install do not check for root privs and fails due to rpm return with error because it can not change the rpm datbse, this patches adds the checks so the user experience is more clean.