### PR TITLE
locales: do not sort out requested locales which are not available (b…

### DIFF
--- a/src/commands/locale/localescmd.cc
+++ b/src/commands/locale/localescmd.cc
@@ -49,11 +49,11 @@ int LocalesCmd::execute(Zypper &zypper, const std::vector<std::string> &position
     zypper.out().warning( _("Ignoring positional arguments because --all argument was provided.") );
   }
 
-  SetupSystemFlags flags = ResetRepoManager | InitTarget | LoadTargetResolvables;
+  SetupSystemFlags flags = ResetRepoManager | InitTarget; // Requested locales can be retrieved without loading the Target
 
-  //need to InitRepos if we want to list all, see info about packages or have a search string
+  // need to InitRepos if we want to list all, see info about packages or have a search string
   if ( _packages || _all || positionalArgs.size() ) {
-    flags = flags | InitRepos | LoadRepoResolvables;
+    flags = flags | InitRepos | LoadResolvables;
   }
 
   int code = defaultSystemSetup( zypper, flags  );

--- a/tests/Locales_test.cc
+++ b/tests/Locales_test.cc
@@ -52,13 +52,12 @@ BOOST_AUTO_TEST_CASE( add_locales )
   localeArgs.push_back( "en" );
   localeArgs.push_back( "invalid" );
 
-  // try to add locales "de", "en" and "invalid"
+  // try to add locales "de", "en"
   std::map<std::string, bool> result;
   addLocales( test.zypper(), localeArgs, false, &result );
 
   BOOST_CHECK( (result.find("de") != result.end()) && result["de"] );
   BOOST_CHECK( (result.find("en") != result.end()) && result["en"] );
-  BOOST_CHECK( result.find("invalid") == result.end() ); // not in result, sorted out
 
   // try to add "de" again
   result.clear();


### PR DESCRIPTION
[bsc#1155678](https://bugzilla.opensuse.org/1155678)

All requested locales are shown in lloc default output and with --all.
Also aloc must not prevent you from adding a (currently) not available
locale.

Not addressed in the PR is resolving the packages. The current approach requires adding/removing the packages together with the locale. Adjusting packages without actually changing the locale set needs an enhanced Resolver API first.