### PR TITLE
Add option to show more conflict information

### DIFF
--- a/src/callbacks/keyring.h
+++ b/src/callbacks/keyring.h
@@ -332,8 +332,6 @@ namespace zypp
           // translators: help text for the 'a' option in the 'r/t/a' prompt
           popts.setOptionHelp( (++off), _("Trust the key and import it into trusted keyring.") );
 
-        if (!zypper.config().non_interactive)
-          clear_keyboard_buffer();
         zypper.out().prompt(PROMPT_YN_GPG_KEY_TRUST, s.str(), popts);
         unsigned prep =
           get_prompt_reply(zypper, PROMPT_YN_GPG_KEY_TRUST, popts);
@@ -527,8 +525,7 @@ namespace zypp
 	// translators: A prompt option help text
 	popts.setOptionHelp( 1, _("Discard the file.") );
 	popts.setShownCount( 1 );
-	if ( !zypper.config().non_interactive )
-	  clear_keyboard_buffer();
+
 	// translators: A prompt text
 	zypper.out().prompt( PROMPT_GPG_WRONG_DIGEST_ACCEPT, _("Unblock or discard?"), popts );
 	int reply = get_prompt_reply( zypper, PROMPT_GPG_WRONG_DIGEST_ACCEPT, popts );

--- a/src/callbacks/media.cc
+++ b/src/callbacks/media.cc
@@ -77,8 +77,6 @@ static MediaChangeReport::Action request_medium_https_handler( Zypper & zypper, 
   set_common_option_help( popts );
   popts.setOptionHelp( 4, _("Disable SSL certificate authority check and continue.") );
 
-  if ( !zypper.config().non_interactive )
-    clear_keyboard_buffer();
   // translators: this is a prompt text
   zypper.out().prompt( PROMPT_ARI_MEDIA_PROBLEM, _("Abort, retry, ignore?"), popts );
   int reply = get_prompt_reply( zypper, PROMPT_ARI_MEDIA_PROBLEM, popts );
@@ -133,8 +131,7 @@ static void eject_drive_dialog( Zypper & zypper, Url & url, const std::vector<st
     int devcount = devices.size();
     PromptOptions popts( numbers.str(), 0 );
     popts.setOptionHelp( devcount, _("Cancel") );
-    if ( !zypper.config().non_interactive )
-      clear_keyboard_buffer();
+
     zypper.out().prompt( PROMPT_MEDIA_EJECT, _("Select device to eject."), popts );
     int reply = get_prompt_reply( zypper, PROMPT_MEDIA_EJECT, popts );
     if ( reply == devcount )
@@ -172,8 +169,6 @@ static MediaChangeReport::Action request_medium_dvd_handler( Zypper & zypper,
   set_common_option_help( popts );
   popts.setOptionHelp( 4, _("Eject medium.") );
 
-  if ( !zypper.config().non_interactive )
-    clear_keyboard_buffer();
   // translators: this is a prompt text
   zypper.out().prompt( PROMPT_ARI_MEDIA_PROBLEM, _("Abort, retry, ignore?"), popts );
   int reply = get_prompt_reply( zypper, PROMPT_ARI_MEDIA_PROBLEM, popts );
@@ -254,8 +249,6 @@ namespace ZmartRecipients
       PromptOptions popts(_("a/r/i/u"), 0 );
       set_common_option_help( popts );
 
-      if ( !zypper.config().non_interactive )
-	clear_keyboard_buffer();
       // translators: this is a prompt text
       zypper.out().prompt( PROMPT_ARI_MEDIA_PROBLEM, _("Abort, retry, ignore?"), popts );
       int reply = get_prompt_reply( zypper, PROMPT_ARI_MEDIA_PROBLEM, popts );

--- a/src/solve-commit.cc
+++ b/src/solve-commit.cc
@@ -151,9 +151,6 @@ static TriBool show_problem( Zypper & zypper, const ResolverProblem & prob, Prob
       fulltext << desc_ext_stm.str();
     fulltext << solution_stm.str();
 
-    if ( !zypper.config().non_interactive )
-      clear_keyboard_buffer();
-
     zypper.out().prompt( PROMPT_DEP_RESOLVE, prompt_text, popts, fulltext.str() );
     reply = get_prompt_reply( zypper, PROMPT_DEP_RESOLVE, popts );
 
@@ -544,8 +541,6 @@ static void show_update_messages( Zypper & zypper, const UpdateNotifications & m
   std::string prompt_text( _("View the notifications now?") );
   unsigned reply;
 
-  if ( !zypper.config().non_interactive )
-    clear_keyboard_buffer();
   zypper.out().prompt( PROMPT_YN_INST_REMOVE_CONTINUE, prompt_text, popts );
   reply = get_prompt_reply( zypper, PROMPT_YN_INST_REMOVE_CONTINUE, popts );
 
@@ -707,8 +702,6 @@ void solve_and_commit (Zypper & zypper , Summary::ViewOptions summaryOptions_r, 
       unsigned reply;
       do
       {
-        if ( !zypper.config().non_interactive )
-          clear_keyboard_buffer();
         zypper.out().prompt( PROMPT_YN_INST_REMOVE_CONTINUE, prompt_text, popts );
         reply = get_prompt_reply( zypper, PROMPT_YN_INST_REMOVE_CONTINUE, popts );
 

--- a/src/utils/prompt.cc
+++ b/src/utils/prompt.cc
@@ -300,8 +300,6 @@ int read_action_ari( PromptId pid, int default_action )
   // correspond to abort/retry/ignore in that order.
   // The answers should be lower case letters.
   PromptOptions popts(_("a/r/i"), (unsigned) default_action );
-  if ( !zypper.config().non_interactive )
-    clear_keyboard_buffer();
   zypper.out().prompt( pid, _("Abort, retry, ignore?"), popts );
   return get_prompt_reply( zypper, pid, popts );
 }
@@ -313,8 +311,6 @@ bool read_bool_answer( PromptId pid, const std::string & question, bool default_
   Zypper & zypper( Zypper::instance() );
   std::string yn( std::string(_("yes")) + "/" + _("no") );
   PromptOptions popts( yn, default_answer ? 0 : 1 );
-  if ( ! zypper.config().non_interactive )
-    clear_keyboard_buffer();
   zypper.out().prompt( pid, question, popts );
   return !get_prompt_reply( zypper, pid, popts );
 }
@@ -324,10 +320,7 @@ std::pair<bool,bool> read_bool_answer_opt_save( PromptId pid_r, const std::strin
   Zypper & zypper( Zypper::instance() );
   PromptOptions popts( { _("yes"), _("no"), _("always"), _("never") }, defaultAnswer_r ? 0 : 1 );
 
-  if ( ! zypper.config().non_interactive )
-    clear_keyboard_buffer();
   zypper.out().prompt( pid_r, question_r, popts );
-
   unsigned r = get_prompt_reply( zypper, pid_r, popts );
   return { !(r%2), (r > 1) };
 }
@@ -344,6 +337,8 @@ unsigned get_prompt_reply( Zypper & zypper, PromptId pid, const PromptOptions & 
     MIL << "running non-interactively, returning " << poptions.options()[poptions.defaultOpt()] << endl;
     return poptions.defaultOpt();
   }
+
+  clear_keyboard_buffer();
 
   // set runtimeData().waiting_for_input flag while in this function
   struct Bye


### PR DESCRIPTION
This patch adds a new option to the prompt generated in the
show_problem() function to show all available conflict information
to a specific solving problem.
Also cleans up the option handling a bit and adds help text.

Needs to land after: https://github.com/openSUSE/libzypp/pull/164