### PR TITLE
Add expert (allow-*) options to zypper in (bsc#428822)

### DIFF
--- a/doc/zypper.8.d/option_Solver_Flags_Installs.txt
+++ b/doc/zypper.8.d/option_Solver_Flags_Installs.txt
@@ -1,0 +1,11 @@
+	*--*[*no-*]*allow-downgrade*::
+		Whether to allow downgrading installed resolvables.
+
+	*--*[*no-*]*allow-name-change*::
+		Whether to allow changing the names of installed resolvables. Setting this to *no* will not replace packages which have been renamed.
+
+	*--*[*no-*]*allow-arch-change*::
+		Whether to allow changing the architecture of installed resolvables.
+
+	*--*[*no-*]*allow-vendor-change*::
+		Whether to allow changing the vendor of installed resolvables. Setting this to *no* might be useful if you do not want packages from foreign repos being changed to the distributions version (or vice versa).	

--- a/doc/zypper.8.txt
+++ b/doc/zypper.8.txt
@@ -301,6 +301,10 @@ include::{incdir}/option_Solver_Flags_Recommends.txt[]
 		*only*, *in-advance*, *in-heaps*, *as-needed*.
 		See corresponding *--download-*'mode' options for their description.
 
+	Expert Options: :: Don't use them unless you know you need them.
+
+include::{incdir}/option_Solver_Flags_Installs.txt[]
+
 	Examples: :: {nop}
 
 		$ *zypper install -t pattern lamp_server*;;
@@ -366,6 +370,10 @@ include::{incdir}/option_Solver_Flags_Recommends.txt[]
 include::{incdir}/option_Solver_Flags_Common.txt[]
 include::{incdir}/option_Solver_Flags_Recommends.txt[]
 
+	Expert Options: :: Don't use them unless you know you need them.
+
+include::{incdir}/option_Solver_Flags_Installs.txt[]
+
 	This command also accepts the *Download-and-install mode options* described in the *install* command.:: {nop}
 --
 
@@ -385,6 +393,10 @@ include::{incdir}/option_Solver_Flags_Recommends.txt[]
 	Solver related options: :: {nop}
 include::{incdir}/option_Solver_Flags_Common.txt[]
 // not supported here! //include::{incdir}/option_Solver_Flags_Recommends.txt[]
+
+	Expert Options: :: Don't use them unless you know you need them.
+
+include::{incdir}/option_Solver_Flags_Installs.txt[]
 
 This command also accepts the *Download-and-install mode options* described in the *install* command.:: {nop}
 --
@@ -502,6 +514,10 @@ Update Management Commands
 	Solver related options: :: {nop}
 include::{incdir}/option_Solver_Flags_Common.txt[]
 include::{incdir}/option_Solver_Flags_Recommends.txt[]
+
+	Expert Options: :: Don't use them unless you know you need them.
+
+include::{incdir}/option_Solver_Flags_Installs.txt[]
 
 	This command also accepts the *Download-and-install mode options* described in the *install* command description.:: {nop}
 --
@@ -622,6 +638,10 @@ include::{incdir}/option_Solver_Flags_Recommends.txt[]
 	Solver related options: :: {nop}
 include::{incdir}/option_Solver_Flags_Common.txt[]
 include::{incdir}/option_Solver_Flags_Recommends.txt[]
+
+	Expert Options: :: Don't use them unless you know you need them.
+
+include::{incdir}/option_Solver_Flags_Installs.txt[]
 
 	This command also accepts the *Download-and-install mode options* described in the *install* command description.:: {nop}
 --

--- a/src/Zypper.cc
+++ b/src/Zypper.cc
@@ -191,6 +191,26 @@ bool sigExitOnce = true;	// Flag to prevent nested calls to Zypper::immediateExi
     ? _("The default is to exclude optional patches.")	\
     : _("The default is to include optional patches.") ))
 
+#define ARG_Solver_Flags_Installs \
+  {"allow-downgrade",           no_argument,       &myOpts->_allowDowngrade, 1 },   \
+  {"no-allow-downgrade",        no_argument,       &myOpts->_allowDowngrade, 0 },   \
+  {"allow-name-change",         no_argument,       &myOpts->_allowNameChange, 1 },  \
+  {"no-allow-name-change",      no_argument,       &myOpts->_allowNameChange, 0 },  \
+  {"allow-arch-change",         no_argument,       &myOpts->_allowArchChange, 1 },  \
+  {"no-allow-arch-change",      no_argument,       &myOpts->_allowArchChange, 0 },  \
+  {"allow-vendor-change",       no_argument,       &myOpts->_allowVendorChange, 1 },\
+  {"no-allow-vendor-change",    no_argument,       &myOpts->_allowVendorChange, 0 }
+
+#define option_Solver_Flags_Installs \
+   option( "--allow-downgrade" )  \
+  .option( "--no-allow-downgrade",		_("Whether to allow downgrading installed resolvables.") ) \
+  .option( "--allow-name-change" ) \
+  .option( "--no-allow-name-change",	_("Whether to allow changing the names of installed resolvables.") ) \
+  .option( "--allow-arch-change" ) \
+  .option( "--no-allow-arch-change",	_("Whether to allow changing the architecture of installed resolvables.") ) \
+  .option( "--allow-vendor-change" ) \
+  .option( "--no-allow-vendor-change",	_("Whether to allow changing the vendor of installed resolvables.") )
+
 ///////////////////////////////////////////////////////////////////
 namespace cli
 {
@@ -1768,6 +1788,8 @@ void Zypper::processCommandOptions()
 
   case ZypperCommand::INSTALL_e:
   {
+    shared_ptr<InstallerBaseOptions> myOpts( new InstallerBaseOptions( ZypperCommand::INSTALL ) );
+    _commandOptions = myOpts;
     static struct option install_options[] = {
       {"repo",                      required_argument, 0, 'r'},
       // rug compatibility option, we have --repo
@@ -1786,6 +1808,7 @@ void Zypper::processCommandOptions()
       {"agree-to-third-party-licenses",  no_argument,  0,  0 },	// rug compatibility, we have --auto-agree-with-licenses
       ARG_Solver_Flags_Common,
       ARG_Solver_Flags_Recommends,
+      ARG_Solver_Flags_Installs,
       {"dry-run",                   no_argument,       0, 'D'},
       // rug uses -N shorthand
       {"dry-run",                   no_argument,       0, 'N'},
@@ -1846,6 +1869,8 @@ void Zypper::processCommandOptions()
     .optionSectionSolverOptions()
     .option_Solver_Flags_Common
     .option_Solver_Flags_Recommends
+    .optionSectionExpertOptions()
+    .option_Solver_Flags_Installs
     ;
     break;
   }
@@ -1936,6 +1961,8 @@ void Zypper::processCommandOptions()
 
   case ZypperCommand::VERIFY_e:
   {
+    shared_ptr<InstallerBaseOptions> myOpts( new InstallerBaseOptions( ZypperCommand::VERIFY ) );
+    _commandOptions = myOpts;
     static struct option verify_options[] = {
       {"no-confirm", no_argument, 0, 'y'},			// pkg/apt/yum user convenience ==> --non-interactive
       {"dry-run", no_argument, 0, 'D'},
@@ -1952,6 +1979,7 @@ void Zypper::processCommandOptions()
       {"repo",                      required_argument, 0, 'r'},
       ARG_Solver_Flags_Common,
       ARG_Solver_Flags_Recommends,
+      ARG_Solver_Flags_Installs,
       {"help", no_argument, 0, 'h'},
       {0, 0, 0, 0}
     };
@@ -1978,12 +2006,16 @@ void Zypper::processCommandOptions()
     .optionSectionSolverOptions()
     .option_Solver_Flags_Common
     .option_Solver_Flags_Recommends
+    .optionSectionExpertOptions()
+    .option_Solver_Flags_Installs
     ;
     break;
   }
 
   case ZypperCommand::INSTALL_NEW_RECOMMENDS_e:
   {
+    shared_ptr<InstallerBaseOptions> myOpts( new InstallerBaseOptions( ZypperCommand::INSTALL_NEW_RECOMMENDS ) );
+    _commandOptions = myOpts;
     static struct option options[] = {
       {"dry-run", no_argument, 0, 'D'},
       {"details",		    no_argument,       0,  0 },
@@ -1996,6 +2028,7 @@ void Zypper::processCommandOptions()
       {"download-as-needed",        no_argument,       0,  0 },
       {"repo", required_argument, 0, 'r'},
       ARG_Solver_Flags_Common,
+      ARG_Solver_Flags_Installs,
       {"help", no_argument, 0, 'h'},
       {0, 0, 0, 0}
     };
@@ -2019,6 +2052,8 @@ void Zypper::processCommandOptions()
 
     .optionSectionSolverOptions()
     .option_Solver_Flags_Common
+    .optionSectionExpertOptions()
+    .option_Solver_Flags_Installs
     ;
     break;
   }
@@ -2513,6 +2548,8 @@ void Zypper::processCommandOptions()
 
   case ZypperCommand::UPDATE_e:
   {
+    shared_ptr<InstallerBaseOptions> myOpts( new InstallerBaseOptions( ZypperCommand::UPDATE ) );
+    _commandOptions = myOpts;
     static struct option update_options[] = {
       {"repo",                      required_argument, 0, 'r'},
       // rug compatibility option, we have --repo
@@ -2526,6 +2563,7 @@ void Zypper::processCommandOptions()
       {"best-effort",               no_argument,       0, 0},
       ARG_Solver_Flags_Common,
       ARG_Solver_Flags_Recommends,
+      ARG_Solver_Flags_Installs,
       {"replacefiles",              no_argument,       0,  0 },
       {"dry-run",                   no_argument,       0, 'D'},
       // rug uses -N shorthand
@@ -2581,12 +2619,16 @@ void Zypper::processCommandOptions()
     .optionSectionSolverOptions()
     .option_Solver_Flags_Common
     .option_Solver_Flags_Recommends
+    .optionSectionExpertOptions()
+    .option_Solver_Flags_Installs
     ;
     break;
   }
 
   case ZypperCommand::PATCH_e:
   {
+    shared_ptr<InstallerBaseOptions> myOpts( new InstallerBaseOptions( ZypperCommand::PATCH ) );
+    _commandOptions = myOpts;
     static struct option update_options[] = {
       {"repo",                      required_argument, 0, 'r'},
       {"updatestack-only",	    no_argument,       0,  0 },
@@ -2597,6 +2639,7 @@ void Zypper::processCommandOptions()
       ARG_License_Agreement,
       ARG_Solver_Flags_Common,
       ARG_Solver_Flags_Recommends,
+      ARG_Solver_Flags_Installs,
       {"replacefiles",              no_argument,       0,  0 },
       {"dry-run",                   no_argument,       0, 'D'},
       {"details",		    no_argument,       0,  0 },
@@ -2655,6 +2698,8 @@ void Zypper::processCommandOptions()
       .optionSectionSolverOptions()
       .option_Solver_Flags_Common
       .option_Solver_Flags_Recommends
+      .optionSectionExpertOptions()
+      .option_Solver_Flags_Installs
       ;
     break;
   }
@@ -2721,15 +2766,7 @@ void Zypper::processCommandOptions()
       // solver flags
       ARG_Solver_Flags_Common,
       ARG_Solver_Flags_Recommends,
-      // dup solver flags
-      {"allow-downgrade",           no_argument,       &myOpts->_dupAllowDowngrade, 1 },
-      {"no-allow-downgrade",        no_argument,       &myOpts->_dupAllowDowngrade, 0 },
-      {"allow-name-change",         no_argument,       &myOpts->_dupAllowNameChange, 1 },
-      {"no-allow-name-change",      no_argument,       &myOpts->_dupAllowNameChange, 0 },
-      {"allow-arch-change",         no_argument,       &myOpts->_dupAllowArchChange, 1 },
-      {"no-allow-arch-change",      no_argument,       &myOpts->_dupAllowArchChange, 0 },
-      {"allow-vendor-change",       no_argument,       &myOpts->_dupAllowVendorChange, 1 },
-      {"no-allow-vendor-change",    no_argument,       &myOpts->_dupAllowVendorChange, 0 },
+      ARG_Solver_Flags_Installs,
       {"help", no_argument, 0, 'h'},
       {0, 0, 0, 0}
     };
@@ -2762,16 +2799,9 @@ void Zypper::processCommandOptions()
       .optionSectionSolverOptions()
       .option_Solver_Flags_Common
       .option_Solver_Flags_Recommends
-
       .optionSectionExpertOptions()
-      .option( "--allow-downgrade" )
-      .option( "--no-allow-downgrade",		_("Whether to allow downgrading installed resolvables.") )
-      .option( "--allow-name-change" )
-      .option( "--no-allow-name-change",	_("Whether to allow changing the names of installed resolvables.") )
-      .option( "--allow-arch-change" )
-      .option( "--no-allow-arch-change",	_("Whether to allow changing the architecture of installed resolvables.") )
-      .option( "--allow-vendor-change" )
-      .option( "--no-allow-vendor-change",	_("Whether to allow changing the vendor of installed resolvables.") )
+      .option_Solver_Flags_Installs
+
       ;
     break;
   }

--- a/src/solve-commit.cc
+++ b/src/solve-commit.cc
@@ -304,13 +304,24 @@ static void set_solver_flags( Zypper & zypper )
   // solve_with_update must be false until the command passed the initialization!
   God->resolver()->setUpdateMode( zypper.runtimeData().solve_with_update );
 
+  //first check if command options is of type DupOptions, fall back to check the generic
+  //type InstallerBaseOptions.
   shared_ptr<DupOptions> dupOptions = zypper.commandOptionsAs<DupOptions>();
   if ( dupOptions )
   {
-    if ( dupOptions->_dupAllowDowngrade != -1 ) God->resolver()->dupSetAllowDowngrade( dupOptions->_dupAllowDowngrade );
-    if ( dupOptions->_dupAllowNameChange != -1 ) God->resolver()->dupSetAllowNameChange( dupOptions->_dupAllowNameChange );
-    if ( dupOptions->_dupAllowArchChange != -1 ) God->resolver()->dupSetAllowArchChange( dupOptions->_dupAllowArchChange );
-    if ( dupOptions->_dupAllowVendorChange != -1 ) God->resolver()->dupSetAllowVendorChange( dupOptions->_dupAllowVendorChange );
+    if ( dupOptions->_allowDowngrade != -1 ) God->resolver()->dupSetAllowDowngrade( dupOptions->_allowDowngrade );
+    if ( dupOptions->_allowNameChange != -1 ) God->resolver()->dupSetAllowNameChange( dupOptions->_allowNameChange );
+    if ( dupOptions->_allowArchChange != -1 ) God->resolver()->dupSetAllowArchChange( dupOptions->_allowArchChange );
+    if ( dupOptions->_allowVendorChange != -1 ) God->resolver()->dupSetAllowVendorChange( dupOptions->_allowVendorChange );
+  } else {
+    shared_ptr<InstallerBaseOptions> installOptions = zypper.commandOptionsAs<InstallerBaseOptions>();
+    if ( installOptions )
+    {
+      if ( installOptions->_allowDowngrade != -1 ) God->resolver()->setAllowDowngrade( installOptions->_allowDowngrade );
+      if ( installOptions->_allowNameChange != -1 ) God->resolver()->setAllowNameChange( installOptions->_allowNameChange );
+      if ( installOptions->_allowArchChange != -1 ) God->resolver()->setAllowArchChange( installOptions->_allowArchChange );
+      if ( installOptions->_allowVendorChange != -1 ) God->resolver()->setAllowVendorChange( installOptions->_allowVendorChange );
+    }
   }
 }
 

--- a/src/solve-commit.h
+++ b/src/solve-commit.h
@@ -17,20 +17,29 @@
 
 #include "Zypper.h"
 
+/**
+ * Commonly shared Options type for all commands that install packages
+ */
+struct InstallerBaseOptions : public Options
+{
+  InstallerBaseOptions ( const ZypperCommand & command_r ) : Options(command_r)
+    , _allowDowngrade( -1 )
+    , _allowNameChange( -1 )
+    , _allowArchChange( -1 )
+    , _allowVendorChange( -1 )
+  {}
+  int _allowDowngrade;
+  int _allowNameChange;
+  int _allowArchChange;
+  int _allowVendorChange;
+};
+
 /** dup specific options */
-struct DupOptions : public Options
+struct DupOptions : public InstallerBaseOptions
 {
   DupOptions()
-    : Options( ZypperCommand::DIST_UPGRADE )
-    , _dupAllowDowngrade( -1 )
-    , _dupAllowNameChange( -1 )
-    , _dupAllowArchChange( -1 )
-    , _dupAllowVendorChange( -1 )
+    : InstallerBaseOptions( ZypperCommand::DIST_UPGRADE )
   {}
-  int _dupAllowDowngrade;
-  int _dupAllowNameChange;
-  int _dupAllowArchChange;
-  int _dupAllowVendorChange;
 };
 
 /**


### PR DESCRIPTION
This patch adds the same set of expert switches to all zypper commands that could install packages as they are available for zypper dup:

--allow-downgrade
--no-allow-downgrade
--allow-name-change
--no-allow-name-change
--allow-arch-change
--no-allow-arch-change
--allow-vendor-change
--no-allow-vendor-change