### PR TITLE
Rephrase file conflict check summary (bsc#1140039)

### DIFF
--- a/doc/zypper.8.txt
+++ b/doc/zypper.8.txt
@@ -114,7 +114,7 @@ Package File Conflicts
 ~~~~~~~~~~~~~~~~~~~~~~
 File conflicts happen when two packages attempt to install files with the same name but different contents. This may happen if you are installing a newer version of a package without erasing the older version, of if two unrelated packages each install a file with the same name.
 
-As checking for file conflicts requires access to the full filelist of each package being installed, zypper will check for file conflict only if all packages are downloaded in advance (see *--download-in-advance*).
+As checking for file conflicts requires access to the full filelist of each package being installed, zypper will be able to check for file conflicts only if all packages are downloaded in advance (see *--download-in-advance*). If you are doing a *--dry-run* no packages are downloaded, so the file conflict check will skip packages not available in the packages cache. To get a meaningful file conflict check use *--dry-run* together with *--download-only*.
 
 As the reason for file conflicts usually is a poor package design or lack of coordination between the people building the packages, they are not easy to resolve. By using the *--replacefiles* option you can force zypper to replace the conflicting files. Nevertheless this may damage the package whose file gets replaced.
 
@@ -259,7 +259,7 @@ Package Management Commands
 		Install the packages even if they replace files from other, already installed, packages. Default is to treat file conflicts as an error. *--download-as-needed* disables the file conflict check because access to all packages file lists is needed in advance in order to perform the check.
 
 	*-D*, *--dry-run*::
-		Test the installation, do not actually install any package. This option will add the *--test* option to the rpm commands run by the install command.
+		Test the installation, do not actually install any package. If used together with *--download-only* a meaningful file conflict check can be performed (see section *Package File Conflicts*).
 
 	*--details*::
 		Show the detailed installation summary.
@@ -277,10 +277,10 @@ include::{incdir}/option_Solver_Flags_Recommends.txt[]
 	Download-and-install mode options: :: {nop}
 
 	*-d*, *--download-only*::
-		Only download the packages for later installation.
+		Only download the packages for later installation. If used together with *--dry-run* a meaningful file conflict check can be performed (see section *Package File Conflicts*).
 
 	*--download-in-advance*::
-		First download all packages, then start installing.
+		First download all packages, then start installing. This is the default.
 
 	*--download-in-heaps*::
 		Download a minimal set of packages that can be installed without leaving
@@ -355,7 +355,7 @@ include::{incdir}/option_Solver_Flags_Installs.txt[]
 +
 --
 	*-D*, *--dry-run*::
-		Test the repair, do not actually do anything to the system.
+		Test the repair, do not actually do anything to the system. If used together with *--download-only* a meaningful file conflict check can be performed (see section *Package File Conflicts*).
 
 	*--details*::
 		Show the detailed installation summary.
@@ -387,7 +387,7 @@ include::{incdir}/option_Solver_Flags_Installs.txt[]
 		Work only with the repository specified by the alias, name, number, or URI. This option can be used multiple times.
 
 	*-D*, *--dry-run*::
-		Test the installation, do not actually install anything.
+		Test the installation, do not actually install anything. If used together with *--download-only* a meaningful file conflict check can be performed (see section *Package File Conflicts*).
 
 	*--details*::
 		Show the detailed installation summary.
@@ -427,7 +427,7 @@ This command also accepts the *Download-and-install mode options* described in t
 		Select packages by capabilities.
 
 	*-D*, *--dry-run*::
-		Test the removal of packages, do not actually remove anything. This option will add the *--test* option to the rpm commands run by the remove command.
+		Test the removal of packages, do not actually remove anything. If used together with *--download-only* a meaningful file conflict check can be performed (see section *Package File Conflicts*).
 
 	*--details*::
 		Show the detailed installation summary.
@@ -502,7 +502,7 @@ Update Management Commands
 		Install the packages even if they replace files from other, already installed, packages. Default is to treat file conflicts as an error. *--download-as-needed* disables the fileconflict check because access to all packages filelists is needed in advance in order to perform the check.
 
 	*-D*, *--dry-run*::
-		Test the update, do not actually install or update any package. This option will add the *--test* option to the rpm commands run by the update command.
+		Test the update, do not actually install or update any package. If used together with *--download-only* a meaningful file conflict check can be performed (see section *Package File Conflicts*).
 
 	*--details*::
 		Show the detailed installation summary.
@@ -632,7 +632,7 @@ include::{incdir}/option_Solver_Flags_Installs.txt[]
 		Install the packages even if they replace files from other, already installed, packages. Default is to treat file conflicts as an error. *--download-as-needed* disables the fileconflict check because access to all packages filelists is needed in advance in order to perform the check.
 
 	*-D*, *--dry-run*::
-		Test the update, do not actually update.
+		Test the update, do not actually update. If used together with *--download-only* a meaningful file conflict check can be performed (see section *Package File Conflicts*).
 
 	*--details*::
 		Show the detailed installation summary.
@@ -679,7 +679,7 @@ include::{incdir}/option_Solver_Flags_Installs.txt[]
 		Install the packages even if they replace files from other, already installed, packages. Default is to treat file conflicts as an error. *--download-as-needed* disables the fileconflict check because access to all packages filelists is needed in advance in order to perform the check.
 
 	*-D*, *--dry-run*::
-		Test the upgrade, do not actually install or update any package. This option will add the *--test* option to the rpm commands run by the dist-upgrade command.
+		Test the upgrade, do not actually install or update any package. If used together with *--download-only* a meaningful file conflict check can be performed (see section *Package File Conflicts*).
 
 	*-y*, *--no-confirm*::
 		Don't require user interaction. Alias for the --non-interactive global option.

--- a/src/callbacks/rpm.h
+++ b/src/callbacks/rpm.h
@@ -146,7 +146,7 @@ struct PatchMessageReportReceiver : public callback::ReceiveReport<target::Patch
   {
     Out & out = Zypper::instance().out();
     std::ostringstream s;
-    s << patch; // [patch]important-patch-101 \todo make some meaningfull message out of this
+    s << patch; // [patch]important-patch-101 \todo make some meaningful message out of this
     out.info(s.str(), Out::HIGH);
     out.info(patch->message());
 
@@ -397,12 +397,25 @@ private:
 ///////////////////////////////////////////////////////////////////
 struct FindFileConflictstReportReceiver : public callback::ReceiveReport<target::FindFileConflictstReport>
 {
+  static std::string mkProgressBarLabel( unsigned skipped_r = 0 )
+  {
+    // translators: A progressbar label
+    std::string ret { _("Checking for file conflicts:") };
+    if ( skipped_r ) {
+      // translators: progressbar label extension; %1% is the number of skipped items
+      static str::Format fmt { MSG_WARNINGString(" (%1% skipped)" ).str() };
+      ret += fmt % skipped_r;
+    }
+    return ret;
+  }
+
   virtual void reportbegin()
   {
+    Zypper::instance().out().gap();
+    _lastskip = 0;
     _progress.reset( new Out::ProgressBar( Zypper::instance().out(),
 					   "fileconflict-check",
-					   // TranslatorExplanation A progressbar label
-					   _("Checking for file conflicts:") ) );
+					   mkProgressBarLabel() ) );
   }
 
   virtual bool start( const ProgressData & progress_r )
@@ -414,6 +427,9 @@ struct FindFileConflictstReportReceiver : public callback::ReceiveReport<target:
   virtual bool progress( const ProgressData & progress_r, const sat::Queue & noFilelist_r )
   {
     (*_progress)->set( progress_r );
+    if ( noFilelist_r.size() != _lastskip ) {
+      (*_progress).print( mkProgressBarLabel( (_lastskip = noFilelist_r.size()) ) );
+    }
     return !Zypper::instance().exitRequested();
   }
 
@@ -434,19 +450,16 @@ struct FindFileConflictstReportReceiver : public callback::ReceiveReport<target:
 
       if ( ! noFilelist_r.empty() )	// warning
       {
-	out.warning( str::Format(
+	out.warning( str::Format( // TranslatorExplanation %1%(number of packages); detailed list follows
+				  PL_( "%1% package had to be excluded from file conflicts check because it is not yet download.",
+				       "%1% packages had to be excluded from file conflicts check because they are not yet downloaded.",
+				       noFilelist_r.size() ) ) % noFilelist_r.size() );
+
+	out.notePar( 4, str::Format(
 		       // TranslatorExplanation %1%(commandline option)
 		       _("Checking for file conflicts requires not installed packages to be downloaded in advance "
 	                 "in order to access their file lists. See option '%1%' in the zypper manual page for details.")
-		     ) % "--download-in-advance" );
-	out.gap();
-
-	out.list( "no-filelist",
-		  // TranslatorExplanation %1%(number of packages); detailed list follows
-		  PL_("The following package had to be excluded from file conflicts check because it is not yet downloaded:",
-		      "The following %1% packages had to be excluded from file conflicts check because they are not yet downloaded:",
-		      noFilelist_r.size() ),
-		  noFilelist_r, out::SolvableListFormater() );
+		     ) % "--download-in-advance / --dry-run --download-only" );
 	out.gap();
       }
 
@@ -488,6 +501,7 @@ struct FindFileConflictstReportReceiver : public callback::ReceiveReport<target:
 
 private:
   scoped_ptr<Out::ProgressBar>	_progress;
+  unsigned _lastskip = 0;
 };
 
 

--- a/src/commands/optionsets.cc
+++ b/src/commands/optionsets.cc
@@ -30,7 +30,9 @@ std::vector<ZyppFlags::CommandGroup> DryRunOptionSet::options()
   if ( _compatMode.testFlag( CompatModeBits::EnableNewOpt ) ) {
     myOpts.push_back( {{
        { "dry-run", 'D', ZyppFlags::NoArgument, ZyppFlags::BoolType( &DryRunSettings::instanceNoConst()._enabled, ZyppFlags::StoreTrue, DryRunSettings::instance()._enabled ),
-            _("Don't change anything, just report what would be done.")}
+            text::join( _("Don't change anything, just report what would be done."),
+			// translators: %1% is a commandline option (like "--download-only")
+			str::Format(_("A meaningful file conflict check can only be performed if used together with '%1%'.")) % "--download-only" ) }
     }});
   }
 


### PR DESCRIPTION
Libzypp may trigger the file conflict check on --dry-run. Shortened the
summary to report just the number of packages skipped because they are
not yet downloaded.

Adjusted the man-page to point to using '--dry-run --download-only' to get
the full file conflict check without actually installing packages.