### PR TITLE
Extend zypper source-install (fixes bsc#663358)

### DIFF
--- a/src/commands/optionsets.cc
+++ b/src/commands/optionsets.cc
@@ -114,7 +114,8 @@ namespace
           ZYPP_THROW( ZyppFlags::InvalidValueException( opt.name, *in, str::form(_("Available download modes: %s"), "only, in-advance, in-heaps, as-needed") ) );
         }
         return;
-      }
+      },
+      ARG_MODE
     );
   }
 

--- a/src/commands/optionsets.cc
+++ b/src/commands/optionsets.cc
@@ -136,6 +136,11 @@ namespace
   }
 }
 
+DownloadOptionSet::DownloadOptionSet( ZypperBaseCommand &parent , Mode cmdMode )
+  : BaseCommandOptionSet( parent )
+  , _cmdMode ( cmdMode )
+{ }
+
 zypp::DownloadMode DownloadOptionSet::mode() const
 {
   MIL << "Download mode: ";
@@ -169,7 +174,7 @@ std::vector<ZyppFlags::CommandGroup> DownloadOptionSet::options()
               // translators: --download
               str::Format(_("Set the download-install mode. Available modes: %s") ) % "only, in-advance, in-heaps, as-needed"
         },
-        { "download-only", 'd', ZyppFlags::NoArgument | ZyppFlags::Repeatable, DownloadModeNoArgType( *this, DownloadMode::DownloadOnly ),
+        { "download-only", _cmdMode == DownloadOptionSet::Default ? 'd' : '\0', ZyppFlags::NoArgument | ZyppFlags::Repeatable, DownloadModeNoArgType( *this, DownloadMode::DownloadOnly ),
               // translators: -d, --download-only
               _("Only download the packages, do not install.")
         },

--- a/src/commands/optionsets.h
+++ b/src/commands/optionsets.h
@@ -57,7 +57,12 @@ public:
 class DownloadOptionSet : public BaseCommandOptionSet
 {
 public:
- using BaseCommandOptionSet::BaseCommandOptionSet;
+  enum Mode {
+    Default,
+    SourceInstall
+  };
+
+  DownloadOptionSet( ZypperBaseCommand &parent, DownloadOptionSet::Mode cmdMode = DownloadOptionSet::Default );
 
   zypp::DownloadMode mode() const;
   void setMode( const zypp::DownloadMode &mode );
@@ -66,6 +71,7 @@ public:
 private:
   zypp::DownloadMode _mode;
   bool _wasSetBefore = false;
+  Mode _cmdMode = Default;
 
   // BaseCommandOptionSet interface
 public:

--- a/src/commands/sourceinstall.h
+++ b/src/commands/sourceinstall.h
@@ -9,6 +9,7 @@
 
 #include "commands/basecommand.h"
 #include "commands/optionsets.h"
+#include "commands/solveroptionset.h"
 #include "utils/flags/zyppflags.h"
 
 class SourceInstallCmd : public ZypperBaseCommand
@@ -19,8 +20,11 @@ public:
 private:
   bool _buildDepsOnly = false;
   bool _noBuildDeps   = false;
-  bool _downloadOnly  = false;
   InitReposOptionSet _initRepos { *this };
+  DownloadOptionSet _dlOpts { *this, DownloadOptionSet::SourceInstall };
+  SolverCommonOptionSet _solverCommonOpts { *this };
+  SolverInstallsOptionSet _solverInstallOpts { *this };
+  SolverRecommendsOptionSet _solverRecommOpts { *this };
 
   // ZypperBaseCommand interface
 protected:

--- a/src/misc.h
+++ b/src/misc.h
@@ -14,6 +14,7 @@
 #include <zypp/DownloadMode.h>
 
 class Zypper;
+struct PackageSpec;
 using namespace zypp;
 
 /**
@@ -45,7 +46,7 @@ void remove_selections( Zypper & zypper );
  * \note we still need to be able to install the source package alone
  *       (without build-deps, which are listed as 'requires' of the srcpackage)
  */
-void mark_src_pkgs(Zypper & zypper , const std::vector<std::string> &packages_r);
+void mark_src_pkgs(Zypper & zypper , const PackageSpec &spec);
 
 /**
  * Install source packages found by \ref mark_src_pkgs.
@@ -58,6 +59,6 @@ void install_src_pkgs( Zypper & zypper, zypp::DownloadMode dlMode_r );
  * Inject requirements of a source package or its build dependencies (depending
  * on command line options) to the pool.
  */
-void build_deps_install(Zypper & zypper , const std::vector<std::string> &srcPkgs_r, bool buildDepsOnly_r);
+void build_deps_install(Zypper & zypper , const PackageSpec &spec, bool buildDepsOnly_r);
 
 #endif

--- a/src/repos.cc
+++ b/src/repos.cc
@@ -21,6 +21,7 @@
 #include <zypp/parser/ParseException.h>
 #include <zypp/media/MediaException.h>
 #include <zypp/media/MediaAccess.h>
+#include <zypp/target/rpm/RpmHeader.h>
 
 #include "output/Out.h"
 #include "main.h"
@@ -31,8 +32,8 @@
 #include "repos.h"
 #include "global-settings.h"
 
-//@TODO REMOVEME
 #include "commands/services/common.h"
+#include "commands/repos/refresh.h"
 
 extern ZYpp::Ptr God;
 
@@ -1863,7 +1864,93 @@ void load_target_resolvables(Zypper & zypper)
   }
 }
 
+std::vector<std::string> createTempRepoFromArgs( Zypper &zypper, std::vector<std::string> &positionalArgs, bool allowUnsigned_r )
+{
+  // check for rpm files among the arguments
+  std::vector<std::string> rpms_files_caps;
+  filesystem::Pathname cliRPMCache;	// temporary plaindir repo (if needed)
+
+  for ( std::vector<std::string>::iterator it = positionalArgs.begin(); it != positionalArgs.end(); )
+  {
+    if ( looks_like_rpm_file( *it ) )
+    {
+      DBG << *it << " looks like rpm file" << endl;
+      zypper.out().info( str::Format(_("'%s' looks like an RPM file. Will try to download it.")) % *it,
+        Out::HIGH );
+
+      // download the rpm into the temp cache
+      if ( cliRPMCache.empty() )
+        cliRPMCache = zypper.runtimeData().tmpdir / TMP_RPM_REPO_ALIAS / "%CLI%";
+      filesystem::Pathname rpmpath = cache_rpm( *it, cliRPMCache );
+      if ( rpmpath.empty() )
+      {
+        zypper.out().error( str::Format(_("Problem with the RPM file specified as '%s', skipping.")) % *it );
+      }
+      else
+      {
+        using target::rpm::RpmHeader;
+        // rpm header (need name-version-release)
+        RpmHeader::constPtr header = RpmHeader::readPackage( rpmpath, RpmHeader::NOSIGNATURE );
+        if ( header )
+        {
+          std::string nvrcap =
+            TMP_RPM_REPO_ALIAS ":srcpackage:" +
+            header->tag_name() + "=" +
+            str::numstring(header->tag_epoch()) + ":" +
+            header->tag_version() + "-" +
+            header->tag_release();
+          DBG << "rpm package capability: " << nvrcap << endl;
+
+          // store the rpm file capability string (name=version-release)
+          rpms_files_caps.push_back( nvrcap );
+        }
+        else
+        {
+          zypper.out().error( str::Format(_("Problem reading the RPM header of %s. Is it an RPM file?")) % *it );
+        }
+      }
+
+      // remove this rpm argument
+      it = positionalArgs.erase( it );
+    }
+    else
+      ++it;
+  }
+
+  // If there were some rpm files, add the rpm cache as a temporary plaindir repo.
+  // Set up as temp repo, but redirect PackagesPath to ZYPPER_RPM_CACHE_DIR. This
+  // way downloaded packages (e.g. --download-only) are accessible until they get
+  // installed (unless .keeppackages)
+  if ( !rpms_files_caps.empty() )
+  {
+    // add a plaindir repo
+    RepoInfo repo;
+    repo.setAlias( TMP_RPM_REPO_ALIAS );
+    repo.setName(_("Plain RPM files cache") );
+    repo.setBaseUrl( cliRPMCache.asDirUrl() );
+    repo.setMetadataPath( zypper.runtimeData().tmpdir / TMP_RPM_REPO_ALIAS / "%AUTO%" );
+    repo.setPackagesPath( Pathname::assertprefix( zypper.config().root_dir, ZYPPER_RPM_CACHE_DIR ) );
+    repo.setType( repo::RepoType::RPMPLAINDIR );
+    repo.setEnabled( true );
+    repo.setAutorefresh( true );
+    repo.setKeepPackages( false );
+
+    if ( allowUnsigned_r )
+    {
+      repo.setGpgCheck(RepoInfo::GpgCheck::AllowUnsignedPackage);
+    }
+
+    // shut up zypper
+    SCOPED_VERBOSITY( zypper.out(), Out::QUIET );
+    RefreshRepoCmd::refreshRepository( zypper, repo );
+    zypper.runtimeData().temporary_repos.push_back( repo );
+  }
+
+  return rpms_files_caps;
+}
+
 // ---------------------------------------------------------------------------
 // Local Variables:
 // c-basic-offset: 2
 // End:
+

--- a/src/repos.h
+++ b/src/repos.h
@@ -229,6 +229,12 @@ bool refresh_raw_metadata( Zypper & zypper, const RepoInfo & repo, bool force_do
 
 bool build_cache( Zypper & zypper, const RepoInfo & repo, bool force_build );
 
+/**
+ * Iterate over \a positionalArgs and try to treat it as a .rpm file, in case it turns out to be a valid
+ * rpm file, remove the arg from the list and place the file in a temporary repository
+ */
+std::vector<std::string> createTempRepoFromArgs(Zypper &zypper, std::vector<std::string> &positionalArgs , bool allowUnsigned_r);
+
 #endif
 // Local Variables:
 // mode: c++

--- a/src/utils/flags/zyppflags.h
+++ b/src/utils/flags/zyppflags.h
@@ -49,6 +49,8 @@
 #define ARG_URI                _( "URI" )
 // translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
 #define ARG_YYYY_MM_DD         _( "YYYY-MM-DD" )
+// translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
+#define ARG_MODE               _( "MODE" )
 
 namespace zypp {
 namespace ZyppFlags {


### PR DESCRIPTION
This patch adds:
- Download and solver related switches to source-install.
- Enables si to install local rpm files