### PR TITLE
zypper-download: Handle unresolvable arguments as error

### DIFF
--- a/src/commands/utils/download.cc
+++ b/src/commands/utils/download.cc
@@ -236,7 +236,7 @@ int DownloadCmd::execute( Zypper &zypper , const std::vector<std::string> &posit
       {
         // translators: Label text; is followed by ': cmdline argument'
         zypper.out().error( str::Str() << _("Argument resolves to no package") << ": " << pkgspec.orig_str );
-        zypper.setExitCode( ZYPPER_EXIT_INF_CAP_NOT_FOUND );
+        zypper.setExitInfoCode( ZYPPER_EXIT_INF_CAP_NOT_FOUND );
         continue;
       }
 
@@ -252,7 +252,7 @@ int DownloadCmd::execute( Zypper &zypper , const std::vector<std::string> &posit
     if ( collect.empty() )
     {
       zypper.out().info( _("Nothing to do.") );
-      return zypper.exitCode();
+      return ZYPPER_EXIT_OK;
     }
 
     unsigned total = 0;
@@ -343,5 +343,5 @@ int DownloadCmd::execute( Zypper &zypper , const std::vector<std::string> &posit
           break;	// first==best version only.
       }
     }
-    return zypper.exitCode();
+    return ZYPPER_EXIT_OK;
 }

--- a/src/commands/utils/download.cc
+++ b/src/commands/utils/download.cc
@@ -235,7 +235,8 @@ int DownloadCmd::execute( Zypper &zypper , const std::vector<std::string> &posit
       if ( q.empty() || !isPackageType( *q.begin() ) )
       {
         // translators: Label text; is followed by ': cmdline argument'
-        zypper.out().warning( str::Str() << _("Argument resolves to no package") << ": " << pkgspec.orig_str );
+        zypper.out().error( str::Str() << _("Argument resolves to no package") << ": " << pkgspec.orig_str );
+        zypper.setExitCode( ZYPPER_EXIT_INF_CAP_NOT_FOUND );
         continue;
       }
 
@@ -251,7 +252,7 @@ int DownloadCmd::execute( Zypper &zypper , const std::vector<std::string> &posit
     if ( collect.empty() )
     {
       zypper.out().info( _("Nothing to do.") );
-      return ZYPPER_EXIT_OK;
+      return zypper.exitCode();
     }
 
     unsigned total = 0;
@@ -342,5 +343,5 @@ int DownloadCmd::execute( Zypper &zypper , const std::vector<std::string> &posit
           break;	// first==best version only.
       }
     }
-    return ZYPPER_EXIT_OK;
+    return zypper.exitCode();
 }


### PR DESCRIPTION
This commit changes `zypper-download` such that it behaves more consistent to
`zypper-install` when an argument can't be resolved.

When an argument provided to `zypper-install` can't be resolved to a package, it
prints an error message and exits with `ZYPPER_EXIT_INF_CAP_NOT_FOUND` after
trying to install the remaining packages. In contrast, when `zypper-download`
fails to resolve a package name, it prints a warning, downloads the remaining
packages and exits with `ZYPPER_EXIT_OK`. This behaviour is inconsistent and
makes it unneccessarily difficult to determine, whether all requested packages
have been downloaded by `zypper-download`, e.g., in automation scenarios.

With this change, `zypper-download` now returns `ZYPPER_EXIT_INF_CAP_NOT_FOUND`
instead of `ZYPPER_EXIT_OK` if any argument could not be resolved to a package.