### PR TITLE
Suggest scout version of command-not-found on zypper based systems

### DIFF
--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -57,6 +57,7 @@ Provides:       zypper(oldpackage)
 Provides:	zypper(updatestack-only)
 Provides:	zypper(auto-agree-with-product-licenses)
 Provides:	zypper(purge-kernels)
+Suggests:       scout-command-not-found
 
 %description
 Zypper is a command line tool for managing software. It can be used to add


### PR DESCRIPTION
Associated with https://build.opensuse.org/request/show/864365 as we want to keep zypper-based systems using scout-based cnf, while dnf will use PackageKit-based one by default