### PR TITLE
Ma l3 locks

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ SET (zypper_HEADERS
   commands/conditions.h
   commands/basecommand.h
   commands/locks.h
+  commands/locks/common.h
   commands/locks/add.h
   commands/locks/clean.h
   commands/locks/list.h
@@ -114,6 +115,7 @@ SET( zypper_SRCS
   commands/commandhelpformatter.cc
   commands/conditions.cc
   commands/basecommand.cc
+  commands/locks/common.cc
   commands/locks/add.cc
   commands/locks/clean.cc
   commands/locks/list.cc

--- a/src/commands/locks/common.cc
+++ b/src/commands/locks/common.cc
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------*\
+                          ____  _ _ __ _ __  ___ _ _
+                         |_ / || | '_ \ '_ \/ -_) '_|
+                         /__|\_, | .__/ .__/\___|_|
+                             |__/|_|  |_|
+\*---------------------------------------------------------------------------*/
+/** \file commands/locks/common.cc
+ * Common code used by different commands.
+ */
+#include "commands/locks/common.h"
+#include "repos.h"
+
+///////////////////////////////////////////////////////////////////
+namespace locks
+{
+  zypp::PoolQuery arg2query( Zypper & zypper, const std::string & arg_r, const std::set<zypp::ResKind> & kinds_r, const std::vector<std::string> & repos_r )
+  {
+    PoolQuery q;
+    if ( kinds_r.empty() ) // derive it from the name
+    {
+      sat::Solvable::SplitIdent split( arg_r );
+      q.addAttribute( sat::SolvAttr::name, split.name().asString() );
+      q.addKind( split.kind() );
+    }
+    else
+    {
+      q.addAttribute(sat::SolvAttr::name, arg_r);
+      for_(itk, kinds_r.begin(), kinds_r.end()) {
+	q.addKind(*itk);
+      }
+    }
+    q.setMatchGlob();
+    parsed_opts::const_iterator itr;
+    for_(it_repo, repos_r.begin(), repos_r.end())
+    {
+      RepoInfo info;
+      if( match_repo( zypper, *it_repo, &info))
+	q.addRepo(info.alias());
+      else //TODO some error handling
+	WAR << "unknown repository" << *it_repo << endl;
+    }
+    q.setCaseSensitive();
+    return q;
+  }
+
+} // namespace locks
+///////////////////////////////////////////////////////////////////

--- a/src/commands/locks/common.cc
+++ b/src/commands/locks/common.cc
@@ -10,36 +10,89 @@
 #include "commands/locks/common.h"
 #include "repos.h"
 
+// OLD STYLE VERSIONED LOCKS:
+//	solvable_name: kernel
+//	version: > 1
+//
+// NEW STYLE VERSIONED LOCKS:
+//	complex: AttrMatchData solvable:name kernel C SolvableRange\ >\ 1\ \"\"
+//   or
+//	solvable_name: kernel > 1
+//
+// Semantically equivalent as locks, but due to the different syntax
+// the complex lock is wrongly handled in list. Different syntax also
+// may prevent removing locks (old and new style locks are not ==).
+//
+// bsc#1112911: Unfortunately all styles are found in real-life locks-files.
+// libzypp will try to make sure, when parsing the locks-file, that only
+// OLD STYLE queries are generated. They should work for list and remove.
+#undef	ENABLE_NEW_STYLE_VERSIONED_LOCKS
+
 ///////////////////////////////////////////////////////////////////
 namespace locks
 {
-  zypp::PoolQuery arg2query( Zypper & zypper, const std::string & arg_r, const std::set<zypp::ResKind> & kinds_r, const std::vector<std::string> & repos_r )
+  using namespace zypp;
+  ///////////////////////////////////////////////////////////////////
+  namespace
   {
-    PoolQuery q;
-    if ( kinds_r.empty() ) // derive it from the name
+    inline void addNameDependency( PoolQuery & q_r, const std::string & arg_r )
     {
-      sat::Solvable::SplitIdent split( arg_r );
-      q.addAttribute( sat::SolvAttr::name, split.name().asString() );
+      CapDetail d { Capability(arg_r) };
+      if ( d.isVersioned() )
+      {
+#ifdef ENABLE_NEW_STYLE_VERSIONED_LOCKS
+	q_r.addDependency( sat::SolvAttr::name, d.name().asString(), d.op(), d.ed() );
+#else
+	q_r.addAttribute( sat::SolvAttr::name, d.name().asString() );
+	q_r.setEdition( d.ed(), d.op() );
+#endif
+      }
+      else
+      {
+#ifdef ENABLE_NEW_STYLE_VERSIONED_LOCKS
+	q_r.addDependency( sat::SolvAttr::name, arg_r );
+#else
+	q_r.addAttribute( sat::SolvAttr::name, arg_r );
+#endif
+      }
+    }
+  }
+  ///////////////////////////////////////////////////////////////////
+
+  PoolQuery arg2query( Zypper & zypper, const std::string & arg_r, const std::set<ResKind> & kinds_r, const std::vector<std::string> & repos_r )
+  {
+    // Try to stay with the syntax the serialized query (AKA lock) generates.
+    //     type: package
+    //     match_type: glob
+    //     case_sensitive: on
+    //     solvable_name: kernel
+
+    PoolQuery q;
+    q.setMatchGlob();
+    q.setCaseSensitive();
+
+    for_( it, repos_r.begin(), repos_r.end() )
+    {
+      RepoInfo info;
+      if ( match_repo( zypper, *it, &info ) )
+	q.addRepo( info.alias() );
+      else //TODO some error handling
+	WAR << "unknown repository" << *it << endl;
+    }
+
+    if ( kinds_r.empty() || ResKind::explicitBuiltin( arg_r ) ) // derive it from the name
+    {
+      sat::Solvable::SplitIdent split { arg_r };
+      addNameDependency( q, split.name().asString() );
       q.addKind( split.kind() );
     }
     else
     {
-      q.addAttribute(sat::SolvAttr::name, arg_r);
-      for_(itk, kinds_r.begin(), kinds_r.end()) {
-	q.addKind(*itk);
-      }
+      addNameDependency( q, arg_r );
+      for_( it, kinds_r.begin(), kinds_r.end() )
+	q.addKind( *it );
     }
-    q.setMatchGlob();
-    parsed_opts::const_iterator itr;
-    for_(it_repo, repos_r.begin(), repos_r.end())
-    {
-      RepoInfo info;
-      if( match_repo( zypper, *it_repo, &info))
-	q.addRepo(info.alias());
-      else //TODO some error handling
-	WAR << "unknown repository" << *it_repo << endl;
-    }
-    q.setCaseSensitive();
+
     return q;
   }
 

--- a/src/commands/locks/common.h
+++ b/src/commands/locks/common.h
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------*\
+                          ____  _ _ __ _ __  ___ _ _
+                         |_ / || | '_ \ '_ \/ -_) '_|
+                         /__|\_, | .__/ .__/\___|_|
+                             |__/|_|  |_|
+\*---------------------------------------------------------------------------*/
+/** \file commands/locks/common.h
+ * Common code used by different commands.
+ */
+#ifndef ZYPPER_COMMANDS_LOCKS_COMMON_H_INCLUDED
+#define ZYPPER_COMMANDS_LOCKS_COMMON_H_INCLUDED
+
+#include <zypp/PoolQuery.h>
+
+#include "Zypper.h"
+
+///////////////////////////////////////////////////////////////////
+namespace locks
+{
+  /** Add/remove locks need to translate their cli args into PoolQueries in a common manner.
+   */
+  zypp::PoolQuery arg2query( Zypper & zypper, const std::string & arg_r, const std::set<zypp::ResKind> & kinds_r, const std::vector<std::string> & repos_r );
+
+} // namespace locks
+///////////////////////////////////////////////////////////////////
+#endif // ZYPPER_COMMANDS_LOCKS_COMMON_H_INCLUDED

--- a/src/commands/locks/list.cc
+++ b/src/commands/locks/list.cc
@@ -25,199 +25,202 @@
 
 using namespace zypp;
 
-namespace out{
-struct LocksTableFormater : public TableFormater
+///////////////////////////////////////////////////////////////////
+namespace out
 {
-private:
-  /** LESS compare for MatchDetails */
-  struct MatchDetailCompare
+  struct LocksTableFormater : public TableFormater
   {
-    bool operator()( const sat::Solvable & lhs, const sat::Solvable & rhs ) const
-    { return( doComapre( lhs, rhs ) < 0 ); }
-
-    int doComapre( const sat::Solvable & lhs, const sat::Solvable & rhs ) const
+  private:
+    /** LESS compare for MatchDetails */
+    struct MatchDetailCompare
     {
-      // do N(<) A(>) VR(>)
-      int res = sat::compareByN( lhs, rhs );									// ascending  l<r
-      if ( res == 0 ) res = rhs.arch().compare( lhs.arch() );							// descending r<l
-      if ( res == 0 ) res = rhs.edition().compare( lhs.edition() );						// descending r<l
-      if ( res == 0 ) res = lhs.repository().asUserString().compare( rhs.repository().asUserString() );	// ascending  l<r
-      return res;
-    }
-  };
-  /** Ordered MatchDetails */
-  typedef std::set<sat::Solvable,MatchDetailCompare> MatchDetails;
+      bool operator()( const sat::Solvable & lhs, const sat::Solvable & rhs ) const
+      { return( doComapre( lhs, rhs ) < 0 ); }
 
-  /** MatchDetail representation */
-  struct MatchDetailFormater
-  {
-    std::string xmlListElement( const sat::Solvable & match_r ) const
+      int doComapre( const sat::Solvable & lhs, const sat::Solvable & rhs ) const
+      {
+	// do N(<) A(>) VR(>)
+	int res = sat::compareByN( lhs, rhs );									// ascending  l<r
+	if ( res == 0 ) res = rhs.arch().compare( lhs.arch() );							// descending r<l
+	if ( res == 0 ) res = rhs.edition().compare( lhs.edition() );						// descending r<l
+	if ( res == 0 ) res = lhs.repository().asUserString().compare( rhs.repository().asUserString() );	// ascending  l<r
+	return res;
+      }
+    };
+    /** Ordered MatchDetails */
+    typedef std::set<sat::Solvable,MatchDetailCompare> MatchDetails;
+
+    /** MatchDetail representation */
+    struct MatchDetailFormater
+    {
+      std::string xmlListElement( const sat::Solvable & match_r ) const
+      {
+	str::Str str;
+	{
+	  xmlout::Node lock( str.stream(), "match", {
+	    { "kind",		match_r.kind()	},
+	    { "name",		match_r.name()	},
+	    { "edition",	match_r.edition()	},
+	    { "arch",		match_r.arch()	},
+	    { "installed",	match_r.isSystem()	},
+	    { "repo",		match_r.repository().alias()	},
+	  } );
+	}
+	return str;
+      }
+    };
+
+  public:
+    std::string xmlListElement( const PoolQuery & q_r ) const
     {
       str::Str str;
+      // <lock>
       {
-        xmlout::Node lock( str.stream(), "match", {
-          { "kind",		match_r.kind()	},
-          { "name",		match_r.name()	},
-          { "edition",	match_r.edition()	},
-          { "arch",		match_r.arch()	},
-          { "installed",	match_r.isSystem()	},
-          { "repo",		match_r.repository().alias()	},
-        } );
+	++_i;
+	xmlout::Node lock( str.stream(), "lock", { { "number", _i } } );
+
+	// <name> (solvable_name)
+	for ( const std::string & val : q_r.attribute( sat::SolvAttr::name ) )
+	{ *xmlout::Node( *lock, "name" ) << val; }
+	// <name> (query_string)
+	for ( const std::string & val : q_r.strings() )
+	{ *xmlout::Node( *lock, "name" ) << val; }
+
+	// <type>
+	for ( const ResKind & kind : q_r.kinds() )
+	{ *xmlout::Node( *lock, "type" ) << kind; }
+
+	// <repo>
+	for ( const std::string & repo : q_r.repos() )
+	{ *xmlout::Node( *lock, "repo" ) << repo; }
+
+	if ( _withMatches )
+	{
+	  // <matches>
+	  xmlout::Node matches( *lock, "matches", xmlout::Node::optionalContent, { { "size", q_r.size() } } );
+	  if ( _withSolvables && !q_r.empty() )
+	  {
+	    MatchDetails d;
+	    getLockDetails( q_r, d );
+	    xmlWriteContainer( *matches, d, MatchDetailFormater() );
+	  }
+	}
       }
       return str;
     }
-  };
 
-public:
-  std::string xmlListElement( const PoolQuery & q_r ) const
-  {
-    str::Str str;
-    // <lock>
+    TableHeader header() const
     {
-      ++_i;
-      xmlout::Node lock( str.stream(), "lock", { { "number", _i } } );
-
-      // <name> (solvable_name)
-      for ( const std::string & val : q_r.attribute( sat::SolvAttr::name ) )
-      { *xmlout::Node( *lock, "name" ) << val; }
-      // <name> (query_string)
-      for ( const std::string & val : q_r.strings() )
-      { *xmlout::Node( *lock, "name" ) << val; }
-
-      // <type>
-      for ( const ResKind & kind : q_r.kinds() )
-      { *xmlout::Node( *lock, "type" ) << kind; }
-
-      // <repo>
-      for ( const std::string & repo : q_r.repos() )
-      { *xmlout::Node( *lock, "repo" ) << repo; }
-
+      TableHeader th;
+      th << "#" << _("Name");
       if ( _withMatches )
-      {
-        // <matches>
-        xmlout::Node matches( *lock, "matches", xmlout::Node::optionalContent, { { "size", q_r.size() } } );
-        if ( _withSolvables && !q_r.empty() )
-        {
-          MatchDetails d;
-          getLockDetails( q_r, d );
-          xmlWriteContainer( *matches, d, MatchDetailFormater() );
-        }
-      }
+	th << _("Matches");
+      th << _("Type") << _("Repository");
+      return th;
     }
-    return str;
-  }
 
-  TableHeader header() const
-  {
-    TableHeader th;
-    th << "#" << _("Name");
-    if ( _withMatches )
-      th << _("Matches");
-    th << _("Type") << _("Repository");
-    return th;
-  }
-
-  TableRow row( const PoolQuery & q_r ) const
-  {
-    TableRow tr;
-
-    // #
-    ++_i;
-    tr << str::numstring( _i );
-
-    // Name
-    const PoolQuery::StrContainer & nameStings( q_r.attribute( sat::SolvAttr::name ) );
-    const PoolQuery::StrContainer & globalStrings( q_r.strings() );
-
-    if ( nameStings.size() + globalStrings.size() > 1 )
-      // translators: locks table value
-      tr << _("(multiple)");
-    else if ( nameStings.empty() && globalStrings.empty() )
-      // translators: locks table value
-      tr << _("(any)");
-    else if ( nameStings.empty() )
-      tr << *globalStrings.begin();
-    else
-      tr << *nameStings.begin();
-
-    // opt Matches
-    if ( _withMatches )
-      tr << q_r.size();
-
-    // Type
-    std::set<std::string> strings;
-    for ( const ResKind & kind : q_r.kinds() )
-      strings.insert( kind.asString() );
-    tr << get_string_for_table( strings );
-
-    // Repository
-    strings.clear();
-    copy( q_r.repos().begin(), q_r.repos().end(), inserter(strings, strings.end()) );
-    tr << get_string_for_table( strings );
-
-    // opt Solvables as detail
-    if ( _withSolvables && !q_r.empty() )
+    TableRow row( const PoolQuery & q_r ) const
     {
-      MatchDetails i;
-      MatchDetails a;
-      getLockDetails( q_r, i, a );
+      TableRow tr;
 
-      PropertyTable p;
+      // #
+      ++_i;
+      tr << str::numstring( _i );
+
+      // Name
+      const PoolQuery::StrContainer & nameStings( q_r.attribute( sat::SolvAttr::name ) );
+      const PoolQuery::StrContainer & globalStrings( q_r.strings() );
+
+      if ( nameStings.size() + globalStrings.size() > 1 )
+	// translators: locks table value
+	tr << _("(multiple)");
+      else if ( nameStings.empty() && globalStrings.empty() )
+	// translators: locks table value
+	tr << _("(any)");
+      else if ( nameStings.empty() )
+	tr << *globalStrings.begin();
+      else
+	tr << *nameStings.begin();
+
+      // opt Matches
+      if ( _withMatches )
+	tr << q_r.size();
+
+      // Type
+      std::set<std::string> strings;
+      for ( const ResKind & kind : q_r.kinds() )
+	strings.insert( kind.asString() );
+      tr << get_string_for_table( strings );
+
+      // Repository
+      strings.clear();
+      copy( q_r.repos().begin(), q_r.repos().end(), inserter(strings, strings.end()) );
+      tr << get_string_for_table( strings );
+
+      // opt Solvables as detail
+      if ( _withSolvables && !q_r.empty() )
       {
-        std::vector<std::string> names;
-        names.reserve( std::max( i.size(), a.size() ) );
-        if ( ! i.empty() )
-        {
-          //names.clear();
-          for ( const auto & solv : i )
-          { names.push_back( solv.asUserString() ); }
-          // translators: property name; short; used like "Name: value"
-          p.add( _("Keep installed"), names );
-        }
-        if ( ! a.empty() )
-        {
-          names.clear();
-          for ( const auto & solv : a )
-          { names.push_back( solv.asUserString() ); }
-          // translators: property name; short; used like "Name: value"
-          p.add( _("Do not install"), names );
-        }
+	MatchDetails i;
+	MatchDetails a;
+	getLockDetails( q_r, i, a );
+
+	PropertyTable p;
+	{
+	  std::vector<std::string> names;
+	  names.reserve( std::max( i.size(), a.size() ) );
+	  if ( ! i.empty() )
+	  {
+	    //names.clear();
+	    for ( const auto & solv : i )
+	    { names.push_back( solv.asUserString() ); }
+	    // translators: property name; short; used like "Name: value"
+	    p.add( _("Keep installed"), names );
+	  }
+	  if ( ! a.empty() )
+	  {
+	    names.clear();
+	    for ( const auto & solv : a )
+	    { names.push_back( solv.asUserString() ); }
+	    // translators: property name; short; used like "Name: value"
+	    p.add( _("Do not install"), names );
+	  }
+	}
+	tr.addDetail( str::Str() << p );
       }
-      tr.addDetail( str::Str() << p );
+      return tr;
     }
-    return tr;
-  }
 
-  LocksTableFormater( bool withSolvables, bool withMatches )
-  : _withSolvables( withSolvables )
-  , _withMatches( _withSolvables || withMatches )
-  {}
+    LocksTableFormater( bool withSolvables, bool withMatches )
+    : _withSolvables( withSolvables )
+    , _withMatches( _withSolvables || withMatches )
+    {}
 
-private:
-  static std::string get_string_for_table( const std::set<std::string> & attrvals_r )
-  {
-    std::string ret;
-    if ( attrvals_r.empty() )
-      ret = _("(any)");
-    else if ( attrvals_r.size() > 1 )
-      ret = _("(multiple)");
-    else
-      ret = *attrvals_r.begin();
-    return ret;
-  }
+  private:
+    static std::string get_string_for_table( const std::set<std::string> & attrvals_r )
+    {
+      std::string ret;
+      if ( attrvals_r.empty() )
+	ret = _("(any)");
+      else if ( attrvals_r.size() > 1 )
+	ret = _("(multiple)");
+      else
+	ret = *attrvals_r.begin();
+      return ret;
+    }
 
-  static void getLockDetails( const PoolQuery & q_r, MatchDetails & i_r, MatchDetails & a_r )
-  { for ( const auto & solv : q_r ) { (solv.isSystem()?i_r:a_r).insert( solv ); } }
+    static void getLockDetails( const PoolQuery & q_r, MatchDetails & i_r, MatchDetails & a_r )
+    { for ( const auto & solv : q_r ) { (solv.isSystem()?i_r:a_r).insert( solv ); } }
 
-  static void getLockDetails( const PoolQuery & q_r, MatchDetails & d_r )
-  { getLockDetails( q_r, d_r, d_r ); }
+    static void getLockDetails( const PoolQuery & q_r, MatchDetails & d_r )
+    { getLockDetails( q_r, d_r, d_r ); }
 
-private:
-  bool _withSolvables	:1;	//< include match details (implies _withMatches)
-  bool _withMatches	:1;	//< include number of matches
-  mutable unsigned _i = 0;	//< Lock Number
-};
-}
+  private:
+    bool _withSolvables	:1;	//< include match details (implies _withMatches)
+    bool _withMatches	:1;	//< include number of matches
+    mutable unsigned _i = 0;	//< Lock Number
+  };
+} // namespace out
+///////////////////////////////////////////////////////////////////
 
 ListLocksCmd::ListLocksCmd(const std::vector<std::string> &commandAliases_r) :
   ZypperBaseCommand (


### PR DESCRIPTION
[ L3-Question: zypper locks display is broken](https://bugzilla.suse.com/show_bug.cgi?id=1112911).
```
type: package
match_type: glob
case_sensitive: on
solvable_name: a*
version: == 1

type: package
match_type: glob
case_sensitive: on
solvable_name: a* == 1

type: package
match_type: glob
case_sensitive: on
complex: AttrMatchData solvable:name a* C SolvableRange\ ==\ 1\ \"\"
```
What a mess. Real life `locks` files may contain the above 3 forms of versioned locks.

The 1st is the one zypper is actually able to handle in `list locks`.

The 2nd one is what zypper creates when creating a versioned lock. Unfortunately this query does not make any sense until libzypp reads it back from the file and translates it into a complex query (3rd). Side effect: You can't remove versioned lock 2nd and 3rd query are not `==`.

Semantically 1st and 3rd lock the same set, but zypper is unable to handle the 3rd form (neither in `list` nor in `remove locks`). 

The PR fixes zypper to create and correctly display the 1st form.

To fix already existing `locks` files containing the 2nd and 3rd form, libzypp will convert them to the 1st when parsing the file. After the next write, only the fist for should be present.