### PR TITLE
Stay with legacy behavior and return ZYPPER_EXIT_INF_REBOOT_NEEDED on…

### DIFF
--- a/src/Summary.cc
+++ b/src/Summary.cc
@@ -76,7 +76,8 @@ typedef std::map<Resolvable::Kind, std::set<ResObject::constPtr, ResNameCompare>
 void Summary::readPool( const ResPool & pool )
 {
   // reset stats
-  _need_reboot = false;
+  _need_reboot_patch = false;
+  _need_reboot_nonpatch = false;
   _need_restart = false;
   _inst_pkg_total = 0;
 
@@ -115,7 +116,7 @@ void Summary::readPool( const ResPool & pool )
         // set the 'need reboot' flag
         if ( patch->rebootSuggested() )
 	{
-          _need_reboot = true;
+          _need_reboot_patch = true;
 	  _rebootNeeded[ResKind::patch].insert( ResPair( nullptr, patch ) );
 	}
         else if ( patch->restartSuggested() )
@@ -130,7 +131,7 @@ void Summary::readPool( const ResPool & pool )
         if ( it->isKind( ResKind::package ) ) {
           Package::constPtr package = asKind<Package>( it->resolvable() );
           if ( package->isNeedreboot() ) {
-            _need_reboot = true;
+            _need_reboot_nonpatch = true;
             _rebootNeeded[ResKind::package].insert( ResPair( nullptr, package ) );
           }
         }
@@ -1577,7 +1578,7 @@ void Summary::dumpTo( std::ostream & out )
     // patch command (auto)restricted to update stack patches
     Zypper::instance().out().notePar( 4, _("Package manager restart required. (Run this command once again after the update stack got updated)") );
   }
-  if ( _need_reboot )
+  if ( _need_reboot_patch || _need_reboot_nonpatch )
   {   Zypper::instance().out().notePar( 4, _("System reboot required.") ); }
 
   if ( !_ctc.empty() )

--- a/src/Summary.h
+++ b/src/Summary.h
@@ -100,9 +100,13 @@ public:
   const ByteCount & inCache() const		{ return _incache; }
   const ByteCount & installedSizeChange() const	{ return _inst_size_change; }
 
-  bool needMachineReboot() const			{ return _need_reboot; }
-
-  bool needPkgMgrRestart() const			{ return _need_restart; }
+  /** The exposed needMachineReboot value causing ZYPPER_EXIT_INF_REBOOT_NEEDED considers patches only (zypper#237)
+   * Packages cause a summary hint but will not lead to a non-zero return value.
+   */
+  bool needMachineReboot() const		{ return _need_reboot_patch; }
+  /** The exposed needPkgMgrRestart value causing ZYPPER_EXIT_INF_RESTART_NEEDED considers patches only (zypper#237)
+   */
+  bool needPkgMgrRestart() const		{ return _need_restart; }
 
 
   void dumpTo( std::ostream & out );
@@ -125,8 +129,9 @@ private:
   bool _force_no_color;
   bool _download_only;
 
-  bool _need_reboot;
-  bool _need_restart;
+  bool _need_reboot_patch;	// need_reboot caused by a patch
+  bool _need_reboot_nonpatch;	// need_reboot caused by something not a patch
+  bool _need_restart;		// by now patch specific
 
   ByteCount _todownload;
   ByteCount _incache;


### PR DESCRIPTION
…ly for patches (openSUSE/zypper#237)

The return code will not be applied to packages even if they carry
the 'reboot_needed' attribute. Preferred way to check for a required
reboot is `zypper needs-rebooting`.