### PR TITLE
Fix compiler warning

### DIFF
--- a/src/utils/flags/zyppflags.cc
+++ b/src/utils/flags/zyppflags.cc
@@ -410,7 +410,7 @@ int parseCLI( const int argc, char * const *argv, const std::vector<CommandGroup
           }
 
           if ( !conflictingList.empty() ) {
-            for ( const std::string conflicting : conflictingList ){
+            for ( const std::string &conflicting : conflictingList ){
               auto it = longOptIndex.find( conflicting );
               if ( it == longOptIndex.end() ) {
                 WAR << "Ignoring unknown option " << conflicting << " specified as conflicting flag for " << opt.name << endl;


### PR DESCRIPTION
Fix the following warning observed on g++ (GCC) 11.1.0

```
[ 96%] Building CXX object src/CMakeFiles/zypper_lib.dir/utils/flags/zyppflags.cc.o
src/utils/flags/zyppflags.cc: In function ‘int zypp::ZyppFlags::parseCLI(int, char* const*, const std::vector<zypp::ZyppFlags::CommandGroup>&)’:
src/utils/flags/zyppflags.cc:413:37: warning: loop variable ‘conflicting’ creates a copy from type ‘const string’ {aka ‘const std::__cxx11::basic_string<char>’} [-Wrange-loop-construct]
  413 |             for ( const std::string conflicting : conflictingList ){
      |                                     ^~~~~~~~~~~
src/utils/flags/zyppflags.cc:413:37: note: use reference type to prevent copying
  413 |             for ( const std::string conflicting : conflictingList ){
      |                                     ^~~~~~~~~~~
      |                                     &
```