### PR TITLE
Fix unknown package handling in zypper install (fixes bsc#1127608)

### DIFF
--- a/src/commands/installremove.h
+++ b/src/commands/installremove.h
@@ -21,7 +21,7 @@ public:
   using ZypperBaseCommand::ZypperBaseCommand;
 protected:
   void fillSrOpts (SolverRequester::Options &sropts_r ) const;
-  int handleFeedback (Zypper &zypper, const SolverRequester &sr_r) const;
+  void handleFeedback(Zypper &zypper, const SolverRequester &sr_r, bool failOnCapNotFound = true ) const;
 
   std::set<zypp::ResKind> _kinds;
 


### PR DESCRIPTION
Fixes a regression in zypper install, which previously only stopped
on a unknown package argument when running in non-interactive mode.
This behaviour was broken when migrating the install command to
the new unified command object API, see commit f2e0f8638a32225ff084458a536eedc0f08ee549.