### PR TITLE
Fix the package build failure with CMake 3.14

### DIFF
--- a/package/zypper.changes
+++ b/package/zypper.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Apr  3 17:11:37 UTC 2019 - Christophe Giboudeaux <christophe@krop.fr>
+
+- Fix build with CMake >= 3.14
+  Starting with CMake 3.14, EXCLUDE_FROM_ALL now spreads from
+  directories to targets. 'make -C someSubdir' when 'someSubdir'
+  uses the 'EXCLUDE_FROM_ALL' keyword does nothing.
+- Remove unneeded CMake commands.
+
+-------------------------------------------------------------------
 Thu Mar 21 12:44:06 CET 2019 - ma@suse.de
 
 - Add Requires: libaugeas0 >= 1.10.0 (fixes #265)

--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -144,12 +144,11 @@ cmake -DCMAKE_INSTALL_PREFIX=%{_prefix} \
       -DCMAKE_C_FLAGS_RELEASE:STRING="$RPM_OPT_FLAGS" \
       -DCMAKE_CXX_FLAGS_RELEASE:STRING="$RPM_OPT_FLAGS" \
       -DCMAKE_BUILD_TYPE=Release \
+      -DENABLE_BUILD_TESTS=ON \
       ..
 
 #gettextize -f
 make %{?_smp_mflags}
-make -C po %{?_smp_mflags} translations
-make -C tests %{?_smp_mflags}
 
 %check
 pushd build/tests
@@ -159,7 +158,6 @@ popd
 %install
 cd build
 make install DESTDIR=$RPM_BUILD_ROOT
-make -C po install DESTDIR=$RPM_BUILD_ROOT
 
 mkdir -p $RPM_BUILD_ROOT%{_prefix}/lib/zypper
 mkdir -p $RPM_BUILD_ROOT%{_prefix}/lib/zypper/commands


### PR DESCRIPTION
same issue as libzypp#165, with CMake>=3.14, EXCLUDE_FROM_ALL now spreads from
directories to targets.
'make -C tests' does nothing because add_subdirectories(tests) uses the
EXCLUDE_FROM_ALL parameter when ENABLE_BUILD_TESTS is false.