### PR TITLE
Improve handling of partially locked packages (bsc#1113296)

### DIFF
--- a/src/SolverRequester.cc
+++ b/src/SolverRequester.cc
@@ -231,7 +231,7 @@ void SolverRequester::install( const PackageSpec & pkg )
     // get the best matching items and tag them for installation.
     // FIXME this ignores vendor lock - we need some way to do --from which
     // would respect vendor lock: e.g. a new Selectable::updateCandidateObj(Options&)
-    PoolItemBest bestMatches( q.begin(), q.end() );
+    PoolItemBest bestMatches( q.begin(), q.end(), PoolItemBest::preferNotLocked );
 
     if ( !bestMatches.empty() )
     {
@@ -264,12 +264,20 @@ void SolverRequester::install( const PackageSpec & pkg )
             // check vendor (since PoolItemBest does not do it)
             bool changes_vendor = ! VendorAttr::instance().equivalent( instobj->vendor(), (*sit)->vendor() );
 
-            PoolItem best;
+            PoolItem best { s->updateCandidateObj() };
+	    if ( best && best.status().isLocked()
+	      && !(*sit).status().isLocked()
+	      && (*sit).edition() > instobj.edition() )
+	    {
+	      // This is a partially locked item. We try the best unlocked version.
+	      best = PoolItem();
+	    }
+
             if ( userconstraints )
               updateTo( pkg, *sit);
             else if  (_opts.force )
               updateTo( pkg, s->highestAvailableVersionObj() );
-            else if ( (best = s->updateCandidateObj()) )
+            else if ( best )
               updateTo( pkg, best );
             else if ( changes_vendor && !_opts.allow_vendor_change )
               updateTo( pkg, instobj );
@@ -729,8 +737,8 @@ void SolverRequester::updateTo( const PackageSpec & pkg, const PoolItem & select
       DBG << "Newer object exists, but has different repo/arch/version: " << highest << endl;
     }
 
-    // update candidate locked
-    if ( s->status() == ui::S_Protected || highest.status().isLocked() )
+    // update candidate locked (suppress if selected is not locked)
+    if ( selected.status().isLocked() && ( s->status() == ui::S_Protected || highest.status().isLocked() ) )
     {
       addFeedback( Feedback::UPD_CANDIDATE_IS_LOCKED, pkg, selected, installed );
       DBG << "Newer object exists, but is locked: " << highest << endl;
@@ -764,7 +772,7 @@ void SolverRequester::setToInstall( const PoolItem & pi )
     pi.status().setToBeInstalled( ResStatus::USER );
     addFeedback( Feedback::FORCED_INSTALL, PackageSpec(), pi );
   }
-  else if ( ui::asSelectable()(pi)->locked() )
+  else if ( ui::asSelectable()(pi)->hasLocks() )
   {
     // Workaround: Use a solver request instead of selecting the item.
     // This will enable the solver to report the lock conflict, while
@@ -791,7 +799,7 @@ void SolverRequester::setToInstall( const PoolItem & pi )
 
 void SolverRequester::setToRemove( const PoolItem & pi )
 {
-  if ( ui::asSelectable()(pi)->locked() )
+  if ( ui::asSelectable()(pi)->hasLocks() )
   {
     // Workaround: Use a solver request instead of selecting the item.
     // This will enable the solver to report the lock conflict, while

--- a/src/misc.cc
+++ b/src/misc.cc
@@ -19,7 +19,6 @@
 #include <zypp/RepoInfo.h>
 
 #include <zypp/PoolQuery.h>
-#include <zypp/PoolItemBest.h>
 
 #include "Zypper.h"
 #include "main.h"

--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -26,7 +26,7 @@ BuildRequires:  boost-devel >= 1.33.1
 BuildRequires:  cmake >= 2.4.6
 BuildRequires:  gcc-c++ >= 4.7
 BuildRequires:  gettext-devel >= 0.15
-BuildRequires:  libzypp-devel >= 17.10.2
+BuildRequires:  libzypp-devel >= 17.10.4
 BuildRequires:  readline-devel >= 5.1
 BuildRequires:  libxml2-devel
 Requires:       procps


### PR DESCRIPTION
([bsc#1113296](https://bugzilla.suse.com/show_bug.cgi?id=1113296)) 
Minimal change which should only affect partially locked packages (only individual versions are locked).

The important fix is to test `ui::asSelectable()(pi)->hasLocks()` to file a solver request. The solver request makes sure existing locks are not accidentally overwritten. The original test for `->locked()` (*all installed* or *all availabe* items are locked) did not include partially locked items.

The remaining code just tries to use the *best unlocked* version, in case the best version is locked (which implies a package is partially locked). 