### PR TITLE
Some enhancements around reporting (traditional rpm and singletrans)

### DIFF
--- a/src/CommitSummary.cc
+++ b/src/CommitSummary.cc
@@ -128,7 +128,7 @@ void CommitSummary::writeFailedInstalls( std::ostream & out )
 
   label = str::form( label.c_str(), _failedInstalls.size() );
 
-  out << endl << ( ColorContext::HIGHLIGHT << label ) << endl;
+  out << endl << ( ColorContext::MSG_ERROR << label ) << endl;
   writeResolvableList( out, _failedInstalls, ColorContext::NEGATIVE );
 }
 
@@ -143,7 +143,7 @@ void CommitSummary::writeSkippedInstalls( std::ostream & out )
 
   label = str::form( label.c_str(), _failedInstalls.size() );
 
-  out << endl << ( ColorContext::HIGHLIGHT << label ) << endl;
+  out << endl << ( ColorContext::MSG_WARNING << label ) << endl;
   writeResolvableList( out, _skippedInstalls, ColorContext::NEGATIVE );
 }
 
@@ -158,7 +158,7 @@ void CommitSummary::writeFailedRemovals( std::ostream & out )
 
   label = str::form( label.c_str(), _failedInstalls.size() );
 
-  out << endl << ( ColorContext::HIGHLIGHT << label ) << endl;
+  out << endl << ( ColorContext::MSG_ERROR << label ) << endl;
   writeResolvableList( out, _failedRemovals, ColorContext::NEGATIVE );
 }
 
@@ -173,7 +173,7 @@ void CommitSummary::writeSkippedRemovals( std::ostream & out )
 
   label = str::form( label.c_str(), _failedInstalls.size() );
 
-  out << endl << ( ColorContext::HIGHLIGHT << label ) << endl;
+  out << endl << ( ColorContext::MSG_WARNING << label ) << endl;
   writeResolvableList( out, _skippedRemovals, ColorContext::NEGATIVE );
 }
 

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -131,19 +131,11 @@ namespace
     return ret;
   }
 
-  void setColorForOut ( const bool &set )
-  {
-    OutNormal *currOut = dynamic_cast<OutNormal *>( Zypper::instance().outputWriter() );
-    if ( currOut )
-      currOut->setUseColors( set );
-  }
+  void setColorForOut ( bool yesno_r )
+  { Zypper::instance().out().setUseColors( yesno_r ); }
 
-  void setOutVerbosity ( Out::Verbosity verb )
-  {
-    Out *currOut = Zypper::instance().outputWriter();
-    if ( currOut )
-      currOut->setVerbosity( verb );
-  }
+  void setOutVerbosity ( Out::Verbosity verb_r )
+  { Zypper::instance().out().setVerbosity( verb_r ); }
 } // namespace
 //////////////////////////////////////////////////////////////////
 

--- a/src/Zypper.h
+++ b/src/Zypper.h
@@ -142,8 +142,6 @@ public:
 
   // setters & getters
   Out & out();
-
-  Out *outputWriter ( );
   void setOutputWriter( Out * out );
 
   const Config & config()				{ return _config; }

--- a/src/callbacks/job.h
+++ b/src/callbacks/job.h
@@ -28,6 +28,8 @@ namespace ZmartRecipients
   {
     virtual bool message( MsgType type_r, const std::string & msg_r, const UserData & userData_r ) const
     {
+      static const JobReport::UserData::ContentType rpmPosttrans { "cmdout", "%posttrans" };
+
       Out & out( Zypper::instance().out() );
       switch ( type_r.asEnum() )
       {
@@ -36,9 +38,13 @@ namespace ZmartRecipients
           break;
 
         case MsgType::info:
-          if ( userData_r.type().type() == "cmdout" )
+          if ( userData_r.type() == rpmPosttrans )
           {
-            // Render command output (like %posttrans) highlighted
+            processAdditionalRpmOutput( msg_r );
+          }
+          else if ( userData_r.type().type() == "cmdout" )
+          {
+            // Render command output highlighted
             out.info( HIGHLIGHTString(msg_r).str() );
           }
           else

--- a/src/main.cc
+++ b/src/main.cc
@@ -126,17 +126,15 @@ int main( int argc, char **argv )
 
   MIL << "===== Hi, me zypper " VERSION << endl;
   dumpRange( MIL, argv, argv+argc, (sudo ? "===== 'sudo' ": "===== "), "'", "' '", "'", " =====" ) << endl;
-
-  OutNormal out( Out::QUIET );
-
+  Zypper & zypper( Zypper::instance() );
 
   if ( ::signal( SIGINT, signal_handler ) == SIG_ERR )
-    out.error("Failed to set SIGINT handler.");
+    zypper.out().error("Failed to set SIGINT handler.");
   if ( ::signal (SIGTERM, signal_handler ) == SIG_ERR )
-    out.error("Failed to set SIGTERM handler.");
+    zypper.out().error("Failed to set SIGTERM handler.");
 
   if ( ::signal( SIGPIPE, signal_nopipe ) == SIG_ERR )
-    out.error("Failed to set SIGPIPE handler.");
+    zypper.out().error("Failed to set SIGPIPE handler.");
 
   try
   {
@@ -151,19 +149,18 @@ int main( int argc, char **argv )
   catch ( const Exception & e )
   {
     ZYPP_CAUGHT( e );
-    out.error( e, "Failed to initialize zypper callbacks." );
-    report_a_bug( out );
+    zypper.out().error( e, "Failed to initialize zypper callbacks." );
+    report_a_bug( zypper.out() );
     return ZYPPER_EXIT_ERR_BUG;
   }
   catch (...)
   {
-    out.error( "Failed to initialize zypper callbacks." );
+    zypper.out().error( "Failed to initialize zypper callbacks." );
     ERR << "Failed to initialize zypper callbacks." << endl;
-    report_a_bug( out );
+    report_a_bug( zypper.out() );
     return ZYPPER_EXIT_ERR_BUG;
   }
 
-  Zypper & zypper( Zypper::instance() );
   int & exitcode { say_goodbye.exitcode };
   exitcode = zypper.main( argc, argv );
   if ( !exitcode )

--- a/src/output/Out.cc
+++ b/src/output/Out.cc
@@ -116,6 +116,19 @@ void Out::searchResult( const Table & table_r )
   std::cout << table_r;
 }
 
+void Out::progressEnd( const std::string & id, const std::string & label, ProgressEnd donetag_r )
+{
+  // translator: Shown as result tag in a progress bar: ............[done]
+  static const std::string done      { _("done") };
+  // translator: Shown as result tag in a progress bar: .......[attention]
+  static const std::string attention { MSG_WARNINGString(_("attention")).str() };
+  // translator: Shown as result tag in a progress bar: ...........[error]
+  static const std::string error     { MSG_ERRORString(_("error")).str() };
+
+  const std::string & donetag { donetag_r==ProgressEnd::done ? done : donetag_r==ProgressEnd::error ? error : attention };
+  progressEnd( id, label, donetag, donetag_r==ProgressEnd::error );
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 //	class Out::Error
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/output/Out.h
+++ b/src/output/Out.h
@@ -872,6 +872,8 @@ public:
     return DtorReset( _verbosity, verbosity_r );
   }
 
+  /** Hint for a handler whether config would allow to use colors. */
+  virtual void setUseColors( bool yesno ) {}
 
 public:
   /** Return the type of the instance. */

--- a/src/output/OutNormal.cc
+++ b/src/output/OutNormal.cc
@@ -201,7 +201,7 @@ void OutNormal::progress( const std::string & id, const std::string & label, int
   _newline = false;
 }
 
-void OutNormal::progressEnd( const std::string & id, const std::string & label, bool error )
+void OutNormal::progressEnd( const std::string & id, const std::string & label, const std::string & donetag, bool error )
 {
   if ( progressFilter() )
     return;
@@ -221,15 +221,10 @@ void OutNormal::progressEnd( const std::string & id, const std::string & label, 
 
     outstr.lhs << label << ' ';
     outstr.rhs << '[';
-    if ( error )
-      outstr.rhs << NEGATIVEString(_("error") );
-    else
-      outstr.rhs << _("done");
   }
-  else
-    outstr.rhs << (error ? _("error") : _("done"));
+  // else: just write the donetag
 
-  outstr.rhs << ']';
+  outstr.rhs << donetag << ']';
 
   std::string outline( outstr.get( termwidth() ) );
   cout << outline << endl << std::flush;

--- a/src/output/OutNormal.cc
+++ b/src/output/OutNormal.cc
@@ -49,13 +49,19 @@ bool OutNormal::infoWarningFilter( Verbosity verbosity_r, Type mask )
   return false;
 }
 
+void OutNormal::fixupProgressNL()
+{
+  if ( !_newline )  // An active Progress bar is not NL terminated
+    cout << ansi::tty::clearLN; // Wipe it before writing out a normal line to the screen
+    // Alternative : cout << endl; to Keep the progress bar visible.
+}
+
 void OutNormal::info( const std::string & msg_r, Verbosity verbosity_r, Type mask )
 {
   if ( infoWarningFilter( verbosity_r, mask ) )
     return;
 
-  if ( !_newline )
-    cout << endl;
+  fixupProgressNL();
 
   ColorString msg( msg_r, ColorContext::MSG_STATUS );
   if ( verbosity_r == Out::QUIET )
@@ -75,8 +81,7 @@ void OutNormal::warning( const std::string & msg, Verbosity verbosity_r, Type ma
   if ( infoWarningFilter( verbosity_r, mask ) )
     return;
 
-  if ( !_newline )
-    cout << endl;
+  fixupProgressNL();
 
   cout << ( ColorContext::MSG_WARNING << _("Warning: ") ) << msg << endl;
   _newline = true;
@@ -84,8 +89,7 @@ void OutNormal::warning( const std::string & msg, Verbosity verbosity_r, Type ma
 
 void OutNormal::error( const std::string & problem_desc, const std::string & hint )
 {
-  if ( !_newline )
-    cout << endl;
+  fixupProgressNL();
 
   cerr << ( ColorContext::MSG_ERROR << problem_desc );
   if ( !hint.empty() && verbosity() > Out::QUIET )
@@ -98,8 +102,7 @@ void OutNormal::error( const std::string & problem_desc, const std::string & hin
 
 void OutNormal::error( const Exception & e, const std::string & problem_desc, const std::string & hint )
 {
-  if ( !_newline )
-    cout << endl;
+  fixupProgressNL();
 
   // problem and cause
   cerr << ( ColorContext::MSG_ERROR << problem_desc << endl << zyppExceptionReport(e) ) << endl;
@@ -352,8 +355,7 @@ void OutNormal::dwnldProgressEnd( const Url & uri, long rate, TriBool error )
 
 void OutNormal::prompt( PromptId id, const std::string & prompt, const PromptOptions & poptions, const std::string & startdesc )
 {
-  if ( !_newline )
-    cout << endl;
+  fixupProgressNL();
 
   if ( startdesc.empty() )
   {

--- a/src/output/OutNormal.h
+++ b/src/output/OutNormal.h
@@ -16,72 +16,37 @@ class OutNormal : public Out
 {
 public:
   OutNormal(Verbosity verbosity = NORMAL);
-  virtual ~OutNormal();
+  ~OutNormal() override;
 
 public:
-  /**
-   * Prints \a msg to the standard output and appends a newline.
-   *
-   *  \see Out::info()
-   */
-  virtual void info(const std::string & msg, Verbosity verbosity = NORMAL, Type mask = TYPE_ALL);
-
-  /**
-   * Prints info message optionally trunkated or expanded.
-   */
-  virtual void infoLine(const TermLine & msg, Verbosity verbosity = NORMAL, Type mask = TYPE_ALL);
-
-  /**
-   * Prints \a msg prepended with <tt>"Warning: "</tt> to the standard output
-   * and appends a newline.
-   *
-   * \see Out::warning
-   */
-  virtual void warning(const std::string & msg, Verbosity verbosity = NORMAL, Type mask = TYPE_ALL);
-
-  /**
-   *
-   */
-  virtual void error(const std::string & problem_desc, const std::string & hint = "");
-  virtual void error(const Exception & e,
-             const std::string & problem_desc,
-             const std::string & hint = "");
+  void info( const std::string & msg, Verbosity verbosity, Type mask ) override;
+  void infoLine( const TermLine & msg, Verbosity verbosity, Type mask ) override;
+  void warning( const std::string & msg, Verbosity verbosity, Type mask ) override;
+  void error( const std::string & problem_desc, const std::string & hint ) override;
+  void error( const Exception & e, const std::string & problem_desc, const std::string & hint ) override;
 
   // progress
-  virtual void progressStart(const std::string & id,
-                             const std::string & label,
-                             bool is_tick = false);
-  virtual void progress(const std::string & id,
-                        const std::string & label,
-                        int value = -1);
-  virtual void progressEnd(const std::string & id,
-                           const std::string & label,
-                           bool error);
+  void progressStart( const std::string & id, const std::string & label, bool is_tick ) override;
+  void progress( const std::string & id, const std::string & label, int value ) override;
+  void progressEnd( const std::string & id, const std::string & label, const std::string & donetag, bool error) override;
 
   // progress with download rate
-  virtual void dwnldProgressStart(const Url & uri);
-  virtual void dwnldProgress(const Url & uri,
-                             int value = -1,
-                             long rate = -1);
-  virtual void dwnldProgressEnd(const Url & uri,
-                                long rate = -1,
-                                TriBool error = false);
+  void dwnldProgressStart( const Url & uri ) override;
+  void dwnldProgress( const Url & uri, int value, long rate ) override;
+  void dwnldProgressEnd( const Url & uri, long rate, TriBool error ) override;
 
-  virtual void prompt(PromptId id,
-                      const std::string & prompt,
-                      const PromptOptions & poptions,
-                      const std::string & startdesc = "");
+  void prompt( PromptId id, const std::string & prompt, const PromptOptions & poptions, const std::string & startdesc ) override;
 
-  virtual void promptHelp(const PromptOptions & poptions);
+  void promptHelp( const PromptOptions & poptions ) override;
 
   void setUseColors( bool value ) override
   { _use_colors = value; }
 
 protected:
-  virtual bool mine(Type type);
+  bool mine( Type type ) override;
 
   /* Return current terminal width or 'unsigned(-1)' when failed */
-  virtual unsigned termwidth() const;
+  unsigned termwidth() const override;
 
 private:
   bool infoWarningFilter(Verbosity verbosity, Type mask);

--- a/src/output/OutNormal.h
+++ b/src/output/OutNormal.h
@@ -85,6 +85,7 @@ protected:
 
 private:
   bool infoWarningFilter(Verbosity verbosity, Type mask);
+  void fixupProgressNL(); //< Make sure we're at BOL even if a ProgressBar is active
   void displayProgress(const std::string & s, int percent);
   void displayTick(const std::string & s);
 

--- a/src/output/OutNormal.h
+++ b/src/output/OutNormal.h
@@ -74,7 +74,7 @@ public:
 
   virtual void promptHelp(const PromptOptions & poptions);
 
-  void setUseColors(bool value)
+  void setUseColors( bool value ) override
   { _use_colors = value; }
 
 protected:

--- a/src/output/OutXML.cc
+++ b/src/output/OutXML.cc
@@ -113,7 +113,7 @@ void OutXML::progress( const std::string & id, const std::string& label, int val
   writeProgressTag( id, label, value, false );
 }
 
-void OutXML::progressEnd( const std::string & id, const std::string& label, bool error )
+void OutXML::progressEnd( const std::string & id, const std::string& label, const std::string & /*donetag*/, bool error )
 {
   if ( progressFilter() )
     return;

--- a/src/output/OutXML.h
+++ b/src/output/OutXML.h
@@ -6,54 +6,37 @@
 class OutXML : public Out
 {
 public:
-  OutXML(Verbosity verbosity = NORMAL);
-  virtual ~OutXML();
+  OutXML( Verbosity verbosity );
+  ~OutXML() override;
 
 public:
-  virtual void info(const std::string & msg, Verbosity verbosity = NORMAL, Type mask = TYPE_ALL);
-  virtual void warning(const std::string & msg, Verbosity verbosity = NORMAL, Type mask = TYPE_ALL);
-  virtual void error(const std::string & problem_desc, const std::string & hint = "");
-  virtual void error(const Exception & e,
-             const std::string & problem_desc,
-             const std::string & hint = "");
+  void info( const std::string & msg, Verbosity verbosity, Type mask ) override;
+  void warning( const std::string & msg, Verbosity verbosity, Type mask ) override;
+  void error( const std::string & problem_desc, const std::string & hint ) override;
+  void error( const Exception & e, const std::string & problem_desc, const std::string & hint ) override;
 
   // progress
-  virtual void progressStart(const std::string & id,
-                             const std::string & label,
-                             bool is_tick = false);
-  virtual void progress(const std::string & id,
-                        const std::string & label,
-                        int value = -1);
-  virtual void progressEnd(const std::string & id,
-                           const std::string & label,
-                           bool error);
+  void progressStart( const std::string & id, const std::string & label, bool is_tick ) override;
+  void progress( const std::string & id, const std::string & label, int value ) override;
+  void progressEnd( const std::string & id, const std::string & label, const std::string & donetag, bool error ) override;
 
   // progress with download rate
-  virtual void dwnldProgressStart(const Url & uri);
-  virtual void dwnldProgress(const Url & uri,
-                             int value = -1,
-                             long rate = -1);
-  virtual void dwnldProgressEnd(const Url & uri,
-                                long rate = -1,
-                                TriBool error = false);
+  void dwnldProgressStart( const Url & uri ) override;
+  void dwnldProgress( const Url & uri, int value, long rate ) override;
+  void dwnldProgressEnd( const Url & uri, long rate, TriBool error ) override;
 
-  virtual void searchResult( const Table & table_r );
+  void searchResult( const Table & table_r ) override;
 
-  virtual void prompt(PromptId id,
-                      const std::string & prompt,
-                      const PromptOptions & poptions,
-                      const std::string & startdesc = "");
+  void prompt( PromptId id, const std::string & prompt, const PromptOptions & poptions, const std::string & startdesc ) override;
 
-  virtual void promptHelp(const PromptOptions & poptions);
+  void promptHelp( const PromptOptions & poptions ) override;
 
 protected:
-  virtual bool mine(Type type);
+  bool mine( Type type ) override;
 
 private:
-  bool infoWarningFilter(Verbosity verbosity, Type mask);
-  void writeProgressTag(const std::string & id,
-                        const std::string & label,
-                        int value, bool done, bool error = false);
+  bool infoWarningFilter( Verbosity verbosity, Type mask );
+  void writeProgressTag( const std::string & id, const std::string & label, int value, bool done, bool error = false );
 };
 
 #endif /*OUTXML_H_*/

--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -26,7 +26,7 @@ BuildRequires:  boost-devel >= 1.33.1
 BuildRequires:  cmake >= 3.1
 BuildRequires:  gcc-c++ >= 7
 BuildRequires:  gettext-devel >= 0.15
-BuildRequires:  libzypp-devel >= 17.28.3
+BuildRequires:  libzypp-devel >= 17.29.0
 BuildRequires:  readline-devel >= 5.1
 BuildRequires:  libxml2-devel
 Requires:       procps


### PR DESCRIPTION
Rpm script output in all modes should now become immediately visible. In singletrans mode non-fatal erros (like failing %post script) will be properly indicated by the progressbars and also provide the correct exit code (107 - ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED). 