### PR TITLE
patch: Let patch reboot-needed flag overrule included packages 

### DIFF
--- a/src/Summary.h
+++ b/src/Summary.h
@@ -52,6 +52,7 @@ public:
     SHOW_LOCKS              = 0x1000,
 
     UPDATESTACK_ONLY        = 0x2000,  //< required for zypper patch
+    PATCH_REBOOT_RULES      = 0x4000,  // for zypper patch bsc#1183268
 
     SHOW_ALL                = 0xffff
   };
@@ -67,6 +68,7 @@ public:
   void setViewOption( const ViewOptions option )	{ _viewop = (ViewOptions) (_viewop | option); }
   void unsetViewOption( const ViewOptions option )	{ _viewop = (ViewOptions) (_viewop & ~option); }
   void toggleViewOption( const ViewOptions option )	{ _viewop & option ? unsetViewOption(option) : setViewOption(option); }
+  bool hasViewOption( const ViewOptions option ) const  { return _viewop & option; }
   void setForceNoColor( bool value = true )		{ _force_no_color = value; }
   void setDownloadOnly( bool value = true )		{ _download_only = value; }
 

--- a/src/commands/patch.cc
+++ b/src/commands/patch.cc
@@ -123,6 +123,11 @@ int PatchCmd::execute( Zypper &zypper, const std::vector<std::string> &positiona
     viewOpts = static_cast<Summary::ViewOptions> ( viewOpts | Summary::ViewOptions::UPDATESTACK_ONLY );
   }
 
+  if ( skip_interactive ) {
+    // bsc#1183268: Patch reboot needed flag overrules included packages
+    viewOpts = static_cast<Summary::ViewOptions> ( viewOpts | Summary::ViewOptions::PATCH_REBOOT_RULES );
+  }
+
   solve_and_commit( zypper, viewOpts, _downloadModeOpts.mode() );
   return zypper.exitCode();
 }


### PR DESCRIPTION
[bsc#1183268](https://bugzilla.suse.com/show_bug.cgi?id=1183268)
