### PR TITLE
Allow source-install to run as non-root user

### DIFF
--- a/src/commands/sourceinstall.cc
+++ b/src/commands/sourceinstall.cc
@@ -34,7 +34,6 @@ SourceInstallCmd::SourceInstallCmd(std::vector<std::string> &&commandAliases_r) 
 std::vector<BaseCommandConditionPtr> SourceInstallCmd::conditions() const
 {
   return {
-    std::make_shared<NeedsRootCondition>(),
     std::make_shared<NeedsWritableRoot>()
   };
 }


### PR DESCRIPTION
`zypper si` refuses to run as as non-root user: "Root privileges are required to run this command."

I don't see a reason for this requirement. In fact it kills my most obvious use case: Run `rpmbuild` as non-root user after source-installing the package with zypper and editing the sources as needed.

This used to be `si`'s default behaviour from the start until the restriction was introduced with commit 7827e3865 into Zypper.cc, and has then propagated with commit e40bdd82e into sourceinstall.cc. The first commit mentions [bsc#1066215](https://bugzilla.suse.com/show_bug.cgi?id=1066215) as its reason, but that looks unrelated.

This PR reinstantiates the original behaviour and works fine for me.