### PR TITLE
Add MixinOptions template to combine multiple common option sets.

### DIFF
--- a/src/ZCOMMAND.h
+++ b/src/ZCOMMAND.h
@@ -15,15 +15,15 @@ class Zypper;
 */
 
 /** @command@ specific options */
-struct @Command@Options : public Options
+struct @Command@Options : public MixinOptions<ZypperCommand::@COMMAND@>
 {
-  @Command@Options() : Options( ZypperCommand::@COMMAND@ )
+  @Command@Options()
   {}
 
   //** @Command@ user help (translated). */
   //virtual std::ostream & showHelpOn( std::ostream & out ) const;
 
-  bool	_myopt;	//< opts go here...
+  bool	_myopt = true;	//< opts go here...
 };
 
 /** Execute @command@.

--- a/src/Zypper.cc
+++ b/src/Zypper.cc
@@ -1788,7 +1788,7 @@ void Zypper::processCommandOptions()
 
   case ZypperCommand::INSTALL_e:
   {
-    shared_ptr<InstallerBaseOptions> myOpts( new InstallerBaseOptions( ZypperCommand::INSTALL ) );
+    shared_ptr<InstallOptions> myOpts( new InstallOptions );
     _commandOptions = myOpts;
     static struct option install_options[] = {
       {"repo",                      required_argument, 0, 'r'},
@@ -1961,7 +1961,7 @@ void Zypper::processCommandOptions()
 
   case ZypperCommand::VERIFY_e:
   {
-    shared_ptr<InstallerBaseOptions> myOpts( new InstallerBaseOptions( ZypperCommand::VERIFY ) );
+    shared_ptr<VerifyOptions> myOpts( new VerifyOptions );
     _commandOptions = myOpts;
     static struct option verify_options[] = {
       {"no-confirm", no_argument, 0, 'y'},			// pkg/apt/yum user convenience ==> --non-interactive
@@ -2014,7 +2014,7 @@ void Zypper::processCommandOptions()
 
   case ZypperCommand::INSTALL_NEW_RECOMMENDS_e:
   {
-    shared_ptr<InstallerBaseOptions> myOpts( new InstallerBaseOptions( ZypperCommand::INSTALL_NEW_RECOMMENDS ) );
+    shared_ptr<InrOptions> myOpts( new InrOptions );
     _commandOptions = myOpts;
     static struct option options[] = {
       {"dry-run", no_argument, 0, 'D'},
@@ -2548,7 +2548,7 @@ void Zypper::processCommandOptions()
 
   case ZypperCommand::UPDATE_e:
   {
-    shared_ptr<InstallerBaseOptions> myOpts( new InstallerBaseOptions( ZypperCommand::UPDATE ) );
+    shared_ptr<UpdateOptions> myOpts( new UpdateOptions );
     _commandOptions = myOpts;
     static struct option update_options[] = {
       {"repo",                      required_argument, 0, 'r'},
@@ -2627,7 +2627,7 @@ void Zypper::processCommandOptions()
 
   case ZypperCommand::PATCH_e:
   {
-    shared_ptr<InstallerBaseOptions> myOpts( new InstallerBaseOptions( ZypperCommand::PATCH ) );
+    shared_ptr<PatchOptions> myOpts( new PatchOptions );
     _commandOptions = myOpts;
     static struct option update_options[] = {
       {"repo",                      required_argument, 0, 'r'},
@@ -2744,7 +2744,7 @@ void Zypper::processCommandOptions()
 
   case ZypperCommand::DIST_UPGRADE_e:
   {
-    shared_ptr<DupOptions> myOpts( new DupOptions() );
+    shared_ptr<DupOptions> myOpts( new DupOptions );
     _commandOptions = myOpts;
     static struct option dupdate_options[] = {
       {"no-confirm",                no_argument,       0, 'y'},	// pkg/apt/yum user convenience ==> --non-interactive

--- a/src/Zypper.h
+++ b/src/Zypper.h
@@ -327,7 +327,10 @@ public:
     return myopt;
   }
 
-  /** Convenience to return command options for \c Opt_, either casted from _commandOptions or newly created. */
+private:
+  /** Convenience to return command options for \c Opt_, either casted from _commandOptions or newly created.
+   * Not for public use, only to init a new commands _commandOptions.
+   */
   template<class Opt_>
   shared_ptr<Opt_> assertCommandOptions()
   {
@@ -397,7 +400,17 @@ void print_unknown_command_hint( Zypper & zypper );
 void print_command_help_hint( Zypper & zypper );
 
 ///////////////////////////////////////////////////////////////////
-/// \brief Base class for command specific option classes.
+/// \class Options
+/// \brief Base class for command specific option values.
+///
+/// Option set for a specific command should be derived from \ref Options.
+/// Place an instance in \ref Zypper and access it e.g. via
+/// \ref Zypper::commandOptionsAs.
+///
+/// The \ref MixinOptions template may be used to build command
+/// options combining multiple common option sets.
+///
+/// \see \ref MixinOptions
 ///////////////////////////////////////////////////////////////////
 struct Options
 {
@@ -437,6 +450,45 @@ private:
 };
 
 ///////////////////////////////////////////////////////////////////
+/// \class OptionsMixin
+/// \brief (Optional) common base class for options mixins.
+///////////////////////////////////////////////////////////////////
+struct OptionsMixin
+{};
+
+///////////////////////////////////////////////////////////////////
+/// \class MixinOptions<TZypperCommand,Mixins...>
+/// \brief Build command options combining multiple common option sets.
+/// \code
+///   struct CommonOptionsMixin : public OptionsMixin
+///   { /* common option values */ };
+///
+///   struct ExoticOptionsMixin : public OptionsMixin
+///   { /* exotic option values */ };
+///
+///   struct AOptions : public MixinOptions<ZypperCommand::A_e, CommonOptionsMixin>
+///   {
+///     /* common option values */
+///     /* command A specific options */
+///   };
+///
+///   struct BOptions : public MixinOptions<ZypperCommand::B_e, CommonOptionsMixin, ExoticOptionsMixin>
+///   {
+///     /* common option values */
+///     /* more common option values */
+///     /* command B specific options */
+///   };
+/// \endcode
+/// \see \ref Options
+///////////////////////////////////////////////////////////////////
+template <const ZypperCommand& TZypperCommand, class... TMixins>
+struct MixinOptions : public Options, public TMixins...
+{
+  MixinOptions() : Options( TZypperCommand ) {}
+};
+
+///////////////////////////////////////////////////////////////////
+/// \class CommandBase<Derived,Options>
 /// \brief Base class for command specific implementation classes.
 ///////////////////////////////////////////////////////////////////
 template <class Derived_, class Options_>

--- a/src/configtest.h
+++ b/src/configtest.h
@@ -13,7 +13,7 @@ class Zypper;
 /// \class ConfigtestOptions
 /// \brief \ref Configtest specific options
 ///////////////////////////////////////////////////////////////////
-struct ConfigtestOptions : public Options
+struct ConfigtestOptions // A FAKED command which can't use class Options
 {};
 ///////////////////////////////////////////////////////////////////
 

--- a/src/download.h
+++ b/src/download.h
@@ -32,13 +32,12 @@ class Zypper;
 */
 
 /** download specific options */
-struct DownloadOptions : public Options
+struct DownloadOptions : public MixinOptions<ZypperCommand::DOWNLOAD>
 {
   static const Pathname _defaultDirectory;
 
   DownloadOptions()
-    : Options( ZypperCommand::DOWNLOAD)
-    , _dryrun( false )
+    : _dryrun( false )
     , _allmatches( false )
   {}
 

--- a/src/locks.h
+++ b/src/locks.h
@@ -4,11 +4,10 @@
 #include "Zypper.h"
 
 /** locks specific options */
-struct ListLocksOptions : public Options
+struct ListLocksOptions : public MixinOptions<ZypperCommand::LIST_LOCKS>
 {
   ListLocksOptions()
-    : Options( ZypperCommand::LIST_LOCKS )
-    , _withMatches( false )
+    : _withMatches( false )
     , _withSolvables( false )
   {}
   bool _withMatches;

--- a/src/ps.h
+++ b/src/ps.h
@@ -15,11 +15,10 @@ class Zypper;
 */
 
 /** ps specific options */
-struct PsOptions : public Options
+struct PsOptions : public MixinOptions<ZypperCommand::PS>
 {
   PsOptions()
-  : Options( ZypperCommand::PS )
-  , _shortness( 0 )
+  : _shortness( 0 )
   {}
 
   unsigned	_shortness;	//< 1:wo file, 2:only proc with services, 3:service names only

--- a/src/solve-commit.cc
+++ b/src/solve-commit.cc
@@ -304,18 +304,17 @@ static void set_solver_flags( Zypper & zypper )
   // solve_with_update must be false until the command passed the initialization!
   God->resolver()->setUpdateMode( zypper.runtimeData().solve_with_update );
 
-  //first check if command options is of type DupOptions, fall back to check the generic
-  //type InstallerBaseOptions.
-  shared_ptr<DupOptions> dupOptions = zypper.commandOptionsAs<DupOptions>();
-  if ( dupOptions )
+  // Use resolver->dupSet... if ZypperCommand::DIST_UPGRADE
+  if ( shared_ptr<InstallerBaseOptions> installOptions = zypper.commandOptionsAs<InstallerBaseOptions>() )
   {
-    if ( dupOptions->_allowDowngrade != -1 ) God->resolver()->dupSetAllowDowngrade( dupOptions->_allowDowngrade );
-    if ( dupOptions->_allowNameChange != -1 ) God->resolver()->dupSetAllowNameChange( dupOptions->_allowNameChange );
-    if ( dupOptions->_allowArchChange != -1 ) God->resolver()->dupSetAllowArchChange( dupOptions->_allowArchChange );
-    if ( dupOptions->_allowVendorChange != -1 ) God->resolver()->dupSetAllowVendorChange( dupOptions->_allowVendorChange );
-  } else {
-    shared_ptr<InstallerBaseOptions> installOptions = zypper.commandOptionsAs<InstallerBaseOptions>();
-    if ( installOptions )
+    if ( zypper.command() == ZypperCommand::DIST_UPGRADE )
+    {
+      if ( installOptions->_allowDowngrade != -1 ) God->resolver()->dupSetAllowDowngrade( installOptions->_allowDowngrade );
+      if ( installOptions->_allowNameChange != -1 ) God->resolver()->dupSetAllowNameChange( installOptions->_allowNameChange );
+      if ( installOptions->_allowArchChange != -1 ) God->resolver()->dupSetAllowArchChange( installOptions->_allowArchChange );
+      if ( installOptions->_allowVendorChange != -1 ) God->resolver()->dupSetAllowVendorChange( installOptions->_allowVendorChange );
+    }
+    else
     {
       if ( installOptions->_allowDowngrade != -1 ) God->resolver()->setAllowDowngrade( installOptions->_allowDowngrade );
       if ( installOptions->_allowNameChange != -1 ) God->resolver()->setAllowNameChange( installOptions->_allowNameChange );

--- a/src/solve-commit.h
+++ b/src/solve-commit.h
@@ -18,29 +18,41 @@
 #include "Zypper.h"
 
 /**
- * Commonly shared Options type for all commands that install packages
+ * Commonly shared Options mixin for all commands that install packages
  */
-struct InstallerBaseOptions : public Options
+struct InstallerBaseOptions : public OptionsMixin
 {
-  InstallerBaseOptions ( const ZypperCommand & command_r ) : Options(command_r)
-    , _allowDowngrade( -1 )
-    , _allowNameChange( -1 )
-    , _allowArchChange( -1 )
-    , _allowVendorChange( -1 )
-  {}
-  int _allowDowngrade;
-  int _allowNameChange;
-  int _allowArchChange;
-  int _allowVendorChange;
+  int _allowDowngrade		= -1;	///< indeterminate: keep the resolvers default
+  int _allowNameChange		= -1;	///< indeterminate: keep the resolvers default
+  int _allowArchChange		= -1;	///< indeterminate: keep the resolvers default
+  int _allowVendorChange	= -1;	///< indeterminate: keep the resolvers default
 };
 
-/** dup specific options */
-struct DupOptions : public InstallerBaseOptions
-{
-  DupOptions()
-    : InstallerBaseOptions( ZypperCommand::DIST_UPGRADE )
-  {}
-};
+/**
+ * Commonly shared Options type for all commands that install packages.
+ */
+template <const ZypperCommand& TZypperCommand>
+struct InstallCommandOptions : public MixinOptions<TZypperCommand, InstallerBaseOptions>
+{};
+
+struct InstallOptions : public InstallCommandOptions<ZypperCommand::INSTALL>
+{};
+
+struct UpdateOptions : public InstallCommandOptions<ZypperCommand::UPDATE>
+{};
+
+struct PatchOptions : public InstallCommandOptions<ZypperCommand::PATCH>
+{};
+
+struct VerifyOptions : public InstallCommandOptions<ZypperCommand::VERIFY>
+{};
+
+struct InrOptions : public InstallCommandOptions<ZypperCommand::INSTALL_NEW_RECOMMENDS>
+{};
+
+struct DupOptions : public InstallCommandOptions<ZypperCommand::DIST_UPGRADE>
+{};
+
 
 /**
  * Run the solver.

--- a/src/source-download.h
+++ b/src/source-download.h
@@ -32,14 +32,13 @@ class Zypper;
 */
 
 /** source-download specific options */
-struct SourceDownloadOptions : public Options
+struct SourceDownloadOptions : public MixinOptions<ZypperCommand::SOURCE_DOWNLOAD>
 {
   static const Pathname _defaultDirectory;
   static const std::string _manifestName;
 
   SourceDownloadOptions()
-    : Options( ZypperCommand::SOURCE_DOWNLOAD )
-    , _directory( _defaultDirectory )
+    : _directory( _defaultDirectory )
 //     , _manifest( true )
     , _delete( true )
     , _dryrun( false )

--- a/src/subcommand.h
+++ b/src/subcommand.h
@@ -34,11 +34,8 @@ class Zypper;
  (Idea and wording are shamelessly stolen from git :)
 */
 /** subcommand specific options */
-struct SubcommandOptions : public Options
+struct SubcommandOptions : public MixinOptions<ZypperCommand::SUBCOMMAND>
 {
-  SubcommandOptions() : Options( ZypperCommand::SUBCOMMAND )
-  {}
-
   /** Subcommand user help (translated).
    * Unlike other commands, this page is created dynamicly for
    * subcommand overview. Command specific help will run


### PR DESCRIPTION
Allow commonly used option sets to be mixed into several command optrions.