### PR TITLE
Add colon to removing string

### DIFF
--- a/src/callbacks/rpm.h
+++ b/src/callbacks/rpm.h
@@ -347,7 +347,7 @@ private:
     _progress.reset( new Out::ProgressBar( zypper.out(),
                                            "remove-resolvable",
                                            // translators: This text is a progress display label e.g. "Removing packagename-x.x.x [42%]"
-                                           str::Format(_("Removing %s") ) % resolvable_r->asString(),
+                                           str::Format(_("Removing: %s") ) % resolvable_r->asString(),
                                            zypper.runtimeData().rpm_pkg_current,
                                            zypper.runtimeData().rpm_pkgs_total ) );
     (*_progress)->range( 100 );	// progress reports percent
@@ -628,7 +628,7 @@ private:
     _progress.reset( new Out::ProgressBar( zypper.out(),
                                            "remove-resolvable",
                                            // translators: This text is a progress display label e.g. "Removing packagename-x.x.x [42%]"
-                                           str::Format(_("Removing %s") ) % resolvable_r->asString(),
+                                           str::Format(_("Removing: %s") ) % resolvable_r->asString(),
                                            zypper.runtimeData().rpm_pkg_current,
                                            zypper.runtimeData().rpm_pkgs_total ) );
     (*_progress)->range( 100 );	// progress reports percent


### PR DESCRIPTION
The installing message has colon(:) but the removing message doesn't. This patch add colon to removing message, so they look better together.

Before:

```
Installing: gtk3-immodule-vietnamese-3.24.37+70-1.1.x86_64
Removing libwx_gtk3u_gl-suse8_0_0-3.2.1-1.3.x86_64
```

After:

```
Installing: gtk3-immodule-vietnamese-3.24.37+70-1.1.x86_64
Removing: libwx_gtk3u_gl-suse8_0_0-3.2.1-1.3.x86_64
```