### PR TITLE
basecommand: Allow to add multiple paragraphs as command description

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,6 +202,7 @@ SET( zypper_utils_HEADERS
   utils/getopt.h
   utils/messages.h
   utils/misc.h
+  utils/MultiParText.h
   utils/pager.h
   utils/prompt.h
   utils/richtext.h

--- a/src/commands/basecommand.cc
+++ b/src/commands/basecommand.cc
@@ -50,7 +50,7 @@ BaseCommandCondition::~BaseCommandCondition()
 }
 
 ZypperBaseCommand::ZypperBaseCommand(std::vector<std::string> &&commandAliases_r, std::string &&synopsis_r,
-                                     std::string &&summary_r, std::string &&description_r,
+                                     std::string &&summary_r, CommandDescription &&description_r,
                                      SetupSystemFlags systemInitFlags_r)
   : ZypperBaseCommand( std::move(commandAliases_r), std::vector<std::string>{ std::move(synopsis_r) }, std::move(summary_r), std::move(description_r), systemInitFlags_r )
 {
@@ -58,7 +58,7 @@ ZypperBaseCommand::ZypperBaseCommand(std::vector<std::string> &&commandAliases_r
 }
 
 ZypperBaseCommand::ZypperBaseCommand(std::vector<std::string> &&commandAliases_r, std::vector<std::string> &&synopsis_r,
-                                     std::string &&summary_r, std::string &&description_r,
+                                     std::string &&summary_r, CommandDescription &&description_r,
                                      SetupSystemFlags systemInitFlags_r)
   : _commandAliases ( std::move( commandAliases_r ) ),
     _synopsis ( std::move( synopsis_r ) ),

--- a/src/commands/basecommand.h
+++ b/src/commands/basecommand.h
@@ -7,6 +7,7 @@
 
 #include <zypp/base/Flags.h>
 #include "utils/flags/zyppflags.h"
+#include "utils/MultiParText.h"
 
 #include <zypp/ZYpp.h>
 
@@ -75,18 +76,19 @@ class ZypperBaseCommand
 {
 public:
   friend class BaseCommandOptionSet;
+  using CommandDescription = MultiParText;
 
   ZypperBaseCommand ( std::vector<std::string> &&commandAliases_r,
                       std::string &&synopsis_r,
                       std::string &&summary_r = std::string(),
-                      std::string &&description_r = std::string(),
+                      CommandDescription &&description_r = CommandDescription(),
                       SetupSystemFlags systemInitFlags_r = DefaultSetup
   );
 
   ZypperBaseCommand ( std::vector<std::string> &&commandAliases_r,
                       std::vector<std::string> &&synopsis_r,
                       std::string &&summary_r = std::string(),
-                      std::string &&description_r = std::string(),
+                      CommandDescription &&description_r = CommandDescription(),
                       SetupSystemFlags systemInitFlags_r = DefaultSetup
   );
 

--- a/src/utils/MultiParText.h
+++ b/src/utils/MultiParText.h
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------*\
+                          ____  _ _ __ _ __  ___ _ _
+                         |_ / || | '_ \ '_ \/ -_) '_|
+                         /__|\_, | .__/ .__/\___|_|
+                             |__/|_|  |_|
+\*---------------------------------------------------------------------------*/
+#ifndef UTILS_MULTIPARTEXT_H
+#define UTILS_MULTIPARTEXT_H
+
+#include <string>
+#include <initializer_list>
+
+#include <zypp/base/String.h>	// zypp::asString
+
+///////////////////////////////////////////////////////////////////
+/// \brief Helper to build multi paragraph description texts
+///
+/// We prefer translated description paragraphs to contain no
+/// format information (parindent,parsep,NL). The class joins
+/// multiple paragraphs passed to the ctor so they are rendered
+/// correctly.
+///
+struct MultiParText
+{
+  MultiParText() = default;
+
+  template <typename Tstr>
+  MultiParText( Tstr str_r )
+  : _text { zypp::asString(str_r) }
+  {}
+
+  template <typename... Targs >
+  MultiParText( Targs&&... args_r )
+  { int __attribute__((unused)) dummy[] = { 0, ( (void)appender( _text, std::forward<Targs>(args_r) ), 0 )... }; }
+
+  const std::string & str() const& { return _text; }
+  std::string && str() && { return std::move(_text); }
+
+  const std::string & asString() const& { return _text; }
+  std::string && asString() && { return std::move(_text); }
+
+  operator const std::string &() & { return _text; }	// Intentionally not const& qualified. GCC-9 sees an ambiguity in `std::string( MultiParText() );`
+  operator std::string &&() && { return std::move(_text); }
+
+private:
+  template <typename Tstr>
+  static void appender( std::string & result_r, Tstr str_r )
+  { result_r += zypp::asString(str_r); }
+
+  std::string _text;
+};
+
+/** \relates MultiParText */
+inline std::ostream & operator<<( std::ostream & str, const MultiParText & obj )
+{ return str << obj.str(); }
+
+#endif // UTILS_MULTIPARTEXT_H


### PR DESCRIPTION
We prefer translated description paragraphs to contain no
format information (parindent,parsep,NL). MultiParText joins
multiple paragraphs passed to the ctor so they are rendered
correctly.