### PR TITLE
Moved logrotate files from user specif directory /etc/logrotate.d to …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ INCLUDE(ZyppCommon)
 OPTION (ENABLE_BUILD_TRANS "Build translation files by default?" ON)
 OPTION (ENABLE_BUILD_TESTS "Build and run test suite by default?" OFF)
 
+#Vendor specific directory
+SET( DISTCONFDIR "/usr/etc")
+ADD_DEFINITIONS( -DDISTCONFDIR="${DISTCONFDIR}" )
+
 # VERSION
 INCLUDE( ${ZYPPER_SOURCE_DIR}/VERSION.cmake )
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -279,7 +279,7 @@ INSTALL(
 # logrotate config file
 INSTALL(
   FILES zypper.lr zypp-refresh.lr
-  DESTINATION ${SYSCONFDIR}/logrotate.d
+  DESTINATION ${DISTCONFDIR}/logrotate.d
 )
 
 # augeas lens

--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -134,6 +134,7 @@ CMAKE_FLAGS=
 cmake $CMAKE_FLAGS \
       -DCMAKE_INSTALL_PREFIX=%{_prefix} \
       -DSYSCONFDIR=%{_sysconfdir} \
+      -DDISTCONFDIR=%{_distconfdir} \
       -DMANDIR=%{_mandir} \
       -DCMAKE_VERBOSE_MAKEFILE=TRUE \
       -DCMAKE_C_FLAGS_RELEASE:STRING="$RPM_OPT_FLAGS" \
@@ -175,8 +176,9 @@ rm -rf "$RPM_BUILD_ROOT"
 %license COPYING
 %endif
 %config(noreplace) %{_sysconfdir}/zypp/zypper.conf
-%config(noreplace) %{_sysconfdir}/logrotate.d/zypper.lr
-%config(noreplace) %{_sysconfdir}/logrotate.d/zypp-refresh.lr
+%dir %{_distconfdir}/logrotate.d
+%{_distconfdir}/logrotate.d/zypper.lr
+%{_distconfdir}/logrotate.d/zypp-refresh.lr
 %{_sysconfdir}/bash_completion.d/zypper.sh
 %{_bindir}/zypper
 %{_bindir}/yzpper


### PR DESCRIPTION
…vendor specif directory /usr/etc/logrotate.d.

So, users changes can still be done in /etc and will not be overwritten by an update.

Logrotate supports /usr/etc now. /etc should only be used for individual changes from the admin