### PR TITLE
Move needs-restarting command to subpackage

### DIFF
--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -111,6 +111,22 @@ Authors:
 --------
     Bernhard M. Wiedemann <bernhard+aptitude4zypp lsmod de>
 
+%package needs-restarting
+Summary:        needs-restarting compatibility with zypper
+Group:          System/Packages
+Requires:       zypper
+%if 0%{?suse_version}
+Supplements:    zypper
+%endif
+BuildArch:      noarch
+
+%description needs-restarting
+provides compatibility to YUM needs-restarting command using zypper
+
+Authors:
+--------
+    Michael Andres <ma@suse.de>
+
 %prep
 %setup -q
 
@@ -168,7 +184,6 @@ rm -rf "$RPM_BUILD_ROOT"
 %{_sysconfdir}/bash_completion.d/zypper.sh
 %{_bindir}/zypper
 %{_bindir}/yzpper
-%{_bindir}/needs-restarting
 %{_bindir}/installation_sources
 %{_sbindir}/zypp-refresh
 %dir %{_datadir}/zypper
@@ -176,7 +191,6 @@ rm -rf "$RPM_BUILD_ROOT"
 %dir %{_datadir}/zypper/xml
 %{_datadir}/zypper/xml/xmlout.rnc
 %{_prefix}/lib/zypper
-%doc %{_mandir}/man1/needs-restarting.1*
 %doc %{_mandir}/man8/zypper.8*
 %doc %{_mandir}/man8/zypp-refresh.8*
 %doc %dir %{_datadir}/doc/packages/zypper
@@ -197,5 +211,10 @@ rm -rf "$RPM_BUILD_ROOT"
 %{_bindir}/apt
 %dir %{_sysconfdir}/zypp/apt-packagemap.d/
 %config(noreplace) %{_sysconfdir}/zypp/apt-packagemap.d/*
+
+%files needs-restarting
+%defattr(-,root,root)
+%{_bindir}/needs-restarting
+%doc %{_mandir}/man1/needs-restarting.1*
 
 %changelog


### PR DESCRIPTION
This makes it so that dnf-utils and zypper can coexist on an
openSUSE system, which is important when dnf-utils is being used
on openSUSE with tools like Mock.