### PR TITLE
Always show exception history

### DIFF
--- a/src/output/Out.cc
+++ b/src/output/Out.cc
@@ -108,19 +108,7 @@ bool Out::progressFilter()
 
 std::string Out::zyppExceptionReport(const Exception & e)
 {
-  std::ostringstream s;
-  // The Exception history is a stack! So Exception::asUserHistory() prints:
-  //   This is bad!          <- Exception::asUserString()
-  //   History:            -+
-  //    - top level error   |<- Exception::historyAsString()
-  //    - mid level error   |
-  //    - first error      -+
-  if (verbosity() > Out::NORMAL)
-    s << e.asUserHistory();
-  else
-    s << e.asUserString();
-
-  return s.str();
+  return e.asUserString();
 }
 
 void Out::searchResult( const Table & table_r )


### PR DESCRIPTION
This patch changes the behaviour of zypper to suppress exception
history in some cases. We did agree that it is better so see as
much information about the error as possible.