### PR TITLE
Fixed broken argument parsing for --reposd-dir (bsc#1122062)

### DIFF
--- a/src/Config.cc
+++ b/src/Config.cc
@@ -482,7 +482,7 @@ std::vector<ZyppFlags::CommandGroup> Config::cliOptions()
       //start a new section of commands
       "", //unnamed section
       {
-        { "reposd-dir", 'D', ZyppFlags::NoArgument, ZyppFlags::PathNameType( rm_options.knownReposPath, boost::optional<std::string>(), ARG_DIR ),
+        { "reposd-dir", 'D', ZyppFlags::RequiredArgument, ZyppFlags::PathNameType( rm_options.knownReposPath, boost::optional<std::string>(), ARG_DIR ),
               // translators: --reposd-dir, -D <DIR>
               _("Use alternative repository definition file directory.")
         },


### PR DESCRIPTION
Fixes bug https://bugzilla.opensuse.org/show_bug.cgi?id=1122062
Command parsing was broken due to wrong argument flags. The error message is misleading here, because the parser did not get the information that a arg is required, it will ignore the passed argument and not pass it to the argument handler, treating it as positional arg instead. However the handler expects a argument, correctly throwing a error out with the given message. 