### PR TITLE
Fix local/remote url classification.

### DIFF
--- a/src/commands/services/modify.cc
+++ b/src/commands/services/modify.cc
@@ -341,13 +341,11 @@ void ModifyServiceCmd::modifyServicesByOption( Zypper & zypper )
     if ( url.isValid() )
     {
       bool modify = false;
-      if ( local  && ! url.schemeIsDownloading() )
+      if ( local && url.schemeIsLocal() )
         modify = true;
-
-      if ( !modify && remote && url.schemeIsDownloading() )
+      else if ( remote && url.schemeIsRemote() )
         modify = true;
-
-      if ( !modify && schemes.find(url.getScheme()) != schemes.end() )
+      else if ( schemes.count( url.getScheme() ) )
         modify = true;
 
       if ( modify )

--- a/src/repos.cc
+++ b/src/repos.cc
@@ -805,7 +805,7 @@ void do_init_repos( Zypper & zypper, const Container & container )
 				   it->asUserString().c_str(), "no-cd" ) );
       gData.repos.erase( it++ );
     }
-    else if ( no_remote && it->url().schemeIsDownloading() )
+    else if ( no_remote && !it->url().schemeIsLocal() )	// !IsLocal includes IsRemote and plugin://
     {
       zypper.out().info( str::form(_("Ignoring repository '%s' because of '%s' option."),
 				   it->asUserString().c_str(), "no-remote" ) );
@@ -1482,14 +1482,14 @@ RepoInfoSet collect_repos_by_option( Zypper & zypper, const RepoServiceCommonSel
     if ( selectOpts._local )
     {
       filterList.push_back([]( const RepoInfo &info ) {
-        return ( !info.baseUrlsEmpty() && !info.url().schemeIsDownloading() );
+        return info.url().schemeIsLocal();
       });
     }
 
     if ( selectOpts._remote )
     {
       filterList.push_back([]( const RepoInfo &info ) {
-        return ( !info.baseUrlsEmpty() && info.url().schemeIsDownloading() );
+        return info.url().schemeIsRemote();
       });
     }
 


### PR DESCRIPTION
Fix inappropriate use of `schemeIsDownloading` to determine remote repos.
`SchemeIsDownloading` is just a subset of `schemeIsRemote`. Nfs, smb e.g.
are not downloading but remote.

For commands accepting `--medium-type/local/remote` use `schemeIsLocal/IsRemote`
because undecidable types (`plugin://`) can be in/excluded via `--medium-type`.

For the global `--no-remote` prefer `!schemeIsLocal` because `plugin://` usually
resolves to a remote url.