### PR TITLE
Case-insensitive sorting of search results (issue #391)

### DIFF
--- a/src/Table.h
+++ b/src/Table.h
@@ -258,7 +258,9 @@ public:
         } else
           return ( noL && ! noR ? -1 : ! noL && noR ?  1 : 0);
       }
-      return ( a_r._columns[curr_column_r] < b_r._columns[curr_column_r] ? -1 : a_r._columns[curr_column_r] > b_r._columns[curr_column_r] ?  1 : 0 );
+      std::string lower_a_r = str::toLower(a_r._columns[curr_column_r]);
+      std::string lower_b_r = str::toLower(b_r._columns[curr_column_r]);
+      return ( lower_a_r < lower_b_r ? -1 : lower_a_r > lower_b_r ?  1 : 0 );
     }
   };
 


### PR DESCRIPTION
Case-insensitive sorting should be used for other columns as well? If so, converting column values to the same case, before performing the comparison, should be enough?