### PR TITLE
Zypper serviceadd fails on idempotency check

### DIFF
--- a/doc/zypper.8.txt
+++ b/doc/zypper.8.txt
@@ -1338,7 +1338,7 @@ The *services*, *addservice*, *removeservice*, *modifyservice*, and *refresh-ser
 Standalone repositories (not belonging to any service) are treated like services, too. The *ls* command will list them, *ms* command will modify them, etc. Repository specific options, like *--keep-packages* are not available here, though. You can use repository handling commands to manipulate them.
 
 *addservice* (*as*) [_options_] _URI_ _alias_::
-	Adds a service specified by *URI* to the system. The _alias_ must be unique and serves to identify the service.
+	Adds a service specified by *URI* to the system. The _alias_ must be unique and serves to identify the service. If a service with the _same alias and URI_ already exists, the command behaves like *modifyservice* and updates the settings accordingly.
 +
 Newly added services are not refreshed automatically. Use the *refresh-services* command to refresh them. Zypper does not access the service URI when adding the service, so the type of the services is unknown until it is refreshed.
 +

--- a/doc/zypper.8.txt
+++ b/doc/zypper.8.txt
@@ -1909,7 +1909,8 @@ This directory is used by all ZYpp-based applications.
 This directory is used by all ZYpp-based applications.
 
 */var/cache/zypp/packages*::
-	If *keeppackages* property is set for a repository (see the *modifyrepo* command), all the RPM file downloaded during installation will be kept here. See also the *clean* command for cleaning these cache directories.
+	If *keeppackages* property is set for a repository (see the *modifyrepo* command), all the RPM file downloaded during installation will be kept here. Packages are stored in subdirectories named after their repositories alias. Subdirectories of removed or otherwise unknown repositories are cleaned automatically. This auto-cleanup can be prevented by creating a file named *.no_auto_prune* in the pkg-cache directory.
+	See also the *clean* command for cleaning these cache directories.
 +
 This directory is used by all ZYpp-based applications.
 

--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -26,7 +26,7 @@ BuildRequires:  boost-devel >= 1.33.1
 BuildRequires:  cmake >= 3.1
 BuildRequires:  gcc-c++ >= 7
 BuildRequires:  gettext-devel >= 0.15
-BuildRequires:  libzypp-devel >= 17.31.2
+BuildRequires:  libzypp-devel >= 17.31.5
 BuildRequires:  readline-devel >= 5.1
 BuildRequires:  libxml2-devel
 Requires:       procps


### PR DESCRIPTION
[bsc#1203715](https://bugzilla.opensuse.org/show_bug.cgi?id=1203715)
(Plus the man page update for `.no_auto_prune`)