### PR TITLE
Progressbar fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -207,6 +207,7 @@ SET( zypper_utils_HEADERS
   utils/messages.h
   utils/misc.h
   utils/MultiParText.h
+  utils/Offering.h
   utils/pager.h
   utils/prompt.h
   utils/richtext.h

--- a/src/Zypper.h
+++ b/src/Zypper.h
@@ -27,6 +27,7 @@
 #include "Config.h"
 #include "Command.h"
 #include "utils/getopt.h"
+#include "utils/Offering.h"
 #include "output/Out.h"
 #include "Guardians.h"
 
@@ -60,8 +61,7 @@ inline std::string dashdash( std::string optname_r )
 struct RuntimeData
 {
   RuntimeData()
-  : show_media_progress_hack( false )
-  , force_resolution( indeterminate )
+  : force_resolution( indeterminate )
   , solve_update_only( false )
   , solve_with_update( false )
   , plain_patch_command( false )
@@ -89,9 +89,8 @@ struct RuntimeData
 
   std::set<SrcPackage::constPtr> srcpkgs_to_install;
 
-  // hack to enable media progress reporting in the commit phase in normal
-  // output level
-  bool show_media_progress_hack;
+  // Demand verbose media progress reporting (e.g. when downloading packages)
+  Offering scopedVerboseDownloadProgress;
 
   // Indicates an ongoing raw meta-data refresh.
   // If not empty call zypper.out().progress(

--- a/src/callbacks/media.h
+++ b/src/callbacks/media.h
@@ -98,7 +98,6 @@ namespace ZmartRecipients
 
     virtual void start( const Url & uri, Pathname localfile )
     {
-      _last_reported = time(NULL);
       _last_drate_avg = -1;
 
       Out & out = Zypper::instance().out();
@@ -123,13 +122,6 @@ namespace ZmartRecipients
 
     virtual bool progress(int value, const Url & uri, double drate_avg, double drate_now)
     {
-      // don't report more often than 1 second
-      time_t now = time(NULL);
-      if (now > _last_reported)
-        _last_reported = now;
-      else
-        return !Zypper::instance().exitRequested();
-
       Zypper & zypper( Zypper::instance() );
 
       if (zypper.exitRequested())
@@ -177,7 +169,6 @@ namespace ZmartRecipients
 
   private:
     bool _be_quiet;
-    time_t _last_reported;
     double _last_drate_avg;
   };
 

--- a/src/callbacks/media.h
+++ b/src/callbacks/media.h
@@ -145,8 +145,13 @@ namespace ZmartRecipients
     virtual DownloadProgressReport::Action
     problem( const Url & uri, DownloadProgressReport::Error error, const std::string & description )
     {
-      DBG << "media problem" << std::endl;
-      if (_be_quiet)
+      if ( error == DownloadProgressReport::NO_ERROR ) {
+        // NO_ERROR: just a report but let the caller proceed as appropriate...
+        Zypper::instance().out().info() << "- " << ( ColorContext::LOWLIGHT << description );
+        return DownloadProgressReport::IGNORE;
+      }
+
+      if ( not _be_quiet )
         Zypper::instance().out().dwnldProgressEnd(uri, _last_drate_avg, true);
       Zypper::instance().out().error(zcb_error2str(error, description));
 

--- a/src/callbacks/media.h
+++ b/src/callbacks/media.h
@@ -105,8 +105,8 @@ namespace ZmartRecipients
 
       if (out.verbosity() < Out::HIGH &&
            (
-             // don't show download info unless show_media_progress_hack is used
-             !Zypper::instance().runtimeData().show_media_progress_hack ||
+             // don't show download info unless scopedVerboseDownloadProgress is demanded
+             not Zypper::instance().runtimeData().scopedVerboseDownloadProgress.isDemanded() ||
              // don't report download of the media file (bnc #330614)
              Pathname(uri.getPathName()).basename() == "media"
            )

--- a/src/callbacks/repo.h
+++ b/src/callbacks/repo.h
@@ -103,15 +103,15 @@ struct DownloadResolvableReportReceiver : public callback::ReceiveReport<repo::D
     Zypper::instance().out().progressEnd("apply-delta", _label_apply_delta);
   }
 
-  void fillsRhs( TermLine & outstr_r, Zypper & zypper_r, Package::constPtr pkg_r )
+  void fillsRhs( TermLine & outstr_r, Zypper & zypper_r, Resolvable::constPtr res_r )
   {
     outstr_r.rhs << " (" << ++zypper_r.runtimeData().commit_pkg_current
                  << "/" << zypper_r.runtimeData().commit_pkgs_total << ")";
-    if ( pkg_r )
+    if ( res_r )
     {
-      outstr_r.rhs << ", " << pkg_r->downloadSize().asString( 5, 3 ) << " "
-                   // TranslatorExplanation %s is package size like "5.6 M"
-                   << str::Format(_("(%s unpacked)")) % pkg_r->installSize().asString( 5, 3 );
+      outstr_r.rhs << ", " << res_r->downloadSize().asString( 5, 3 ) << "    "/* indent `/s)]` of download speed line following */;
+      // TranslatorExplanation %s is package size like "5.6 M"
+      // outstr_r.rhs << " " << str::Format(_("(%s unpacked)")) % pkg_r->installSize().asString( 5, 3 );
     }
   }
 
@@ -121,7 +121,7 @@ struct DownloadResolvableReportReceiver : public callback::ReceiveReport<repo::D
 
     TermLine outstr( TermLine::SF_SPLIT | TermLine::SF_EXPAND );
     outstr.lhs << str::Format(_("In cache %1%")) % localfile_r.basename();
-    fillsRhs( outstr, zypper, asKind<Package>(res_r) );
+    fillsRhs( outstr, zypper, res_r );
     zypper.out().infoLine( outstr );
   }
 
@@ -136,11 +136,8 @@ struct DownloadResolvableReportReceiver : public callback::ReceiveReport<repo::D
     Zypper & zypper = Zypper::instance();
 
     TermLine outstr( TermLine::SF_SPLIT | TermLine::SF_EXPAND );
-    outstr.lhs << str::Format(_("Retrieving %s %s-%s.%s"))
-        % kind_to_string_localized(_resolvable_ptr->kind(), 1)
-        % _resolvable_ptr->name()
-        % _resolvable_ptr->edition() % _resolvable_ptr->arch();
-    fillsRhs( outstr, zypper, asKind<Package>(resolvable_ptr) );
+    outstr.lhs << _("Retrieving:") << " " << _resolvable_ptr-> asUserString();
+    fillsRhs( outstr, zypper, resolvable_ptr );
 
     // temporary fix for bnc #545295
     if ( zypper.runtimeData().commit_pkg_current == zypper.runtimeData().commit_pkgs_total )

--- a/src/callbacks/repo.h
+++ b/src/callbacks/repo.h
@@ -36,13 +36,15 @@ struct DownloadResolvableReportReceiver : public callback::ReceiveReport<repo::D
   Pathname _patch;
   ByteCount _patch_size;
 
+  Offering::ScopedDemand _demandVerboseDownloadProgress;
+
   void reportbegin() override
   {
-    Zypper::instance().runtimeData().show_media_progress_hack = true;
+    _demandVerboseDownloadProgress = Zypper::instance().runtimeData().scopedVerboseDownloadProgress.demand();
   }
   void reportend() override
   {
-    Zypper::instance().runtimeData().show_media_progress_hack = false;
+    _demandVerboseDownloadProgress.reset();
   }
 
   // Dowmload delta rpm:

--- a/src/callbacks/repo.h
+++ b/src/callbacks/repo.h
@@ -36,6 +36,15 @@ struct DownloadResolvableReportReceiver : public callback::ReceiveReport<repo::D
   Pathname _patch;
   ByteCount _patch_size;
 
+  void reportbegin() override
+  {
+    Zypper::instance().runtimeData().show_media_progress_hack = true;
+  }
+  void reportend() override
+  {
+    Zypper::instance().runtimeData().show_media_progress_hack = false;
+  }
+
   // Dowmload delta rpm:
   // - path below url reported on start()
   // - expected download size (0 if unknown)

--- a/src/commands/utils/download.cc
+++ b/src/commands/utils/download.cc
@@ -293,7 +293,6 @@ int DownloadCmd::execute( Zypper &zypper , const std::vector<std::string> &posit
             {
               Out::ProgressBar report( zypper.out(), Out::ProgressBar::noStartBar, pi.asUserString(), current, total );
               report.error(); // error if provideSrcPackage throws
-              Out::DownloadProgress redirect( report );
               localfile = packageCache.get( pi );
               report.error( false );
               report.print( cachedLocation( pi ).asString() );

--- a/src/commands/utils/source-download.cc
+++ b/src/commands/utils/source-download.cc
@@ -433,7 +433,6 @@ namespace Pimpl
           ManagedFile localfile;
           {
             report.error(); // error if provideSrcPackage throws
-            Out::DownloadProgress redirect( report );
             localfile = prov.provideSrcPackage( spkg._srcPackage->asKind<SrcPackage>() );
             DBG << localfile << endl;
             report.error( false );

--- a/src/output/Out.cc
+++ b/src/output/Out.cc
@@ -101,9 +101,7 @@ Out::~Out()
 
 bool Out::progressFilter()
 {
-  if (verbosity() < Out::NORMAL)
-      return true;
-  return false;
+  return verbosity() < Out::NORMAL;
 }
 
 std::string Out::zyppExceptionReport(const Exception & e)

--- a/src/output/Out.h
+++ b/src/output/Out.h
@@ -738,9 +738,6 @@ public:
   /** Convenience class for progress output. */
   class ProgressBar;
 
-  /** Convenience class for download progress output. */
-  struct DownloadProgress;
-
   /**
    * Start of an operation with reported progress.
    *
@@ -1103,76 +1100,6 @@ private:
   ProgressData _progress;
   std::string _progressId;
   std::string _labelPrefix;
-};
-///////////////////////////////////////////////////////////////////
-
-///////////////////////////////////////////////////////////////////
-/// \class Out::DownloadProgress
-/// \brief Listen on media::DownloadProgressReport to feed a ProgressBar.
-///
-/// Connect to media::DownloadProgressReport to feed a ProgressBar, but forward
-/// callbacks to any original receiver.
-///////////////////////////////////////////////////////////////////
-struct Out::DownloadProgress : public callback::ReceiveReport<media::DownloadProgressReport>
-{
-  DownloadProgress( Out::ProgressBar & progressbar_r )
-  : _progressbar( &progressbar_r )
-  , _oldReceiver( Distributor::instance().getReceiver() )
-  {
-    connect();
-  }
-
-  ~DownloadProgress()
-  {
-    if ( _oldReceiver )
-      Distributor::instance().setReceiver( *_oldReceiver );
-    else
-      Distributor::instance().noReceiver();
-  }
-
-  virtual void start( const Url & file, Pathname localfile )
-  {
-    (*_progressbar)->range( 100 );	// we'll receive %
-
-    if ( _oldReceiver )
-      _oldReceiver->start( file, localfile );
-  }
-
-  virtual bool progress( int value, const Url & file, double dbps_avg = -1, double dbps_current = -1 )
-  {
-    (*_progressbar)->set( value );
-
-    if ( _oldReceiver )
-      return _oldReceiver->progress( value, file, dbps_avg, dbps_current );
-    return true;
-  }
-
-  virtual Action problem( const Url & file, Error error, const std::string & description )
-  {
-    ERR << description << endl;
-
-    if ( _oldReceiver )
-      return _oldReceiver->problem( file, error, description );
-    return Receiver::problem( file, error, description );
-  }
-
-  virtual void finish( const Url & file, Error error, const std::string & reason )
-  {
-    if ( error == NO_ERROR )
-      (*_progressbar)->toMax();
-    else
-    {
-      ERR << reason << std::endl;
-      _progressbar->error();
-    }
-
-    if ( _oldReceiver )
-      _oldReceiver->finish( file, error, reason );
-  }
-
-private:
-  Out::ProgressBar * _progressbar;
-  Receiver * _oldReceiver;
 };
 ///////////////////////////////////////////////////////////////////
 

--- a/src/output/OutNormal.cc
+++ b/src/output/OutNormal.cc
@@ -259,7 +259,7 @@ void OutNormal::dwnldProgressStart( const Url & uri )
     outstr.rhs << '[' ;
 
   std::string outline( outstr.get( termwidth() ) );
-  cout << outline << PROGRESS_FLUSH;
+  cout << (ColorContext::HIGHLIGHT << outline) << PROGRESS_FLUSH;
   // no _oneup if CRUSHed // _oneup = (outline.length() > termwidth());
 
   _newline = false;
@@ -300,7 +300,7 @@ void OutNormal::dwnldProgress( const Url & uri, int value, long rate )
   outstr.rhs << ']';
 
   std::string outline( outstr.get( termwidth() ) );
-  cout << outline << PROGRESS_FLUSH;
+  cout << (ColorContext::HIGHLIGHT << outline) << PROGRESS_FLUSH;
   // no _oneup if CRUSHed // _oneup = (outline.length() > termwidth());
   _newline = false;
 }
@@ -314,34 +314,36 @@ void OutNormal::dwnldProgressEnd( const Url & uri, long rate, TriBool error )
     cout << ColorContext::MSG_STATUS;
 
   TermLine outstr( TermLine::SF_CRUSH | TermLine::SF_EXPAND, '.' );
+  ColorStream lhs { outstr.lhs.stream(), ColorContext::HIGHLIGHT };
+  ColorStream rhs { outstr.rhs.stream(), ColorContext::HIGHLIGHT };
   if ( _isatty )
   {
     if( _oneup )
       cout << ansi::tty::clearLN << ansi::tty::cursorUP;
     cout << ansi::tty::clearLN;
-    outstr.lhs << _("Retrieving:") << " ";
+    lhs << _("Retrieving:") << " ";
     if ( verbosity() == DEBUG )
-      outstr.lhs << uri;
+      lhs << uri;
     else
-      outstr.lhs << Pathname(uri.getPathName()).basename();
-    outstr.lhs << ' ';
-    outstr.rhs << '[';
+      lhs << Pathname(uri.getPathName()).basename();
+    lhs << ' ';
+    rhs << '[';
     if ( indeterminate( error ) )
       // Translator: download progress bar result: "........[not found]"
-      outstr.rhs << CHANGEString(_("not found") );
+      rhs << CHANGEString(_("not found") );
     else if ( error )
       // Translator: download progress bar result: "............[error]"
-      outstr.rhs << NEGATIVEString(_("error") );
+      rhs << NEGATIVEString(_("error") );
     else
       // Translator: download progress bar result: ".............[done]"
-      outstr.rhs << _("done");
+      rhs << _("done");
   }
   else
-    outstr.rhs << ( indeterminate( error ) ? _("not found") : ( error ? _("error") : _("done") ) );
+    rhs << ( indeterminate( error ) ? _("not found") : ( error ? _("error") : _("done") ) );
 
   if ( rate > 0 )
-    outstr.rhs << " (" << ByteCount(rate) << "/s)";
-  outstr.rhs << ']';
+    rhs << " (" << ByteCount(rate) << "/s)";
+  rhs << ']';
 
   std::string outline( outstr.get( termwidth() ) );
   cout << outline << endl << std::flush;

--- a/src/output/OutNormal.cc
+++ b/src/output/OutNormal.cc
@@ -115,6 +115,10 @@ void OutNormal::error( const Exception & e, const std::string & problem_desc, co
 }
 
 // ----------------------------------------------------------------------------
+inline std::ostream & PROGRESS_FLUSH( std::ostream & str ) {
+  static const bool dbg = getenv("ZYPPER_PBD"); // every progress bar redraw on a single line
+  return (dbg ? str << std::endl : str << std::flush );
+}
 
 void OutNormal::displayProgress ( const std::string & s, int percent )
 {
@@ -138,7 +142,7 @@ void OutNormal::displayProgress ( const std::string & s, int percent )
     cout << ansi::tty::clearLN;
 
     std::string outline( outstr.get( termwidth() ) );
-    cout << outline << std::flush;
+    cout << outline << PROGRESS_FLUSH;
     // no _oneup if CRUSHed // _oneup = ( outline.length() > termwidth() );
   }
   else
@@ -163,7 +167,7 @@ void OutNormal::displayTick( const std::string & s )
     cout << ansi::tty::clearLN;
 
     std::string outline( outstr.get( termwidth() ) );
-    cout << outline << std::flush;
+    cout << outline << PROGRESS_FLUSH;
     // no _oneup if CRUSHed // _oneup = ( outline.length() > termwidth() );
   }
   else
@@ -171,7 +175,6 @@ void OutNormal::displayTick( const std::string & s )
 }
 
 // ----------------------------------------------------------------------------
-
 void OutNormal::progressStart( const std::string & id, const std::string & label, bool is_tick )
 {
   if ( progressFilter() )
@@ -256,7 +259,7 @@ void OutNormal::dwnldProgressStart( const Url & uri )
     outstr.rhs << '[' ;
 
   std::string outline( outstr.get( termwidth() ) );
-  cout << outline << std::flush;
+  cout << outline << PROGRESS_FLUSH;
   // no _oneup if CRUSHed // _oneup = (outline.length() > termwidth());
 
   _newline = false;
@@ -297,7 +300,7 @@ void OutNormal::dwnldProgress( const Url & uri, int value, long rate )
   outstr.rhs << ']';
 
   std::string outline( outstr.get( termwidth() ) );
-  cout << outline << std::flush;
+  cout << outline << PROGRESS_FLUSH;
   // no _oneup if CRUSHed // _oneup = (outline.length() > termwidth());
   _newline = false;
 }

--- a/src/solve-commit.cc
+++ b/src/solve-commit.cc
@@ -851,7 +851,6 @@ void solve_and_commit ( Zypper &zypper, SolveAndCommitPolicy policy )
         try
         {
           RuntimeData & gData = Zypper::instance().runtimeData();
-          gData.show_media_progress_hack = true;
           // Total packages to download & install.
           // To be used to write overall progress of retrieving packages.
           gData.commit_pkgs_total = summary.packagesToGetAndInstall();
@@ -877,7 +876,6 @@ void solve_and_commit ( Zypper &zypper, SolveAndCommitPolicy policy )
           MIL << "Using commit policy: " << policy.zyppCommitPolicy() << endl;
           result = God->commit( policy.zyppCommitPolicy() );
 
-          gData.show_media_progress_hack = false;
           gData.entered_commit = false;
 
           if ( !result->allDone() && !( dryRunEtc && result->noError() ) )

--- a/src/utils/Offering.h
+++ b/src/utils/Offering.h
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------*\
+                          ____  _ _ __ _ __  ___ _ _
+                         |_ / || | '_ \ '_ \/ -_) '_|
+                         /__|\_, | .__/ .__/\___|_|
+                             |__/|_|  |_|
+\*---------------------------------------------------------------------------*/
+#ifndef ZYPPER_UTILS_OFFERING_H
+#define ZYPPER_UTILS_OFFERING_H
+
+#include <memory>
+
+/// \brief Offer scoped handles to let requesters indicate their demand.
+/// Store the \ref ScopedDemand handle returned by \ref demand as long
+/// as you need it. The request ends if the handle goes out of scope, if
+/// you assign a different \ref ScopedDemand handle to it or explicitly
+/// call \ref handle.reset()
+struct Offering
+{
+  struct _Content {};
+  using ScopedDemand = std::shared_ptr<const _Content>;
+
+  ScopedDemand demand()
+  {
+    ScopedDemand ret { _demand.lock() };
+    if ( not ret ) {
+      _demand = ret = std::make_shared<const _Content>();
+    }
+    return ret;
+  }
+
+  bool isDemanded() const
+  { return not _demand.expired(); }
+
+  unsigned demandCount() const
+  { return _demand.use_count(); }
+
+private:
+  std::weak_ptr<const _Content> _demand;
+};
+
+#endif // ZYPPER_UTILS_OFFERING_H

--- a/src/utils/colors.h
+++ b/src/utils/colors.h
@@ -62,6 +62,10 @@ struct CCString : public ColorString
   explicit CCString( std::string && str_r )		: ColorString( _ctxt, std::move(str_r) ) {}
 };
 
+template <ColorContext _ctxt>
+inline ansi::ColorStream & operator<<( ansi::ColorStream & cstr_r, const CCString<_ctxt> & cstring_r )
+{ return cstr_r << (const ColorString &)cstring_r; }
+
 typedef CCString<ColorContext::DEFAULT>		DEFAULTString;
 
 typedef CCString<ColorContext::MSG_STATUS>	MSG_STATUSString;


### PR DESCRIPTION
Best read IMO commit by commit.

Depending on openSUSE/libzypp#432 we drop any download report frequency limitation (~1 report/sec.) and report whatever libzypp delivers (between 0.1 and 1 report/sec.)

Also a lot of cleanup and coloring the download progress bar.

Still missing: the indication of download retries, but this won't affect the commits here so far.

