### PR TITLE
Ma faster ctrl c response

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ INCLUDE_DIRECTORIES(${ZYPPER_SOURCE_DIR}/src)
 
 SET (zypper_HEADERS
   Zypper.h
+  Guardians.h
   main.h
   Command.h
   Config.h

--- a/src/Guardians.h
+++ b/src/Guardians.h
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------*\
+                          ____  _ _ __ _ __  ___ _ _
+                         |_ / || | '_ \ '_ \/ -_) '_|
+                         /__|\_, | .__/ .__/\___|_|
+                             |__/|_|  |_|
+\*---------------------------------------------------------------------------*/
+#ifndef ZYPPER_GUARDIANS_H
+#define ZYPPER_GUARDIANS_H
+
+#include <zypp/base/PtrTypes.h>
+
+///////////////////////////////////////////////////////////////////
+/// \class Guardians<TreasureT>
+/// \brief Simple static guardians protecting a TreasureT
+///
+/// Basically \c shared_ptr/weak_ptr<TreasureT>.
+/// \code
+///  struct SigExitTreasureT {
+///    friend std::ostream & operator<<( std::ostream & str, SigExitTreasureT obj )
+///    { return str << "SigExitTreasure"; }
+///  };
+///  typedef Guardians<SigExitTreasureT> SigExitGuardians;
+///  typedef SigExitGuardians::Guard     SigExitGuard;
+///
+///  static SigExitGuard sigExitGuard()
+///  { return SigExitGuardians::guard(); }
+/// \endcode
+template <typename TreasureT>
+struct Guardians
+{
+  /** The Guards type. */
+  typedef zypp::shared_ptr<TreasureT> Guard;
+
+  /** Get a Guard protecting the treasure. */
+  static Guard guard() {
+    Guard ret { hideout().lock() };
+    if ( !ret )
+    {
+      ret.reset( new TreasureT );
+      hideout() = ret;
+    }
+    return ret;
+  }
+
+  /** Return whether the treasure is unguarded. */
+  static bool expired()
+  { return hideout().expired(); }
+
+  friend std::ostream & operator<<( std::ostream & str, Guardians obj )
+  { return str << TreasureT() << ( expired() ? "-Void" : "-Guarded" ); }
+
+private:
+  static zypp::weak_ptr<TreasureT> & hideout()
+  { static zypp::weak_ptr<TreasureT> _hideout; return _hideout; }
+};
+
+#endif // ZYPPER_GUARDIANS_H


### PR DESCRIPTION
Basically fix `Zypper::immediateExitCheck` to repond to the 1st  Ctrl-C.

The media callbacks however have code to handle this exit request, even resetting the exit request depending on the users answer. Not sure if this code is still active, nevertheless allow these callback classes to protect against exiting to the 1st  Ctrl-C.
