### PR TITLE
Show patch status changes (jsc#sle 5116)

### DIFF
--- a/doc/zypper.8.txt
+++ b/doc/zypper.8.txt
@@ -82,9 +82,11 @@ Zypper works with several types of resource objects, called 'resolvables'. A res
 *package*::
 	An ordinary RPM package.
 *patch*::
-	A released patch conflicts with the affected/vulnerable versions of a collection of packages. As long as any of these affected/vulnerable versions are installed, the conflict triggers and the patch is classified as *needed*, *optional* or as *unwanted* if the patch is locked.
+	A released patch conflicts with the affected/vulnerable versions of a collection of packages. As long as any of these affected/vulnerable versions are installed, the conflict triggers and the patch is classified as *needed*, or as *unwanted* if the patch is locked.
 	+
 	Selecting the patch, the conflict is resolved by updating all installed and affected/vulnerable packages to a version providing the fix. When updating the packages zypper always aims for the latest available version. Resolved patches are classified as either *applied* or *not needed*, depending on whether they refer to actually installed packages.
+	+
+	So installation, update or removal of packages may change the classification of patches refering to these packages. Since libyzpp-17.23.0 the /var/log/zypp/history remembers if a commited transaction changes a patchs classification. If history data are available, patch tables show a column telling 'since' when the patch is in it's current state.
 	+
 	Depending on the kind of defect, patches are classified by 'category' and 'severity'. Commonly used values for 'category' are *security*, *recommended*, *optional*, *feature*, *document* or *yast*. Commonly used values for 'severity' are *critical*, *important*, *moderate*, *low* or *unspecified*.
 	+

--- a/src/Table.cc
+++ b/src/Table.cc
@@ -89,6 +89,7 @@ std::ostream & TableRow::dumpTo( std::ostream & stream, const Table & parent ) c
   std::string::size_type editionSep( std::string::npos );
 
   container::const_iterator i = _columns.begin (), e = _columns.end ();
+  const unsigned lastCol = _columns.size() - 1;
   for ( unsigned c = 0; i != e ; ++i, ++c )
   {
     const std::string & s( *i );
@@ -168,7 +169,7 @@ std::ostream & TableRow::dumpTo( std::ostream & stream, const Table & parent ) c
       {
 	stream << ( _ctxt << s );
       }
-      stream.width( parent._max_width[c] - ssize );
+      stream.width( c == lastCol ? 0 : parent._max_width[c] - ssize );
     }
     stream << "";
     curpos += parent._max_width[c] + (parent._style == none ? 2 : 3);

--- a/src/commands/search/search.cc
+++ b/src/commands/search/search.cc
@@ -484,7 +484,11 @@ int SearchCmd::execute( Zypper &zypper, const std::vector<std::string> &position
     } else {
       if ( _cmdMode == CmdMode::RugPatchSearch )
       {
-        FillPatchesTable callback( t, inst_notinst );
+	// TODO: PatchHistoryData::placeholder just added to get it compiled. In fact
+	// 'zypper.out().searchResult( t )' in XML mode understands just FillSearchTable*
+	// formats. The output is wrong in this case. RugPatchSearch is an undocumented rug legacy.
+	// Maybe we should drop it.
+	FillPatchesTable callback( t, PatchHistoryData::placeholder(), inst_notinst );
         invokeOnEach( query.poolItemBegin(), query.poolItemEnd(), callback );
       }
       else if ( details )

--- a/src/search.cc
+++ b/src/search.cc
@@ -252,7 +252,7 @@ void list_patches( Zypper & zypper )
   MIL << "Pool contains " << God->pool().size() << " items. Checking whether available patches are needed." << std::endl;
 
   Table tbl;
-  FillPatchesTable callback( tbl );
+  FillPatchesTable callback( tbl, PatchHistoryData() );
   invokeOnEach( God->pool().byKindBegin(ResKind::patch),
 		God->pool().byKindEnd(ResKind::patch),
 		callback);


### PR DESCRIPTION
Introduces a ´Since´ column showing the date the patch changed to it's current ´Status´. As those data need to be derived from the history file (since libyzpp-17.23.0) and are not available on older systems, the column is suppressed if the history file contains not a single patch-status-change entry.