### PR TITLE
Set the shebang properly for zypper-log

### DIFF
--- a/tools/zypper-log
+++ b/tools/zypper-log
@@ -1,28 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env python
 
 # This tool helps you accessing the zypper logfile
 # see --help for more details
 #
 # Author: Dominik Heidler <dheidler@suse.de>
-
-# Shell commands follow
-# Next line is bilingual: it starts a comment in Python, and is a no-op in shell
-""":"
-
-if which python3 > /dev/null 2>&1 ; then
-	PYTHON=python3
-elif which python > /dev/null 2>&1 ; then
-	PYTHON=python
-elif which python2 > /dev/null 2>&1 ; then
-	PYTHON=python2
-fi
-
-exec $PYTHON $0 "$@"
-
-":"""
-# Previous line is bilingual: it ends a comment in Python, and is a no-op in shell
-# Shell commands end here
-# Python script follows
 
 from __future__ import print_function
 import os, string, re, bz2, zlib, sys, time, argparse, errno

--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -162,6 +162,9 @@ make install DESTDIR=$RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT%{_prefix}/lib/zypper
 mkdir -p $RPM_BUILD_ROOT%{_prefix}/lib/zypper/commands
 
+# Fix shebang for zypper-log
+sed -e "s|/usr/bin/env python|/usr/bin/python3|g" -i $RPM_BUILD_ROOT%{_sbindir}/zypper-log
+
 # yzpper symlink
 ln -s zypper $RPM_BUILD_ROOT%{_bindir}/yzpper
 


### PR DESCRIPTION
Doing insane things like having a shell stub to locate a Python to
execute causes problems, particularly in scenarios where no matching
Python interpreter was installed.

Instead, let's do the reasonable thing and actually just set the
correct shebang in the spec file so that it works properly when packaged.

This solution was adapted from Fedora's zypper package: https://src.fedoraproject.org/rpms/zypper/c/1eeac978cbea6494705e3f5785c12de458a1aa2b