### PR TITLE
Update cs.po with the mice instead of hedgehog

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -2892,9 +2892,9 @@ msgid ""
 "  \\\\\\\\\\\\\\__o\n"
 "__\\\\\\\\\\\\\\'/_"
 msgstr ""
-"   \\\\\\\\\\\n"
-"  \\\\\\\\\\\\\\__o\n"
-"__\\\\\\\\\\\\\\'/_"
+"  (o)(o)--."
+"   \oo/ (  )"
+"   m\/m--m'`--------."
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/nullcommands.cc:37


### PR DESCRIPTION
Apodemus uralensis cimrmani  is one and only endemic taxon vertebrate animal in the Czech republic, so it should be in the Czech translation instead of the hedgehog