### PR TITLE
Correctly detect ambigous switch abbrev / Still allow legacy longopt abbrev on 15.0/15.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,14 @@ SET( CMAKE_C_FLAGS_RELEASE   "${CMAKE_C_FLAGS_RELEASE}   -O3" )
 SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Woverloaded-virtual -Wnon-virtual-dtor -fstack-protector -fvisibility-inlines-hidden" )
 SET( CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -g -Wall -fstack-protector" )
 
+IF ( LEGACY_ENABLE_LONGOPT_ABBREV )
+  # Fixed in 1.14.34: Do not allow the abbreviation of cli arguments (bsc#1164543)
+  # On SLE15/Leap 15.0 and 15.1 we will stay bug-compatible and accept the
+  # abbreviations in order not to break tools. In 15.2 they must be fixed.
+  MESSAGE( STATUS "LEGACY_ENABLE_LONGOPT_ABBREV" )
+  ADD_DEFINITIONS( -DLEGACY_ENABLE_LONGOPT_ABBREV=1 )
+ENDIF ( LEGACY_ENABLE_LONGOPT_ABBREV )
+
 
 GENERATE_PACKAGING(${PACKAGE} ${VERSION})
 
@@ -120,3 +128,4 @@ INSTALL(
   DIRECTORY tools/apt-packagemap.d/
   DESTINATION ${SYSCONFDIR}/zypp/apt-packagemap.d
 )
+

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -317,14 +317,6 @@ std::vector<ZyppFlags::CommandGroup> Config::cliOptions()
     OUTPUT  = 2000,
     ROOT    = 1000
   };
-
-  auto notifyDisableRepos = [](){
-    MIL << "Repositories disabled, using target only." << endl;
-    Zypper::instance().out().info(
-      _("Repositories disabled, using the database of installed packages only."),
-      Out::HIGH);
-  };
-
   return {
     {
       "", //unnamed section
@@ -583,15 +575,14 @@ std::vector<ZyppFlags::CommandGroup> Config::cliOptions()
               _("Additionally use disabled repositories providing a specific keyword. Try '--plus-content debug' to enable repos indicating to provide debug packages.")
         },
         { "disable-repositories", 0, ZyppFlags::NoArgument, std::move(ZyppFlags::BoolType( &disable_system_sources, ZyppFlags::StoreTrue )
-              .after([ notifyDisableRepos ](){ notifyDisableRepos(); })),
+              .after([](){
+                MIL << "Repositories disabled, using target only." << endl;
+                Zypper::instance().out().info(
+                  _("Repositories disabled, using the database of installed packages only."),
+                  Out::HIGH);
+              })),
               // translators: --disable-repositories
               _("Do not read meta-data from repositories.")
-        },
-        // synonym for --disable-repositories for SUMA
-        // @TODO remove this once SUMA has reverted their SALT stack
-        { "disable-repos", 0, ZyppFlags::NoArgument | ZyppFlags::Hidden, std::move(ZyppFlags::BoolType( &disable_system_sources, ZyppFlags::StoreTrue )
-              .after([ notifyDisableRepos ](){ notifyDisableRepos(); })),
-          ""
         },
         { "no-refresh", 0, ZyppFlags::NoArgument, std::move(ZyppFlags::BoolType( &no_refresh, ZyppFlags::StoreTrue )
               .after( []() {

--- a/src/utils/flags/zyppflags.cc
+++ b/src/utils/flags/zyppflags.cc
@@ -174,7 +174,11 @@ Value & Value::after( PostWriteHook &&postWriteHook )
 
 bool &onlyWarnOnAbbrevSwitches()
 {
+#if LEGACY_ENABLE_LONGOPT_ABBREV
+  static bool enable = true;
+#else
   static bool enable = false;
+#endif
   return enable;
 }
 

--- a/src/utils/flags/zyppflags.h
+++ b/src/utils/flags/zyppflags.h
@@ -220,6 +220,12 @@ namespace ZyppFlags {
   };
 
   /**
+   * parseCLI normally fails instantly if a switch given is not a exact match
+   * to one of the registered switches. Setting this to true it will only write a warning instead.
+   */
+  bool &onlyWarnOnAbbrevSwitches();
+
+  /**
    * Parses the command line arguments based on \a options.
    * \returns The first index in argv that was not parsed
    * \throws ZyppFlagsException or any subtypes of it

--- a/src/utils/messages.cc
+++ b/src/utils/messages.cc
@@ -118,6 +118,12 @@ std::string legacyCLIStr( const std::string & old_r, const std::string & new_r, 
        _("Legacy commandline option %1% detected. This option is ignored."))
        % NEGATIVEString(dashdash(old_r));
     break;
+  case LegacyCLIMsgType::Abbreviated:
+    return str::Format(
+       _("Abbreviated commandline options will not be supported in future versions. Please use %2% instead of %1% .") )
+       % NEGATIVEString(dashdash(old_r))
+       % POSITIVEString(dashdash(new_r));
+    break;
   }
   return std::string();
 }

--- a/src/utils/messages.h
+++ b/src/utils/messages.h
@@ -41,7 +41,8 @@ void exit_rug_compat ();
 enum class LegacyCLIMsgType {
   Local,
   Global,
-  Ignored
+  Ignored,
+  Abbreviated
 };
 std::string legacyCLIStr( const std::string & old_r, const std::string & new_r, LegacyCLIMsgType type_r );
 void print_legacyCLIStr(Out & out, const std::string & old_r, const std::string & new_r, Out::Verbosity verbosity_r = Out::NORMAL, LegacyCLIMsgType type_r = LegacyCLIMsgType::Local );

--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -130,7 +130,17 @@ Authors:
 mkdir -p build
 cd build
 
-cmake -DCMAKE_INSTALL_PREFIX=%{_prefix} \
+CMAKE_FLAGS=
+
+%if 0%{?suse_version} == 1500 && 0%{?sle_version} && 0%{?sle_version} <= 150100
+  # Fixed in 1.14.34: Do not allow the abbreviation of cli arguments (bsc#1164543)
+  # On SLE15/Leap 15.0 and 15.1 we will stay bug-compatible and accept the
+  # abbreviations in order not to break tools. In 15.2 they must be fixed.
+  CMAKE_FLAGS="$CMAKE_FLAGS -DLEGACY_ENABLE_LONGOPT_ABBREV=1"
+%endif
+
+cmake $CMAKE_FLAGS \
+      -DCMAKE_INSTALL_PREFIX=%{_prefix} \
       -DSYSCONFDIR=%{_sysconfdir} \
       -DMANDIR=%{_mandir} \
       -DCMAKE_VERBOSE_MAKEFILE=TRUE \


### PR DESCRIPTION
[bsc#1164543](https://bugzilla.suse.com/1164543)
[bsc#1165573](https://bugzilla.suse.com/1165573)
Includes and fixes #326 

On 15.0/15.1 just issue a warning if abbrev. switches are used.