### PR TITLE
Quickfix setting "openSUSE_Tumbleweed" as default platform for "MicroOs"

### DIFF
--- a/src/commands/repos/add.cc
+++ b/src/commands/repos/add.cc
@@ -102,8 +102,8 @@ int AddRepoCmd::execute(Zypper &zypper, const std::vector<std::string> &position
       }
     case 2:
       Url url;
-      if ( positionalArgs_r[0].find("obs") == 0 )
-        url = make_obs_url( positionalArgs_r[0], zypper.config().obs_baseUrl, zypper.config().obs_platform );
+      if ( positionalArgs_r[0].find("obs:") == 0 )
+        url = make_obs_url( positionalArgs_r[0] );
       else
         url = make_url( positionalArgs_r[0] );
       if ( !url.isValid() )

--- a/src/utils/misc.h
+++ b/src/utils/misc.h
@@ -190,7 +190,7 @@ Url make_url( const std::string & url_s );
  * Creates Url out of obs://project/platform URI with given base URL and default
  * platform (used in case the platform is not specified in the URI).
  */
-Url make_obs_url( const std::string & obsuri, const Url & base_url, const std::string & default_platform );
+Url make_obs_url( const std::string & obsuri );
 
 /**
  * Returns <code>true</code> if the string \a s contains a substring starting


### PR DESCRIPTION
[bsc#1153687](https://bugzilla.suse.com/show_bug.cgi?id=1153687)

This fixes the guessed platform for "obs://<project>/" URLs.