### PR TITLE
Translation Typo

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -164,7 +164,7 @@ msgstr ""
 #: src/Config.cc:377
 msgid "User defined transaction id used in history and plugins."
 msgstr ""
-"tBenutzerdefinierte Transaktions-ID, die in der Historie und Plugins benutzt "
+"Benutzerdefinierte Transaktions-ID, die in der Historie und Plugins benutzt "
 "wird."
 
 #. translators: --quiet, -q


### PR DESCRIPTION
Remove errorneous t in German translation.

Yesterday, I switched to GeckoLinux ROLLING Mate and configured it for German locale.
Today, I noticed a small error in the help output of zypper and looked into submitting a patch.

I took a look at https://en.opensuse.org/openSUSE:Zypper_development but couldn't find a `trunk` branch.
According to https://github.com/openSUSE/zypper/pulls PRs seem to be opened against `master`, so I hope this is correct.
Looking at https://github.com/openSUSE/zypper/commits/master I can see something about Weblate used for translations, but I wasn't able to discover an URL, so please point me to it in case that's used instead.

Tagging @skriesch as she is the last one listed in `de.po` as localisation team. (as of https://github.com/openSUSE/zypper/pull/103 ?)