### PR TITLE
zypper-log: Make Python 3 compatible

### DIFF
--- a/tools/zypper-log
+++ b/tools/zypper-log
@@ -5,6 +5,7 @@
 #
 # Author: Dominik Heidler <dheidler@suse.de>
 
+from __future__ import print_function
 import os, string, re, bz2, zlib, sys, time, argparse, errno
 import subprocess
 
@@ -32,8 +33,8 @@ def getLogFiles(rotate = 0):
 def readFile(logfile):
   try:
     logtxt = open(logfile).read()
-  except IOError, e:
-    print >> sys.stderr, "\rIOError: %s: '%s'" % (e.strerror, e.filename)
+  except IOError as e:
+    print("\rIOError: %s: '%s'" % (e.strerror, e.filename), file=sys.stderr)
     sys.exit(1)
   fext = logfile.split('.')[-1]
   if fext == 'xz':
@@ -53,7 +54,7 @@ def getListFromLogFiles(logfiles):
   c = re.compile(r"===== Hi, me zypper (\d+.\d+.\d+).*$\s(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}).+\((\d+)\).+=====\s(.+)\s=====|genericfrontend.cc.*Launched (YaST2) component (.*)$\s(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}).+\((\d+)\)", re.M)
 
   for logfile in logfiles:
-    print >> sys.stderr, "Reading %s" % logfile, '.' * (filenamelen - len(logfile) + 3),
+    print("Reading %s" % logfile, '.' * (filenamelen - len(logfile) + 3), end=' ', file=sys.stderr)
     sys.stderr.flush()
     for run in c.findall(readFile(logfile)):
       if run[4] == 'YaST2':
@@ -75,9 +76,9 @@ def getListFromLogFiles(logfiles):
                        'time': time.strptime(tim, "%Y-%m-%d %H:%M:%S"),
                        'pid': pid,
                        'cmd': cmd.replace("'", "")})
-    print >> sys.stderr, "DONE"
+    print("DONE", file=sys.stderr)
     sys.stderr.flush()
-  print >> sys.stderr, ""
+  print("", file=sys.stderr)
   sys.stderr.flush()
   return logindex
 
@@ -85,7 +86,7 @@ def printList(logindex, date = False):
   global pidlen, verlen
   rows, columns = os.popen('stty size', 'r').read().split()
 
-  print "TIME              PID", ' ' * (pidlen - 3), "VER", ' ' * (verlen - 3), "CMD"
+  print("TIME              PID", ' ' * (pidlen - 3), "VER", ' ' * (verlen - 3), "CMD")
   for logentry in logindex:
     if date and date != time.strftime("%Y-%m-%d", logentry['time']):
       continue
@@ -93,7 +94,7 @@ def printList(logindex, date = False):
     spaceleft = int(columns) - (22 + pidlen + len(logentry['version']) + len(logentry['cmd']))
     if spaceleft < 0 and sys.stdout.isatty():
       logentry['cmd'] = logentry['cmd'][:spaceleft-3] + '...'
-    print "%(ptime)s  %(pid)s" % logentry, ' ' * (pidlen - len(logentry['pid'])), "%(version)s" % logentry, ' ' * (verlen - len(logentry['version'])),  "%(cmd)s" % logentry
+    print("%(ptime)s  %(pid)s" % logentry, ' ' * (pidlen - len(logentry['pid'])), "%(version)s" % logentry, ' ' * (verlen - len(logentry['version'])),  "%(cmd)s" % logentry)
 
 def printLogByPID(logfiles, pid, date = False):
   if not date:
@@ -102,14 +103,14 @@ def printLogByPID(logfiles, pid, date = False):
   c = re.compile(r"%s \d{2}:\d{2}:\d{2} \<\d+\> [^(]+\(%d\).+" % (date, pid))
 
   for logfile in logfiles:
-    print >> sys.stderr, "Reading %s" % logfile, '.' * (filenamelen - len(logfile) + 3),
+    print("Reading %s" % logfile, '.' * (filenamelen - len(logfile) + 3), end=' ', file=sys.stderr)
     sys.stderr.flush()
     output.extend( c.findall(readFile(logfile)) )
-    print >> sys.stderr, "DONE"
+    print("DONE", file=sys.stderr)
     sys.stderr.flush()
-  print >> sys.stderr, ""
+  print("", file=sys.stderr)
   sys.stderr.flush()
-  print "\n".join(output)
+  print("\n".join(output))
 
 def main():
   parser = argparse.ArgumentParser(description='This tool helps you to access the zypper logfile. Run this command without any arguments to get a list of your zypper runs. Provide the PID-File of a zypper run as an argument to query the log for this run.')
@@ -130,7 +131,7 @@ def main():
     try:
       args.date = time.strftime("%Y-%m-%d", time.strptime(args.date, "%Y-%m-%d"))
     except ValueError:
-      print >> sys.stderr, "ValueError: Time data '%s' does not match format 'YYYY-MM-DD'" % args.date
+      print("ValueError: Time data '%s' does not match format 'YYYY-MM-DD'" % args.date, file=sys.stderr)
       sys.exit(1)
   if args.pid:
      printLogByPID(logfiles, args.pid, args.date)
@@ -142,6 +143,6 @@ def main():
 if __name__ == "__main__":
   try:
     main()
-  except IOError, e:
+  except IOError as e:
     if e.errno != errno.EPIPE:
       raise


### PR DESCRIPTION
As part of the effort to cull Python 2 dependencies in Fedora, this code was trivially ported to Python 3 to remove the Python 2 dependency in Zypper.

Reference: https://fedoraproject.org/wiki/FinalizingFedoraSwitchtoPython3
Reference: https://fedoraproject.org/wiki/Changes/Mass_Python_2_Package_Removal