### PR TITLE
Add --repo switch to download

### DIFF
--- a/doc/zypper.8.txt
+++ b/doc/zypper.8.txt
@@ -1549,6 +1549,12 @@ Other Commands
 
 	*--dry-run*::
 		Don't download any package, just report what would be done.
+
+	*-r*, *--repo* 'alias'|'name'|'#'|'URI'::
+		Work only with the repository specified by the alias, name, number or URI. This option can be used multiple times.
+
+	*--from* 'alias'|'name'|'#'|'URI'::
+		Select packages from the specified repository only. This option can be used multiple times.
 --
 
 *source-download*::

--- a/src/commands/utils/download.cc
+++ b/src/commands/utils/download.cc
@@ -166,7 +166,11 @@ ZyppFlags::CommandGroup DownloadCmd::cmdOptions() const
          ZyppFlags::BoolType( &that->_allMatches, ZyppFlags::StoreTrue, _allMatches ),
          // translators: --all-matches
          _("Download all versions matching the commandline arguments. Otherwise only the best version of each matching package is downloaded.")
-      }
+      },
+      { "from", '\0', ZyppFlags::Repeatable | ZyppFlags::RequiredArgument, ZyppFlags::StringVectorType( &InitRepoSettings::instanceNoConst()._repoFilter, ARG_REPOSITORY),
+        // translators: --from <ALIAS|#|URI>
+        _("Select packages from the specified repository.")
+      },
   }};
 }
 

--- a/src/commands/utils/download.h
+++ b/src/commands/utils/download.h
@@ -43,6 +43,7 @@ public:
 
 private:
   DryRunOptionSet _dryRun { *this };
+  InitReposOptionSet _initRepos { *this };
   bool _allMatches = false;
 
 


### PR DESCRIPTION
Introduces the --repo switch to the zypper download command so
downloading can be limited to a specific repository (jira#SLE-9171)