### PR TITLE
Use new testcase API in libzypp

### DIFF
--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -26,7 +26,7 @@ BuildRequires:  boost-devel >= 1.33.1
 BuildRequires:  cmake >= 3.1
 BuildRequires:  gcc-c++ >= 7
 BuildRequires:  gettext-devel >= 0.15
-BuildRequires:  libzypp-devel >= 17.23.2
+BuildRequires:  libzypp-devel >= 17.25.0
 BuildRequires:  readline-devel >= 5.1
 BuildRequires:  libxml2-devel
 Requires:       procps


### PR DESCRIPTION
Switches TestSetup to use the new libzypp testcase API 

TODO: bump libzypp version in build requires