### PR TITLE
Allow auto import only for specific key

### DIFF
--- a/doc/zypper.8.txt
+++ b/doc/zypper.8.txt
@@ -1787,8 +1787,8 @@ Repository Options: :: {nop}
 *--no-gpg-checks*::
 	Ignore GPG check failures and continue. If a GPG issue occurs when using this option zypper prints and logs a warning and automatically continues without interrupting the operation. Use this option with caution, as you can easily overlook security problems by using it. (see section *GPG checks*)
 
-*--gpg-auto-import-keys*::
-	If new repository signing key is found, do not ask what to do; trust and import it automatically. This option causes that the new key is imported also in non-interactive mode, where it would otherwise got rejected.
+*--gpg-auto-import-keys* _KEY_ID_::
+	If the specified repository signing key is found, do not ask what to do; trust and import it automatically. This option causes that the new key is imported also in non-interactive mode, where it would otherwise got rejected. The KEY_ID argument is optional; when left unspecified, any repository signing key which is found will be trusted and imported automatically. You can specify this option multiple times.
 
 *-p*, *--plus-repo* _URI_::
 	Use an additional repository for this operation. The repository aliased tmp# and named by the specified URI will be added for this operation and removed at the end. You can specify this option multiple times.

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -297,6 +297,7 @@ Config::Config()
   , reboot_req_non_interactive( false )
   , no_gpg_checks( false )
   , gpg_auto_import_keys( false )
+  , gpg_auto_import_key_id( "" )
   , machine_readable( false )
   , no_refresh( false )
   , no_cd( false )
@@ -569,6 +570,18 @@ std::vector<ZyppFlags::CommandGroup> Config::cliOptions()
               })),
               // translators: --gpg-auto-import-keys
               _("Automatically trust and import new repository signing keys.")
+        },
+        { "gpg-auto-import-key-id", 0, ZyppFlags::RequiredArgument, std::move( ZyppFlags::StringType( &gpg_auto_import_key_id, "", "KEY_ID").
+            after( [](const ZyppFlags::CommandOption &, const boost::optional<std::string> & key_id) {
+              std::string warn = str::form(
+                  _("Turning on '%s' for key id '%s'. The specified signing key will be automatically imported if present!"),
+                  "--gpg-auto-import-key-id",
+                  key_id->c_str());
+              Zypper::instance().out().warning( warn, Out::HIGH );
+              MIL << "gpg-auto-import-key-id is on for " << *key_id << endl;
+            })),
+            // translators: --gpg-auto-import-key-id
+            _("Automatically trust and import the specified repository signing key, if it is present.")
         },
         { "plus-repo", 'p', ZyppFlags::Repeatable | ZyppFlags::RequiredArgument, ZyppFlags::GenericContainerType( plusRepoFromCLI, ARG_URI ),
               // translators: --plus-repo, -p <URI>

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -10,11 +10,11 @@ extern "C"
   #include <libintl.h>
 }
 #include <iostream>
-#include <boost/algorithm/string.hpp>
 
 #include <zypp/base/Logger.h>
 #include <zypp/base/Measure.h>
 #include <zypp/base/String.h>
+#include <zypp/base/StringV.h>
 #include <zypp/base/Exception.h>
 #include <zypp/ZConfig.h>
 
@@ -560,10 +560,14 @@ std::vector<ZyppFlags::CommandGroup> Config::cliOptions()
               _("Ignore GPG check failures and continue.")
         },
         { "gpg-auto-import-keys", 0, ZyppFlags::OptionalArgument | ZyppFlags::Repeatable, std::move( ZyppFlags::GenericContainerType( gpg_auto_import_keys, ARG_KEY_ID, ",", "*" ).
-              after( [this](const ZyppFlags::CommandOption &, const boost::optional<std::string> & arg) {
+              after( [](const ZyppFlags::CommandOption &, const boost::optional<std::string> & arg) {
                 if (arg.has_value()) {
                   std::vector<std::string> key_ids;
-                  boost::split(key_ids, *arg, boost::is_any_of(","));
+                  strv::splitRx(*arg, ",", [&key_ids]( std::string_view key_id ) {
+                    if ( ! key_id.empty() )
+                      key_ids.push_back( std::string(key_id) );
+                  });
+
                   for (const std::string& key_id : key_ids) {
                     std::string warn = str::form(
                         _("Turning on '%s' for key id '%s'. This signing key will be automatically imported if present!"),

--- a/src/Config.h
+++ b/src/Config.h
@@ -94,8 +94,7 @@ struct Config
   bool non_interactive;
   bool reboot_req_non_interactive;
   bool no_gpg_checks;
-  bool gpg_auto_import_keys;
-  std::string gpg_auto_import_key_id;
+  std::vector<std::string> gpg_auto_import_keys;
   bool machine_readable;
   /** Whether to disable autorefresh. */
   bool no_refresh;

--- a/src/Config.h
+++ b/src/Config.h
@@ -95,6 +95,7 @@ struct Config
   bool reboot_req_non_interactive;
   bool no_gpg_checks;
   bool gpg_auto_import_keys;
+  std::string gpg_auto_import_key_id;
   bool machine_readable;
   /** Whether to disable autorefresh. */
   bool no_refresh;

--- a/src/callbacks/keyring.h
+++ b/src/callbacks/keyring.h
@@ -273,8 +273,9 @@ namespace zypp
         // gpg key info
         dumpKeyInfo( s << std::endl, key_r, context_r )  << std::endl;
 
-        // if --gpg-auto-import-keys or --no-gpg-checks print info and don't ask
-        if (_gopts.gpg_auto_import_keys)
+        // if --gpg-auto-import-keys, --no-gpg-check, or --gpg-auto-import-key-id matches key, print info and don't ask.
+        if (_gopts.gpg_auto_import_keys
+            || (!_gopts.gpg_auto_import_key_id.empty() && _gopts.gpg_auto_import_key_id == key_r.id()))
         {
           MIL << "Automatically importing key " << key_r << std::endl;
           zypper.out().info(s.str());

--- a/src/utils/flags/flagtypes.h
+++ b/src/utils/flags/flagtypes.h
@@ -112,9 +112,16 @@ template <>
 int argValueConvert ( const CommandOption &, const boost::optional<std::string> &in );
 
 template <template<typename ...> class Container, typename T >
-Value GenericContainerType  ( Container<T> &target_r, std::string hint = std::string(), const std::string sep = "" ) {
+Value GenericContainerType  ( Container<T> &target_r, std::string hint = std::string(), const std::string &sep = "", const std::string &defaultVal = std::string() ) {
+  DefValueFun defValueFun;
+  if (!defaultVal.empty()) {
+    defValueFun = [defaultVal]() { return boost::optional<std::string>(defaultVal); };
+  }
+  else {
+    defValueFun = noDefaultValue;
+  }
   return Value (
-    noDefaultValue,
+    std::move( defValueFun ),
     [ &target_r, sep ] ( const CommandOption &opt, const boost::optional<std::string> &in ) {
       if ( !in ) ZYPP_THROW(MissingArgumentException(opt.name)); //value required
 

--- a/src/utils/flags/zyppflags.h
+++ b/src/utils/flags/zyppflags.h
@@ -48,6 +48,8 @@
 // translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
 #define ARG_URI                _( "URI" )
 // translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
+#define ARG_KEY_ID             _( "KEY_ID" )
+// translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
 #define ARG_YYYY_MM_DD         _( "YYYY-MM-DD" )
 // translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
 #define ARG_MODE               _( "MODE" )


### PR DESCRIPTION
Implemented a new command option "--gpg-auto-import-key-id" which allows users to only auto-import a GPG key with the provided key ID. This was done in response to a feature request in [issue 401](https://github.com/openSUSE/zypper/issues/401).