### PR TITLE
Always warn if no repos are defined, but don't return ZYPPER_EXIT_NO_…

### DIFF
--- a/src/Zypper.cc
+++ b/src/Zypper.cc
@@ -5355,16 +5355,6 @@ void Zypper::doCommand()
       init_repos( *this );
       if ( exitCode() != ZYPPER_EXIT_OK )
 	return;
-
-      if ( _rdata.repos.empty() )
-      {
-	out().warning(_("No repositories defined. Operating only with the installed resolvables. Nothing can be installed.") );
-	if ( command() == ZypperCommand::INSTALL )
-	{
-	  setExitCode( ZYPPER_EXIT_NO_REPOS );
-	  return;
-	}
-      }
     }
 
     // prepare target
@@ -5502,11 +5492,6 @@ void Zypper::doCommand()
     init_repos( *this );
     if ( exitCode() != ZYPPER_EXIT_OK )
       return;
-
-    if ( _rdata.repos.empty() )
-    {
-      out().warning(_("No repositories defined. Operating only with the installed resolvables. Nothing can be installed.") );
-    }
 
     // prepare target
     init_target( *this );

--- a/src/repos.cc
+++ b/src/repos.cc
@@ -3225,6 +3225,8 @@ void load_repo_resolvables( Zypper & zypper )
   RuntimeData & gData = zypper.runtimeData();
 
   zypper.out().info(_("Loading repository data...") );
+  if ( gData.repos.empty() )
+    zypper.out().warning(_("No repositories defined. Operating only with the installed resolvables. Nothing can be installed.") );
 
   for_( it, gData.repos.begin(), gData.repos.end() )
   {


### PR DESCRIPTION
…REPOS(6) in install commands [(bsc#1109893)](https://bugzilla.suse.com/show_bug.cgi?id=1109893)

IMO makes more sense to warn when repos are loaded. This way all repo loading commands show the warning, not like now just in/verify/inr. 

It's a corner case, so we may let the command simply complete and return it's code (though we may know in advance that an `install` or `search -i` will not succeed.