### PR TITLE
zypper enhancements for patch issue checking

### DIFF
--- a/src/SolverRequester.h
+++ b/src/SolverRequester.h
@@ -87,6 +87,9 @@ struct CliMatchPatch
   bool operator()( const Patch::constPtr & patch_r ) const
   { return missmatch( patch_r ) == Missmatch::None; }
 
+  bool operator()( const PoolItem & pi_r ) const
+  { return pi_r.isKind<Patch>() && operator()( asKind<Patch>(pi_r) ); }
+
 private:
   friend class SolverRequester;	// SolverRequester::updatePatches uses _dateBefore
   Date _dateBefore;

--- a/src/commands/selectpatchoptionset.cc
+++ b/src/commands/selectpatchoptionset.cc
@@ -51,7 +51,8 @@ std::vector<zypp::ZyppFlags::CommandGroup> SelectPatchOptionSet::options()
     };
 
     grp.conflictingOptions.insert( grp.conflictingOptions.end(), {
-      { "issue", "bugzilla", "bz", "cve" }
+      { "issue", "bugzilla" }, { "issue", "bz" }, { "issue", "cve" }
+
     });
   }
 

--- a/src/commands/selectpatchoptionset.cc
+++ b/src/commands/selectpatchoptionset.cc
@@ -49,11 +49,6 @@ std::vector<zypp::ZyppFlags::CommandGroup> SelectPatchOptionSet::options()
             // translators: --cve
             _("Select issues matching the specified string.")
     };
-
-    grp.conflictingOptions.insert( grp.conflictingOptions.end(), {
-      { "issue", "bugzilla" }, { "issue", "bz" }, { "issue", "cve" }
-
-    });
   }
 
   return {{

--- a/src/issue.cc
+++ b/src/issue.cc
@@ -4,8 +4,12 @@
                          /__|\_, | .__/ .__/\___|_|
                              |__/|_|  |_|
 \*---------------------------------------------------------------------------*/
+#include <iostream>
 #include "issue.h"
 
 Issue::Issue(std::string issueType_r, std::string issueId_r)
   : std::pair<std::string, std::string>( std::move(issueType_r), std::move(issueId_r) )
 {}
+
+std::ostream & operator<<( std::ostream & str, const Issue & obj )
+{ return str << "Issue(" << (obj.anyType()?"ANY":obj.type()) << "#" << (obj.anyId()?"ANY":obj.id()) << ")"; }

--- a/src/issue.h
+++ b/src/issue.h
@@ -8,6 +8,7 @@
 #ifndef ZYPPER_ISSUE_H_INCLUDED
 #define ZYPPER_ISSUE_H_INCLUDED
 
+#include <iosfwd>
 #include <string>
 #include <utility>
 
@@ -28,7 +29,10 @@ struct Issue : std::pair<std::string, std::string>
   const std::string & id()		const	{ return second; }
   bool                anyId()		const 	{ return id().empty(); }
   bool                specificId()	const	{ return !anyId(); }
+
 };
 
+/** \relates Issue Stream output */
+std::ostream & operator<<( std::ostream & str, const Issue & obj );
 
 #endif

--- a/src/output/xmlout.rnc
+++ b/src/output/xmlout.rnc
@@ -11,6 +11,7 @@ stream-element =
 
       # special stuff (updates list, installation summary, search output, info)
       update-status-element* |   # for zypper list-updates/list-patches
+      list-patches-byissue-element* |  # list-patches --issue/cve/bugzilla...
       install-summary-element* | # for zypper install/remove/update
       repo-list-element? |       # for zypper repos
       service-list-element? |
@@ -81,6 +82,13 @@ update-status-element =
     element blocked-update-list { patch-update-list }?	# applicable patches waiting for a pending software stack update to be installed first
   }
 
+list-patches-byissue-element =                            # list-patches --issue/cve/bugzilla...
+  element list-patches-byissue {
+    element issue-matches { patch-update-list }?,         # patches with match within their issue ids
+    element description-matches { patch-update-list }?    # patches with match within summary/description
+  }
+
+update-list =
   ( patch-update | other-update )*
 
 patch-update-list =

--- a/src/output/xmlout.rnc
+++ b/src/output/xmlout.rnc
@@ -77,7 +77,7 @@ prompt-element =
 update-status-element =
   element update-status {
     attribute version {xsd:string},
-    element update-list { ( patch-update | other-update )* }
+    element update-list { ( patch-update | other-update )* },
     element blocked-update-list { ( patch-update )* }?	# applicable patches waiting for a pending software stack update to be installed first
   }
 
@@ -96,9 +96,9 @@ update-commons =
 other-update =
   element update {
     update-commons,
-    attribute kind { "package" | "pattern" | "product" }
+    attribute kind { "package" | "pattern" | "product" },
     attribute edition-old { xsd:string }?, # currently installed version in case of upgrade
-    attribute arch-old { xsd:string }?,    # currently installed architecture if arch changed
+    attribute arch-old { xsd:string }?     # currently installed architecture if arch changed
   }
 
 patch-update =
@@ -106,7 +106,8 @@ patch-update =
     update-commons,
     attribute kind { "patch" },
     attribute status { "needed" | "optional" | "unwanted" | "applied" | "not-needed" | "undetermined" }?, #
-    attribute category { xsd:string }?,   # patch category (security, recommended, ...)
+    attribute category { xsd:string }?,   # patch category (security, recommended, optional, feature, document, yast, ...)
+    attribute severity { xsd:string }?,   # patch severity (critical, important, moderate, low, unspecified, ...)
     attribute pkgmanager { xsd:boolean }, # affect package management?
     attribute restart { xsd:boolean },    # needs restart of the machine?
     attribute interactive { xsd:boolean } # needs user interaction?

--- a/src/output/xmlout.rnc
+++ b/src/output/xmlout.rnc
@@ -10,7 +10,7 @@ stream-element =
       progress-elements* | download-progress-elements* | message-element* | prompt-element* |
 
       # special stuff (updates list, installation summary, search output, info)
-      update-status-element* |   # for zypper list-updates
+      update-status-element* |   # for zypper list-updates/list-patches
       install-summary-element* | # for zypper install/remove/update
       repo-list-element? |       # for zypper repos
       service-list-element? |
@@ -77,9 +77,14 @@ prompt-element =
 update-status-element =
   element update-status {
     attribute version {xsd:string},
-    element update-list { ( patch-update | other-update )* },
-    element blocked-update-list { ( patch-update )* }?	# applicable patches waiting for a pending software stack update to be installed first
+    element update-list { update-list },
+    element blocked-update-list { patch-update-list }?	# applicable patches waiting for a pending software stack update to be installed first
   }
+
+  ( patch-update | other-update )*
+
+patch-update-list =
+  ( patch-update )*
 
 update-commons =
   attribute name { xsd:string },
@@ -110,7 +115,19 @@ patch-update =
     attribute severity { xsd:string }?,   # patch severity (critical, important, moderate, low, unspecified, ...)
     attribute pkgmanager { xsd:boolean }, # affect package management?
     attribute restart { xsd:boolean },    # needs restart of the machine?
-    attribute interactive { xsd:boolean } # needs user interaction?
+    attribute interactive { xsd:boolean },# needs user interaction?
+    element issue-date { zypp-date },     # Issue date of the patch
+    patch-issue-list-element              # List of issues the patch references (bugzilla, cve, ...)
+  }
+
+patch-issue-list-element =              # List of issues the patch references (bugzilla, cve, ...)
+  element issue-list {
+    element issue {
+      attribute type { xsd:string },    # Issue type (cve, bugzilla, fate, jira,...)
+      attribute id { xsd:string },      # String to identify the issue
+      element title { text? }?,         # Summary text describing the issue
+      element href { text? }?           # Url or pointer where to find more information
+    }*
   }
 
 search-result-element =
@@ -249,3 +266,6 @@ patch-selectable-info =
   }
 
 
+zypp-date =                             # zypp::Date as XML
+  attribute time_t { xsd:long },        # time_t value
+  attribute text { xsd:dateTime }       # ISO format

--- a/src/utils/flags/flagtypes.cc
+++ b/src/utils/flags/flagtypes.cc
@@ -175,7 +175,10 @@ Value PathNameType( filesystem::Pathname &target, const boost::optional<std::str
 Value IssueSetType(std::set<Issue> &target_r, const std::string &issueType_r, std::string hint_r )
 {
   return Value (
-    noDefaultValue,
+    [](){
+      //in case the default value is given a Issue with anyID is pushed into the result set
+      return std::string ();
+    },
     [ &target_r, issueType_r ]( const CommandOption &opt, const boost::optional<std::string> &in ){
 
       std::vector<std::string> issueIds;

--- a/src/utils/flags/zyppflags.cc
+++ b/src/utils/flags/zyppflags.cc
@@ -499,12 +499,7 @@ void renderHelp( const std::vector<CommandGroup> &options )
           std::cout << ">";
       }
 
-      std::cout << "\t" << opt.help;
-
-      auto defVal = opt.value.defaultValue();
-      if ( defVal )
-        std::cout << " Default: " << *defVal;
-
+      std::cout << "\t" << opt.optionHelp();
       std::cout << std::endl;
 
     }
@@ -524,7 +519,7 @@ std::string CommandOption::optionHelp() const
 {
   std::string optHelpTxt = help;
   auto defVal = value.defaultValue();
-  if ( defVal )
+  if ( defVal && defVal->size() )
     optHelpTxt.append(" ").append(str::Format(("Default: %1%")) %*defVal );
   return optHelpTxt;
 }


### PR DESCRIPTION
[bsc#1154805](https://bugzilla.suse.com/show_bug.cgi?id=1154805)

Reorganized parts of the xml wtiting code and added issue data to patches. 
Rewrote list_patches_by_issue to orevent duplicate entires (obsoletes the CLI conflict between issue options) and added XML output.

