### PR TITLE
Don't iterate twice on --no-cd

### DIFF
--- a/src/repos.cc
+++ b/src/repos.cc
@@ -798,7 +798,7 @@ void do_init_repos( Zypper & zypper, const Container & container )
 				   it->asUserString().c_str(), "no-cd" ) );
       gData.repos.erase( it++ );
     }
-    if ( no_remote && it->url().schemeIsDownloading() )
+    else if ( no_remote && it->url().schemeIsDownloading() )
     {
       zypper.out().info( str::form(_("Ignoring repository '%s' because of '%s' option."),
 				   it->asUserString().c_str(), "no-remote" ) );


### PR DESCRIPTION
In https://bugzilla.opensuse.org/show_bug.cgi?id=1111319 it was discovered that the `--no-cd` option did not work as expected: Even when all repositories were optical repositories it would still try to do something.

The condition https://github.com/openSUSE/zypper/blob/26d146ccdad0845053f1849b79177c7da876635a/src/repos.cc#L801 is missing an else clause, thus incrementing the iterator a second time in https://github.com/openSUSE/zypper/blob/26d146ccdad0845053f1849b79177c7da876635a/src/repos.cc#L808 The result are random non-deactivated repositories (with an odd number of repositories the incrementor would start at the beginning again).

Also fixes a potential segmentation fault when using `--no-cd` and `--no-remote` at the same time.