### PR TITLE
Provide reverse-requires search in zypper

### DIFF
--- a/doc/zypper.8.txt
+++ b/doc/zypper.8.txt
@@ -777,6 +777,27 @@ Query Commands
 	*--supplements*::
 		Search for packages which supplement the search strings.
 
+	*--provides-pkg*::
+		Search for all packages that provide any of the provides of the package(s) matched by the input parameters.
+
+	*--requires-pkg*::
+		Search for all packages that require any of the provides of the package(s) matched by the input parameters.
+
+	*--recommends-pkg*::
+		Search for all packages that recommend any of the provides of the package(s) matched by the input parameters.
+
+	*--supplements-pkg*::
+		Search for all packages that supplement any of the provides of the package(s) matched by the input parameters.
+
+	*--conflicts-pkg*::
+		Search for all packages that conflict with any of the package(s) matched by the input parameters.
+
+	*--obsoletes-pkg*::
+		Search for all packages that obsolete any of the package(s) matched by the input parameters.
+
+	*--suggests-pkg*::
+		Search for all packages that suggest any of the provides of the package(s) matched by the input parameters.
+
 	*-n*, *--name*::
 		Useful together with dependency options, otherwise searching in package name is default.
 

--- a/src/commands/search/search.h
+++ b/src/commands/search/search.h
@@ -11,7 +11,9 @@
 #include "commands/optionsets.h"
 #include "utils/flags/zyppflags.h"
 
+
 #include <zypp/sat/SolvAttr.h>
+#include <boost/optional.hpp>
 
 class SearchCmd : public ZypperBaseCommand
 {
@@ -44,6 +46,8 @@ private:
   bool _details = false;
   bool _verbose = false;
   std::set<zypp::sat::SolvAttr> _requestedDeps;
+  boost::optional<zypp::sat::SolvAttr> _requestedReverseSearch;
+
   std::set<ResKind> _requestedTypes;
 
   //careful when adding new optionsets, only enable them for the right command mode

--- a/src/search.h
+++ b/src/search.h
@@ -30,11 +30,17 @@ struct FillSearchTableSolvable
   bool operator()( const sat::Solvable & solv_r ) const;
   /** PoolQuery iterator provides info about matches */
   bool operator()( const PoolQuery::const_iterator & it_r ) const;
+  /** For reverse dependency search */
+  bool operator()( const sat::Solvable & solv_r, const sat::SolvAttr &searchedAttr, const CapabilitySet &matchedReq ) const;
+
+private:
+  std::string attribStr(const sat::SolvAttr &attr) const;
 
 private:
   Table * _table;		//!< The table used for output
   std::set<std::string> _repos;	//!< Filter --repo
   TriBool _instNotinst;		//!< Filter --[not-]installed
+
 };
 
 struct FillSearchTableSelectable

--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -26,7 +26,7 @@ BuildRequires:  boost-devel >= 1.33.1
 BuildRequires:  cmake >= 2.4.6
 BuildRequires:  gcc-c++ >= 4.7
 BuildRequires:  gettext-devel >= 0.15
-BuildRequires:  libzypp-devel >= 17.15.0
+BuildRequires:  libzypp-devel >= 17.15.1
 BuildRequires:  readline-devel >= 5.1
 BuildRequires:  libxml2-devel
 Requires:       procps


### PR DESCRIPTION
This patch adds a new set of switches to zypper to support searching
reverse dependencies for a package or a set of packages (fixes #214)