### PR TITLE
zypper-aptitude: don't supplement zypper

### DIFF
--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -95,9 +95,6 @@ Summary:        aptitude compatibility with zypper
 Group:          System/Packages
 Requires:       perl
 Requires:       zypper
-%if 0%{?suse_version}
-Supplements:    zypper
-%endif
 BuildArch:      noarch
 
 %description aptitude


### PR DESCRIPTION
supplementing zypper means zypper-aptitude gets installed by default
and pulls in perl. Neither is desired on small systems.