### PR TITLE
Allow more complex argument parsing in zypper

### DIFF
--- a/src/utils/flags/zyppflags.cc
+++ b/src/utils/flags/zyppflags.cc
@@ -15,6 +15,7 @@
 #include <exception>
 #include <utility>
 #include <string.h>
+#include <algorithm>
 
 namespace zypp
 {
@@ -61,11 +62,11 @@ namespace {
 
     //we do not use the flag and val types, instead we use optind to figure out what happend
     using OptType = struct option;
-    opts.push_back(OptType{opt.name.c_str(), has_arg, 0 ,0});
+    opts.push_back( OptType{opt.name.c_str(), has_arg, 0 ,0} );
   }
 }
 
-Value::Value(DefValueFun &&defValue, SetterFun &&setter, std::string argHint)
+Value::Value( DefValueFun &&defValue, SetterFun &&setter, std::string argHint )
   : _defaultVal( std::move(defValue) ),
     _setter( std::move(setter) ),
     _argHint( std::move(argHint) )
@@ -73,21 +74,40 @@ Value::Value(DefValueFun &&defValue, SetterFun &&setter, std::string argHint)
 
 }
 
-void Value::set(const CommandOption &opt, const boost::optional<std::string> in)
+void Value::set( const CommandOption &opt, const boost::optional<std::string> in )
 {
-  if ( _wasSet && !(opt.flags & Repeatable)) {
+  if ( _wasSet && !(opt.flags & Repeatable) ) {
     ZYPP_THROW( FlagRepeatedException(opt.name) );
+  }
+
+  if ( _preWriteHook.size() ) {
+    for ( auto &hook : _preWriteHook ) {
+      if ( !hook ( opt, in ) )
+        return;
+    }
   }
 
   _wasSet = true;
 
+  bool runPostSetHook = false;
   if ( !in && opt.flags & OptionalArgument ) {
       auto optVal = _defaultVal();
-      if (!optVal)
-        ZYPP_THROW( ZyppFlagsException(str::Format("BUG: Flag %1% is optional, but no default value was provided") % opt.name) );
-      return _setter( opt, optVal );
-  } else if ( in || (!in && (opt.flags & ArgumentTypeMask) == NoArgument) )  {
-    return _setter(opt, in);
+      if ( !optVal )
+        ZYPP_THROW( ZyppFlagsException( str::Format("BUG: Flag %1% is optional, but no default value was provided") % opt.name ) );
+      _setter( opt, optVal );
+      runPostSetHook = true;
+  } else if ( in || ( !in && ( opt.flags & ArgumentTypeMask ) == NoArgument ) )  {
+    _setter( opt, in );
+    runPostSetHook = true;
+  }
+
+  if ( runPostSetHook ) {
+    if ( _postWriteHook.size() ) {
+      for ( auto &hook : _postWriteHook ) {
+        hook ( opt, in );
+      }
+    }
+    return;
   }
 
   // this line should never be reached, because the case of required argument is handled directly in parseCLI
@@ -110,7 +130,27 @@ bool Value::wasSet() const
   return _wasSet;
 }
 
-int parseCLI(const int argc, char * const *argv, const std::vector<CommandGroup> &options, const int firstOpt)
+Value &Value::after( std::function<void ()> &&postWriteHook )
+{
+  return after ( [ postWriteHook ] ( const CommandOption &, const boost::optional<std::string> & ) {
+    postWriteHook();
+  } );
+}
+
+Value & Value::before( PreWriteHook &&preWriteHook )
+{
+  _preWriteHook.push_back( std::move(preWriteHook) );
+  return *this;
+}
+
+Value & Value::after( PostWriteHook &&postWriteHook )
+{
+  _postWriteHook.push_back( std::move(postWriteHook) );
+  return *this;
+}
+
+
+int parseCLI( const int argc, char * const *argv, const std::vector<CommandGroup> &options, const int firstOpt )
 {
   // the short options string as used int getopt
   // + - do not permute, stop at the 1st nonoption, which is the command
@@ -129,6 +169,9 @@ int parseCLI(const int argc, char * const *argv, const std::vector<CommandGroup>
   std::unordered_map<std::string, int> longOptIndex;  //we do not actually need that index other than checking for dups
   std::unordered_map<char, int>        shortOptIndex;
 
+  //we intentionally copy all the CommandOptions here instead of using pointers, each state change in the
+  //Options or Value implementations are only valid for one run of parseCLI, state should not be remembered
+  //to not influence a possible next run
   for ( const CommandGroup &grp : options ) {
     for ( const CommandOption &currOpt : grp.options ) {
       allOpts.push_back( currOpt );
@@ -141,29 +184,106 @@ int parseCLI(const int argc, char * const *argv, const std::vector<CommandGroup>
       }
 
       if ( !currOpt.name.empty() ) {
-        if ( !longOptIndex.insert( { currOpt.name, allOptIndex } ).second) {
+        if ( !longOptIndex.insert( { currOpt.name, allOptIndex } ).second ) {
           throw ZyppFlagsException( str::Format("Duplicate long option ''%1%") % currOpt.name );
         }
         appendToLongOptions( currOpt, longopts );
       }
 
       if ( currOpt.shortName ) {
-        if ( !shortOptIndex.insert( { currOpt.shortName, allOptIndex } ).second) {
+        if ( !shortOptIndex.insert( { currOpt.shortName, allOptIndex } ).second ) {
           throw ZyppFlagsException( str::Format("Duplicate short option %1%") % currOpt.shortName );
         }
         appendToOptString( currOpt, shortopts );
       }
-
-      conflictingFlags.insert( conflictingFlags.end(), grp.conflictingOptions.begin(), grp.conflictingOptions.end() );
     }
+    conflictingFlags.insert( conflictingFlags.end(), grp.conflictingOptions.begin(), grp.conflictingOptions.end() );
   }
 
   //the long options always need to end with a set of zeros
-  longopts.push_back({0, 0, 0, 0});
+  longopts.push_back( {0, 0, 0, 0} );
+
+
+
+  /*
+   * Because of complex rules for flags in zypper, its required to process
+   * them in a defined order. We model the dependency tree in a very simple
+   * list of options with their first level dependencies, then use a multi pass
+   * approach to find directly writeable flags.
+   *
+   * A flag is considered directly writeable if it either has no dependencies,
+   * the dependencies where not used on CLI  or all dependencies are solved already.
+   * We keep track of solved flags in a simple set.
+   *
+   * Consider the following dependency tree (read from top down):
+   *
+   *     A      D
+   *    / \    / \
+   *   B   \  E  F
+   *        \/
+   *        c
+   *
+   * The list representation would look like that:
+   *
+   *   |-A-B
+   *   |  |_C
+   *   |-B
+   *   |-C
+   *   |-D-E
+   *   |  |_F
+   *   |-E-C
+   *   |-F
+   *
+   * The first pass through will write
+   *    B, C, and F
+   * Second pass through can write
+   *    A, E
+   * Third pass through
+   *    D
+   *
+   * We keep track of the number of values to be written, if the number
+   * does not change during a pass through something is the dependency chain is broken
+   * we need to give up, since its most likely to be a circular dependency problem we can
+   * try to detect that and give a hint by throwing a exception
+   */
+
+
+  //build the dependency tree
+  //the dependency tree, pointing to indices in the allOpts
+  std::map< int, std::set<int> > dependencyTree;
+  for ( int i = 0; i < allOpts.size(); i++ ) {
+    const CommandOption &opt = allOpts[i];
+
+    std::set<int> myDeps;
+    for ( const std::string &str : opt.dependencies ) {
+      int idx = -1;
+      if ( str.size() == 1 ) {
+        auto it = shortOptIndex.find( str.at(0) );
+        if ( it != shortOptIndex.end() ) {
+          idx = it->second;
+        }
+      } else {
+        auto it = longOptIndex.find( str );
+        if ( it != longOptIndex.end() ) {
+          idx = it->second;
+        }
+      }
+
+      if ( idx == -1 ) {
+        throw ZyppFlagsException( str::Format("Flag %1% (%2%) depends on unknown flag %3%") % opt.name % opt.shortName % str );
+      }
+      myDeps.insert( idx );
+    }
+    dependencyTree.insert( std::make_pair( i, myDeps) );
+  }
 
   //setup getopt
   opterr = 0; 			// we report errors on our own
   optind = firstOpt;            // start on the first arg
+
+  //remember all values we want to write
+  //the key of the map is the index of options in allOpts
+  std::map<int, std::vector< boost::optional<std::string> > > parsedValues;
 
   while ( true ) {
 
@@ -179,14 +299,14 @@ int parseCLI(const int argc, char * const *argv, const std::vector<CommandGroup>
         // wrong option in the last argument
         // last argument was a short option
         if ( option_index == -1 && optopt)
-          ZYPP_THROW(UnknownFlagException( std::string(1, optopt)) );
+          ZYPP_THROW( UnknownFlagException( std::string( 1, optopt ) ) );
         else
-          ZYPP_THROW(UnknownFlagException( std::string(argv[optind - 1]) ) );
+          ZYPP_THROW( UnknownFlagException( std::string( argv[optind - 1] ) ) );
         break;
       }
       case ':': {
         //the current argument requires a option
-        ZYPP_THROW(MissingArgumentException(argv[optind - 1]));
+        ZYPP_THROW( MissingArgumentException( argv[optind - 1] ) );
         break;
       }
       default: {
@@ -227,22 +347,112 @@ int parseCLI(const int argc, char * const *argv, const std::vector<CommandGroup>
               if ( it == longOptIndex.end() ) {
                 WAR << "Ignoring unknown option " << conflicting << " specified as conflicting flag for " << opt.name << endl;
               } else {
-                if ( allOpts[it->second].value.wasSet() ) {
+                if ( parsedValues.find( it->second ) != parsedValues.end() ) {
                   throw ConflictingFlagsException( opt.name, conflicting );
                 }
               }
             }
           }
-          opt.value.set( allOpts[index], arg );
+
+          //we remember the given value for now, and write it out in the next step when iterating over the dependency tree
+          parsedValues[ index ].push_back( arg );
         }
         break;
       }
     }
   }
+
+  std::set<int> flagsSolved;
+
+  auto allSolved = [ &flagsSolved ]( const int &flagIdx ) {
+    return ( flagsSolved.find( flagIdx ) != flagsSolved.end() );
+  };
+
+  //first mark all flags as solved that where not specified on cli
+  for ( const auto &node : dependencyTree ) {
+    if ( parsedValues.find( node.first ) == parsedValues.end() )
+      flagsSolved.insert( node.first );
+  }
+
+  while ( parsedValues.size() ) {
+
+    std::vector<int> writeableFlags;
+
+    for ( const auto &node : dependencyTree ) {
+
+      //all values for that flag where written
+      if ( flagsSolved.find( node.first ) != flagsSolved.end() )
+        continue;
+      //no values for that flag where given on CLI
+      if ( parsedValues.find( node.first ) == parsedValues.end() )
+        continue;
+
+      std::vector<CommandOption *> opts;
+      const std::set<int> &nodeDependencies = node.second;
+
+      if ( nodeDependencies.empty() || std::all_of( nodeDependencies.begin(), nodeDependencies.end(), allSolved ) ) {
+        writeableFlags.push_back ( node.first );
+      }
+    }
+
+    if ( writeableFlags.size() == 0 ) {
+
+      //we were unable to resolve one argument in one pass, give up and check for circular deps (recursive search with copied set)
+      std::set< std::string > dep;
+      std::function<void ( std::set<int>, int )> findAllDeps = [ &allOpts, &dependencyTree, &findAllDeps] ( std::set < int > foundSoFar, int nextDep ) -> void {
+        for ( int i : dependencyTree.at( nextDep ) ) {
+
+          //explicitely do a copy, so we only have one path in the set always
+          std::set<int> mySet = foundSoFar;
+
+          if ( ! mySet.insert( i ).second ) {
+            //found a circular dependency
+
+            std::string circDep;
+            auto appendDepToString = [ &circDep, &allOpts ] ( int depIndex ) {
+              auto &opt = allOpts.at( depIndex );
+              if ( circDep.size() )
+                circDep += "->";
+              circDep += opt.name + "(" + opt.shortName + ")";
+            };
+
+            for ( int dep : foundSoFar )
+              appendDepToString(dep);
+            appendDepToString(i);
+
+            ZYPP_THROW( ZyppFlagsException ( str::Format("Found a circular dependency: %1%") % circDep ) );
+          } else {
+            findAllDeps( mySet, i );
+          }
+        }
+      };
+
+      for ( const auto &currDep : dependencyTree )
+        findAllDeps ( { currDep.first }, currDep.first );
+
+      break;
+    }
+
+    //we now have all writeables for this pass through,
+    //lets sort them by priority and finally write them
+    std::sort( writeableFlags.begin(), writeableFlags.end(), [ &allOpts ]( int flagA, int flagB  ) {
+      return allOpts.at(flagA).priority > allOpts.at(flagB).priority;
+    });
+
+    //finally we can write the values
+    for ( int flag : writeableFlags ) {
+      for ( const auto & val : parsedValues.at( flag ) ) {
+        allOpts[flag].value.set( allOpts[flag], val );
+      }
+      flagsSolved.insert( flag );
+      parsedValues.erase( flag );
+    }
+  }
+
   return optind;
 }
 
-void renderHelp(const std::vector<CommandGroup> &options)
+void renderHelp( const std::vector<CommandGroup> &options )
 {
   for ( const CommandGroup &grp : options ) {
     std::cout << grp.name << ":" << std::endl << std::endl;
@@ -292,7 +502,7 @@ CommandOption::CommandOption( std::string &&name_r, char shortName_r, int flags_
     help ( std::move(help_r) )
 { }
 
-CommandGroup::CommandGroup(std::string &&name_r, std::vector<CommandOption> &&options_r, ConflictingFlagsList &&conflictingOptions_r )
+CommandGroup::CommandGroup( std::string &&name_r, std::vector<CommandOption> &&options_r, ConflictingFlagsList &&conflictingOptions_r )
   : name ( std::move(name_r) ),
     options ( std::move(options_r) ),
     conflictingOptions ( std::move(conflictingOptions_r) )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,3 +15,4 @@ ADD_CUSTOM_TARGET( ctest
 
 ADD_TESTS( PackageArgs )
 ADD_TESTS( SolverRequester )
+ADD_TESTS( ZyppFlags )

--- a/tests/ZyppFlags_test.cc
+++ b/tests/ZyppFlags_test.cc
@@ -1,0 +1,528 @@
+#include <boost/test/auto_unit_test.hpp>
+using boost::unit_test::test_case;
+
+#include "utils/flags/zyppflags.h"
+#include "utils/flags/flagtypes.h"
+#include <boost/optional.hpp>
+
+using namespace zypp;
+using namespace ZyppFlags;
+
+std::ostream& operator<<(std::ostream& ostr, std::vector<int> const& r) {
+  ostr << "{";
+  for ( int i : r ) {
+    ostr << " " << i;
+  }
+  ostr << "}";
+  return ostr;
+}
+
+namespace boost { namespace test_tools { namespace tt_detail {
+template<>
+struct print_log_value< std::vector<int> > {
+void operator()( std::ostream& os,
+    std::vector<int> const& ts)
+{
+    ::operator<<(os,ts);
+}
+};
+}}}
+
+BOOST_AUTO_TEST_CASE( simpleOptions )
+{
+  bool noArgOption;
+  int  requiredArgOption;
+  int  optionalArgOption;
+  std::vector<int> containerArg;
+
+  auto resetVals = [ & ] () {
+    noArgOption       = false;
+    requiredArgOption = 0;
+    optionalArgOption = 0;
+    containerArg.clear();
+  };
+
+  CommandGroup grp {{{
+    { "noArg", 'a', NoArgument, BoolCompatibleType ( noArgOption, StoreTrue, boost::optional<bool>( noArgOption ) ), "Help text 1" },
+    { "reqArg", 'b', RequiredArgument, IntType( &requiredArgOption ), "Help text 2" },
+    { "optionalArg", 'c', OptionalArgument, IntType( &optionalArgOption, 22 )},
+    { "repeatableArg", 'd', RequiredArgument | Repeatable, GenericContainerType( containerArg ) }
+  }}};
+
+  {
+    //test basic functionalityoptionalArg
+    resetVals();
+    const char *testArgs[] {
+      "command",
+      "--noArg",
+      "--reqArg", "10",
+      "--optionalArg",
+      "--repeatableArg", "1",
+      "--repeatableArg", "2",
+      "--repeatableArg", "3"
+    };
+
+    std::vector<int> expectedSet{ 1, 2, 3};
+
+    BOOST_CHECK_NO_THROW( parseCLI( sizeof(testArgs) / sizeof(char *), ( char *const* )testArgs, { grp } ) );
+    BOOST_CHECK_EQUAL ( noArgOption, true );
+    BOOST_CHECK_EQUAL ( requiredArgOption, 10 );
+    BOOST_CHECK_EQUAL ( optionalArgOption, 22 );
+    BOOST_CHECK_EQUAL ( containerArg, expectedSet );
+
+  }
+
+  {
+    //write optional value explictely
+    resetVals();
+    const char *testArgs[] {
+      "command",
+      "--optionalArg=42"
+    };
+
+    BOOST_CHECK_NO_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ) );
+    BOOST_CHECK_EQUAL ( noArgOption, false );
+    BOOST_CHECK_EQUAL ( requiredArgOption, 0 );
+    BOOST_CHECK_EQUAL ( optionalArgOption, 42 );
+  }
+
+  {
+    //write optional value explictely , short option
+    resetVals();
+    const char *testArgs[] {
+      "command",
+      "-c42"
+    };
+
+    BOOST_CHECK_NO_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ) );
+    BOOST_CHECK_EQUAL ( noArgOption, false );
+    BOOST_CHECK_EQUAL ( requiredArgOption, 0 );
+    BOOST_CHECK_EQUAL ( optionalArgOption, 42 );
+  }
+
+  {
+    //missing argument for a flag that requires arguments
+    resetVals();
+    const char *testArgs[] {
+      "command",
+      "--reqArg"
+    };
+
+    BOOST_REQUIRE_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ), MissingArgumentException );
+  }
+
+  {
+    //uknown long flag
+    resetVals();
+    const char *testArgs[] {
+      "command",
+      "--unknownFlag"
+    };
+
+    BOOST_REQUIRE_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ), UnknownFlagException );
+  }
+
+  {
+    //uknown short flag
+    resetVals();
+    const char *testArgs[] {
+      "command",
+      "-z"
+    };
+
+    BOOST_REQUIRE_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char* const* )testArgs, { grp } ), UnknownFlagException );
+  }
+
+  {
+    //flag repeated, but is not repeatable
+    resetVals();
+    const char *testArgs[] {
+      "command",
+       "--reqArg", "10",
+       "--reqArg", "10"
+    };
+
+    BOOST_REQUIRE_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char* const* )testArgs, { grp } ), FlagRepeatedException );
+  }
+}
+
+BOOST_AUTO_TEST_CASE( hooks )
+{
+
+  std::vector<int> values;
+  std::vector<int> expectedResult { 1, 2, 3};
+  std::string valInPreHook;
+  std::string valInCB;
+  std::string valInPostHook;
+
+  CommandGroup grp {{{
+        { "arg", 'a', RequiredArgument,
+              std::move(CallbackVal( [&] ( const CommandOption &, const boost::optional<std::string> &in) {
+                values.push_back( 2);
+                valInCB = *in;
+              }).before( [&]( const CommandOption &, const boost::optional<std::string> &in ) {
+                  values.push_back( 1 );
+                  valInPreHook = *in;
+                  return true;
+                }).after( [&] ( const CommandOption &, const boost::optional<std::string> &in ) {
+                    values.push_back( 3 );
+                    valInPostHook = *in;
+                  }))
+        }
+  }}};
+
+  const char *testArgs[] {
+    "command",
+     "--arg", "test"
+  };
+
+  BOOST_CHECK_NO_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ) );
+  BOOST_CHECK_EQUAL ( values, expectedResult );
+  BOOST_CHECK_EQUAL ( valInPreHook, "test" );
+  BOOST_CHECK_EQUAL ( valInCB, "test" );
+  BOOST_CHECK_EQUAL ( valInPostHook, "test" );
+
+}
+
+BOOST_AUTO_TEST_CASE( priority )
+{
+  std::vector <int> values;
+  CommandGroup grp {
+    {
+      std::move( CommandOption (
+         "arg1", 'a', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 1 );
+          })
+      ).setPriority( 3 ) ),
+      std::move( CommandOption (
+         "arg2", 'b', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 2 );
+          })
+      ).setPriority( 2 ) ),
+      std::move( CommandOption (
+         "arg3", 'c', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 3 );
+          })
+      ).setPriority( 1 ) ),
+      std::move( CommandOption (
+         "arg4", 'd', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 4 );
+          })
+      ).setPriority( -10 ) )
+    }
+  };
+
+  {
+    std::vector <int> expected { 1, 2, 3, 4 };
+    values.clear();
+
+    const char *testArgs[] {
+      "command",
+       "--arg3", "--arg4", "--arg1", "--arg2"
+    };
+
+    BOOST_CHECK_NO_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ) );
+    BOOST_CHECK_EQUAL ( values, expected );
+  }
+
+  {
+    std::vector <int> expected { 2, 3 };
+    values.clear();
+
+    const char *testArgs[] {
+      "command",
+       "--arg3", "--arg2"
+    };
+
+    BOOST_CHECK_NO_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ) );
+    BOOST_CHECK_EQUAL ( values, expected );
+  }
+}
+
+BOOST_AUTO_TEST_CASE( dependencies )
+{
+  /*
+
+    +-------arg8---->arg9-+
+   /                      |
+  v                       |
+ arg7-+                   |
+  \   |                   |
+  v   |                   |
+ arg6 |                   |
+   \  |                   |
+   v  v                   |
+   arg4  arg5             |
+       \/                 |
+       v                  v
+      arg1       arg2   arg3
+  */
+  std::vector <int> values;
+  CommandGroup grp {
+    {
+      std::move( CommandOption (
+         "arg1", 'a', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 1 );
+          })
+      ).setPriority( 3 ) ),
+      std::move( CommandOption (
+         "arg2", 'b', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 2 );
+          })
+      ).setPriority( 1 ) ),
+      std::move( CommandOption (
+         "arg3", 'c', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 3 );
+          })
+      ).setPriority( 2 ) ),
+      std::move( CommandOption (
+         "arg4", 'd', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 4 );
+          })
+      ).setDependencies( { "arg1" } ) ),
+      std::move( CommandOption (
+         "arg5", 'e', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 5 );
+          })
+      ).setDependencies( { "arg1" } ) ),
+      std::move( CommandOption (
+         "arg6", 'f', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 6 );
+          })
+      ).setDependencies( { "arg4" } ) ),
+      std::move( CommandOption (
+         "arg7", 'g', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 7 );
+          })
+      ).setDependencies( { "arg4", "arg6" } ) ),
+      std::move( CommandOption (
+         "arg8", 'h', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 8 );
+          })
+      ).setDependencies( { "arg3", "arg7", "arg9" } ) ),
+      std::move( CommandOption (
+         "arg9", 'i', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 9 );
+          })
+      ).setDependencies( { "arg3", "arg7" } )  )
+    }
+  };
+
+  const char *testArgs[] {
+    "command",
+     "--arg6", "--arg1", "--arg8", "--arg4", "--arg7", "--arg5", "--arg3", "--arg2", "--arg9"
+    ""
+  };
+
+  std::vector <int> expected { 1, 3, 2, 4, 5, 6, 7, 9, 8 };
+
+  BOOST_CHECK_NO_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ) );
+  BOOST_CHECK_EQUAL ( values, expected );
+}
+
+BOOST_AUTO_TEST_CASE( circular_dependencies )
+{
+  /*
+
+    arg1 --> arg2 --> arg3 --> arg4
+     ^                          |
+     |                          |
+     +--------------------------+
+
+  */
+  std::vector <int> values;
+  CommandGroup grp {
+    {
+      std::move( CommandOption (
+         "arg1", 'a', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 1 );
+          })
+      ).setPriority( 3 ) )
+       .setDependencies( { "arg2" } ),
+      std::move( CommandOption (
+         "arg2", 'b', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 2 );
+          })
+      ).setPriority( 1 ) )
+       .setDependencies( { "arg3" } ),
+      std::move( CommandOption (
+         "arg3", 'c', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 3 );
+          })
+      ).setPriority( 2 ) )
+       .setDependencies( { "arg4" } ),
+      std::move( CommandOption (
+         "arg4", 'd', NoArgument, CallbackVal(  [&] ( const CommandOption &, const boost::optional<std::string> & ) {
+            values.push_back( 4 );
+          })
+      ).setDependencies( { "arg1" } ) )
+    }
+  };
+
+  const char *testArgs[] {
+    "command",
+     "--arg1", "--arg4", "--arg3", "--arg2"
+    ""
+  };
+
+  std::vector <int> expected { 1, 2, 3, 4 };
+
+  BOOST_REQUIRE_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ), ZyppFlagsException ) ;
+}
+
+BOOST_AUTO_TEST_CASE( types )
+{
+  int integer = 0;
+  std::string str;
+  bool boolVal = false;
+  int counter = 0;
+  std::set<ResKind> kindSet;
+  std::vector<std::string> strVec;
+  zypp::Date date;
+
+  CommandGroup grp {{{
+    { "intArg", 'i', RequiredArgument, IntType( &integer )},
+    { "strArg", 's', RequiredArgument, StringType( &str )},
+    { "boolArg", 'b', NoArgument, BoolCompatibleType( boolVal, StoreTrue )},
+    { "counterArg", 'c', NoArgument | Repeatable, CounterType( &counter, boost::optional<int>(), 5 )},
+    { "kindSetArg", 'k', RequiredArgument | Repeatable, KindSetType( &kindSet) },
+    { "strvecArg", 'v', RequiredArgument | Repeatable, StringVectorType( &strVec ) },
+    { "dateArg", 'd', RequiredArgument, GenericValueType( date )}
+  }}};
+
+  {
+    const char *testArgs[] {
+      "command",
+       "--intArg", "10"
+    };
+
+    BOOST_CHECK_NO_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ) );
+    BOOST_CHECK_EQUAL ( integer, 10 );
+  }
+
+  {
+    const char *testArgs[] {
+      "command",
+       "--intArg", "error"
+    };
+
+    BOOST_REQUIRE_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ), InvalidValueException );
+  }
+
+  {
+    const char *testArgs[] {
+      "command",
+       "--strArg", "test"
+    };
+
+    BOOST_CHECK_NO_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ) );
+    BOOST_CHECK_EQUAL ( str, "test" );
+  }
+
+  {
+    const char *testArgs[] {
+      "command",
+       "--boolArg"
+    };
+
+    BOOST_CHECK_NO_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ) );
+    BOOST_CHECK_EQUAL ( boolVal, true );
+  }
+
+  {
+    const char *testArgs[] {
+      "command",
+       "--counterArg",
+       "--counterArg",
+       "--counterArg"
+    };
+
+    BOOST_CHECK_NO_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ) );
+    BOOST_CHECK_EQUAL ( counter, 3 );
+  }
+
+  {
+    const char *testArgs[] {
+      "command",
+      "--counterArg","--counterArg",
+      "--counterArg","--counterArg",
+      "--counterArg","--counterArg"
+    };
+
+    BOOST_REQUIRE_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ), ZyppFlagsException );
+    //check that the counter where hit at the 6th iteration
+    BOOST_CHECK_EQUAL ( counter, 6 );
+  }
+
+  {
+
+    std::set<ResKind> expected {
+      ResKind::package,
+      ResKind::pattern,
+      ResKind::product,
+      ResKind::patch,
+      ResKind::srcpackage,
+      ResKind::application
+    };
+
+    const char *testArgs[] {
+      "command",
+      "--kindSetArg", "package",
+      "--kindSetArg", "pattern",
+      "--kindSetArg", "product",
+      "--kindSetArg", "patch",
+      "--kindSetArg", "srcpackage",
+      "--kindSetArg", "application",
+    };
+
+    BOOST_CHECK_NO_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ) );
+    BOOST_CHECK_EQUAL ( kindSet, expected );
+  }
+
+  {
+    const char *testArgs[] {
+      "command",
+      "--kindSetArg", "unknown"
+    };
+
+    BOOST_REQUIRE_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ), InvalidValueException );
+  }
+
+  {
+    std::vector<std::string> expected {
+      "str1",
+      "str2",
+      "str3"
+    };
+
+    const char *testArgs[] {
+      "command",
+      "--strvecArg","str1",
+      "--strvecArg","str2",
+      "--strvecArg","str3"
+    };
+
+    BOOST_CHECK_NO_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ) );
+    //check that the counter where hit at the 6th iteration
+    BOOST_CHECK_EQUAL_COLLECTIONS( expected.begin(), expected.end(), strVec.begin(), strVec.end() );
+  }
+
+  {
+    const char *testArgs[] {
+      "command",
+       "--dateArg", "2018-12-10"
+    };
+
+    BOOST_CHECK_NO_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ) );
+    BOOST_CHECK_EQUAL ( Date( "2018-12-10", "%F" ), date );
+  }
+
+  {
+    const char *testArgs[] {
+      "command",
+       "--dateArg", "2018-15-12"
+    };
+
+    BOOST_REQUIRE_THROW( parseCLI( sizeof(testArgs) / sizeof(char *),  ( char *const* )testArgs, { grp } ), InvalidValueException );
+  }
+}


### PR DESCRIPTION
This patch introduces dependencies between flags, additionally each flag can have its own policy to force a even stricter parsing order.
Also adds the possibility to have pre and post hooks that are called before and after writing a flag.