### PR TITLE
Bugsquashing

### DIFF
--- a/src/Zypper.cc
+++ b/src/Zypper.cc
@@ -235,6 +235,11 @@ int Zypper::main( int argc, char ** argv )
     error_r.report( *this );
     report_a_bug( out() );
   }
+  catch ( const ZyppFlags::ZyppFlagsException &e) {
+    ERR << e.asString() << endl;
+    out().error( e.asUserString() );
+    setExitCode( ZYPPER_EXIT_ERR_SYNTAX );
+  }
   catch ( const Exception & ex )
   {
     ZYPP_CAUGHT( ex );

--- a/src/commands/commonflags.h
+++ b/src/commands/commonflags.h
@@ -31,14 +31,6 @@ namespace CommonFlags
     };
   }
 
-  inline zypp::ZyppFlags::CommandOption replaceFilesFlag ( bool &targetFlag ) {
-    return {
-      "replacefiles", '\0', zypp::ZyppFlags::NoArgument, zypp::ZyppFlags::BoolType( &targetFlag, zypp::ZyppFlags::StoreTrue, targetFlag ),
-      // translators: --replacefiles
-      _("Install the packages even if they replace files from other, already installed, packages. Default is to treat file conflicts as an error. --download-as-needed disables the fileconflict check.")
-    };
-  }
-
   inline zypp::ZyppFlags::CommandOption bestEffortUpdateFlag ( bool &targetFlag ) {
     return {
       "best-effort", '\0', zypp::ZyppFlags::NoArgument, zypp::ZyppFlags::BoolType( &targetFlag, zypp::ZyppFlags::StoreTrue, targetFlag ),

--- a/src/commands/installremove.cc
+++ b/src/commands/installremove.cc
@@ -182,10 +182,6 @@ ZyppFlags::CommandGroup InstallCmd::cmdOptions() const
       // translators: --oldpackage
       _("Allow to replace a newer item with an older one. Handy if you are doing a rollback. Unlike --force it will not enforce a reinstall.")
     },
-    { "replacefiles", '\0', ZyppFlags::NoArgument, ZyppFlags::BoolType( &that->_replaceFiles, ZyppFlags::StoreTrue, _replaceFiles ),
-      // translators: --replacefiles
-      _("Install the packages even if they replace files from other, already installed, packages. Default is to treat file conflicts as an error. --download-as-needed disables the fileconflict check.")
-    },
     // disable gpg checks for directly passed rpms
     { "allow-unsigned-rpm", '\0', ZyppFlags::NoArgument, ZyppFlags::BoolType( &that->_allowUnsignedRPM, ZyppFlags::StoreTrue, _allowUnsignedRPM ),
       _("Silently install unsigned rpm packages given as commandline parameters.")
@@ -208,7 +204,6 @@ void InstallCmd::doReset()
   InstallRemoveBase::doReset();
   _force  = false;
   _oldPackage = false;
-  _replaceFiles = false;
   _allowUnsignedRPM = false;
   _fromRepos.clear();
   _entireCatalog.clear();

--- a/src/commands/installremove.h
+++ b/src/commands/installremove.h
@@ -63,11 +63,11 @@ public:
 private:
   bool _force  = false;
   bool _oldPackage = false;
-  bool _replaceFiles = false;
   bool _allowUnsignedRPM = false;
   std::vector<std::string> _fromRepos;
   std::vector<std::string> _entireCatalog;
 
+  FileConflictPolicyOptionSet _fileConflictOpts { *this };
   LicensePolicyOptionSet _licensePolicy { *this };
   DownloadOptionSet _downloadMode { *this };
 

--- a/src/commands/patch.cc
+++ b/src/commands/patch.cc
@@ -47,7 +47,6 @@ zypp::ZyppFlags::CommandGroup PatchCmd::cmdOptions() const
       { "with-update", '\0', ZyppFlags::NoArgument, ZyppFlags::BoolType( &that->_withUpdate, ZyppFlags::StoreTrue, _withUpdate ),
             _("Additionally try to update all packages not covered by patches. The option is ignored, if the patch command must update the update stack first. Can not be combined with --updatestack-only.")
       },
-      CommonFlags::replaceFilesFlag( that->_replaceFiles ),
       CommonFlags::detailsFlag( that->_details )
     }, {
       { "updatestack-only", "bugzilla" },
@@ -62,7 +61,6 @@ void PatchCmd::doReset()
 {
   _updateStackOnly = false;
   _withUpdate = false;
-  _replaceFiles = false;
   _details = false;
 }
 

--- a/src/commands/patch.h
+++ b/src/commands/patch.h
@@ -24,9 +24,9 @@ public:
 private:
   bool _updateStackOnly = false;
   bool _withUpdate = false;
-  bool _replaceFiles = false;
   bool _details = false;
 
+  FileConflictPolicyOptionSet _fileConflictOpts { *this };
   InitReposOptionSet _initRepoOpts { *this };
   SelectPatchOptionSet _selectPatchOpts { *this };
   NoConfirmRugOption _noConfirmOpts { *this };

--- a/src/commands/query/info.cc
+++ b/src/commands/query/info.cc
@@ -112,22 +112,18 @@ int InfoCmd::execute( Zypper &zypper, const std::vector<std::string> &positional
   }
 
   //for aliased modes we override the _kinds in the option object
-  if ( _cmdMode != Mode::Default ) {
-    switch ( _cmdMode ) {
-      case Mode::RugPatchInfo:
-        _options._kinds = { ResKind::patch };
-        break;
-      case Mode::RugPatternInfo:
-        _options._kinds = { ResKind::pattern };
-        break;
-      case Mode::RugProductInfo:
-        _options._kinds = { ResKind::product };
-        break;
-      default:
-        //this should never happen
-        report_a_bug( zypper.out() );
-        break;
-    }
+  switch ( _cmdMode ) {
+    case Mode::RugPatchInfo:
+      _options._kinds = { ResKind::patch };
+      break;
+    case Mode::RugPatternInfo:
+      _options._kinds = { ResKind::pattern };
+      break;
+    case Mode::RugProductInfo:
+      _options._kinds = { ResKind::product };
+      break;
+    case Mode::Default:
+      break;
   }
 
   printInfo( zypper, positionalArgs_r, _options );
@@ -146,7 +142,6 @@ std::string InfoCmd::summary() const
     case Mode::RugProductInfo:
       // translators: command summary: product-info
       return _("Show full information for specified products.");
-    default:
     case Mode::Default:
       break;
   }
@@ -166,7 +161,6 @@ std::vector<std::string> InfoCmd::synopsis() const
     case Mode::RugProductInfo:
       // translators: command synopsis; do not translate lowercase words
       return { _("product-info <PRODUCT_NAME> ...") };
-    default:
     case Mode::Default:
       break;
   }
@@ -185,7 +179,6 @@ std::string InfoCmd::description() const
     case Mode::RugProductInfo:
       // translators: command description
       return _("Show detailed information for products.");
-    default:
     case Mode::Default:
       break;
   }

--- a/src/commands/update.cc
+++ b/src/commands/update.cc
@@ -46,7 +46,6 @@ zypp::ZyppFlags::CommandGroup UpdateCmd::cmdOptions() const
   return {{
      CommonFlags::resKindSetFlag( that._kinds ),
      CommonFlags::detailsFlag( that._details ),
-     CommonFlags::replaceFilesFlag( that._replaceFiles ),
      CommonFlags::bestEffortUpdateFlag( that._bestEffort )
   }};
 }
@@ -54,7 +53,6 @@ zypp::ZyppFlags::CommandGroup UpdateCmd::cmdOptions() const
 void UpdateCmd::doReset()
 {
   _details = false;
-  _replaceFiles = false;
   _bestEffort   = false;
   _kinds.clear();
 }

--- a/src/commands/update.h
+++ b/src/commands/update.h
@@ -21,9 +21,9 @@ public:
 
 private:
   bool _details = false;
-  bool _replaceFiles = false;
   bool _bestEffort   = false;
   std::set<zypp::ResKind> _kinds;
+  FileConflictPolicyOptionSet _fileConflictOpts { *this };
   InitReposOptionSet _initReposOpts { *this };
   NoConfirmRugOption _noComfirmOpts { *this };
   InteractiveUpdatesOptionSet _interactiveOpts { *this };


### PR DESCRIPTION
- Fix broken --replacefiles switch (fixes bsc#1123137)
- Catch ZyppFlagsException from global option parsing
- Remove unnecessary use of report_a_bug 