### PR TITLE
according instead of accoring

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -4778,7 +4778,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -5250,7 +5250,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/ast.po
+++ b/po/ast.po
@@ -4722,7 +4722,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/be.po
+++ b/po/be.po
@@ -4748,7 +4748,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -4784,7 +4784,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/bn.po
+++ b/po/bn.po
@@ -4786,7 +4786,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/bs.po
+++ b/po/bs.po
@@ -4837,7 +4837,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -5029,7 +5029,7 @@ msgstr "Suprimiu nuclis antics."
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -5061,7 +5061,7 @@ msgstr "Odstranit stará jádra systému."
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/cy.po
+++ b/po/cy.po
@@ -4955,7 +4955,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/da.po
+++ b/po/da.po
@@ -5002,7 +5002,7 @@ msgstr "Fjern gamle kerner."
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -5138,7 +5138,7 @@ msgstr "Alte Kernel entfernen."
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -4959,7 +4959,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -4803,7 +4803,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -5093,7 +5093,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/et.po
+++ b/po/et.po
@@ -4819,7 +4819,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -5012,7 +5012,7 @@ msgstr "Poista vanhoja ytimiä."
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -5101,7 +5101,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -4780,7 +4780,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/gu.po
+++ b/po/gu.po
@@ -4785,7 +4785,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -4723,7 +4723,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -4789,7 +4789,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -4796,7 +4796,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -5061,7 +5061,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -4900,7 +4900,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/ie.po
+++ b/po/ie.po
@@ -4658,7 +4658,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -5080,7 +5080,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -4921,7 +4921,7 @@ msgstr "古いカーネルを削除します。"
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/ka.po
+++ b/po/ka.po
@@ -4592,7 +4592,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/km.po
+++ b/po/km.po
@@ -4650,7 +4650,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -4793,7 +4793,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/ku.po
+++ b/po/ku.po
@@ -4728,7 +4728,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -4990,7 +4990,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -4788,7 +4788,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -4827,7 +4827,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -5114,7 +5114,7 @@ msgstr "Oude kernels verwijderen."
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/nn.po
+++ b/po/nn.po
@@ -4838,7 +4838,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -4761,7 +4761,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -5160,7 +5160,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -4820,7 +4820,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5043,7 +5043,7 @@ msgstr "Remover kernels antigos."
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/ro.po
+++ b/po/ro.po
@@ -4968,7 +4968,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -5101,7 +5101,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/sk.po
+++ b/po/sk.po
@@ -5060,7 +5060,7 @@ msgstr "Odstrániť staré jadrá."
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -4938,7 +4938,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -4817,7 +4817,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -4952,7 +4952,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/ta.po
+++ b/po/ta.po
@@ -4782,7 +4782,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -4662,7 +4662,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -4819,7 +4819,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -4995,7 +4995,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/wa.po
+++ b/po/wa.po
@@ -4748,7 +4748,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/xh.po
+++ b/po/xh.po
@@ -4779,7 +4779,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4688,7 +4688,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -4689,7 +4689,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/zu.po
+++ b/po/zu.po
@@ -4808,7 +4808,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
 msgid ""
-"Autoremoves installed kernels accoring to list of kernels to keep from /etc/"
+"Autoremoves installed kernels according to list of kernels to keep from /etc/"
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""

--- a/po/zypper.pot
+++ b/po/zypper.pot
@@ -4407,7 +4407,7 @@ msgstr ""
 
 #. translators: command description
 #: src/commands/utils/purge-kernels.cc:30
-msgid "Autoremoves installed kernels accoring to list of kernels to keep from /etc/zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-N), running, oldest(+N)."
+msgid "Autoremoves installed kernels according to list of kernels to keep from /etc/zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-N), running, oldest(+N)."
 msgstr ""
 
 #: src/commands/utils/purge-kernels.cc:51

--- a/src/commands/utils/purge-kernels.cc
+++ b/src/commands/utils/purge-kernels.cc
@@ -27,7 +27,7 @@ PurgeKernelsCmd::PurgeKernelsCmd(std::vector<std::string> &&commandAliases_r) :
     // translators: command summary: targetos, tos
     _("Remove old kernels."),
     // translators: command description
-    _("Autoremoves installed kernels accoring to list of kernels to keep from /etc/zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-N), running, oldest(+N)."),
+    _("Autoremoves installed kernels according to list of kernels to keep from /etc/zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-N), running, oldest(+N)."),
     ResetRepoManager | InitTarget | LoadTargetResolvables | Resolve
     )
 { }


### PR DESCRIPTION
I translated the sentence "Autoremoves installed kernels accoring to list of kernels to keep from /etc/zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-N), running, oldest(+N)."

The word "accoring" does not exist in English. That should be "according". That has been changed with sed in all files.