### PR TITLE
Improve the SIGC handler to be signal safe ( bsc#1214292 )

### DIFF
--- a/src/Zypper.cc
+++ b/src/Zypper.cc
@@ -192,11 +192,12 @@ Zypper::~Zypper()
 }
 
 
-Zypper & Zypper::instance()
+Zypper & Zypper::instance(bool inSignalHandler)
 {
   static Zypper _instance;
   // PENDING SigINT? Some frequently called place to avoid exiting from within the signal handler?
-  _instance.immediateExitCheck();
+  if ( !inSignalHandler )
+    _instance.immediateExitCheck();
   return _instance;
 }
 
@@ -255,6 +256,24 @@ Out & Zypper::out()
     // PENDING SigINT? Some frequently called place to avoid exiting from within the signal handler?
     immediateExitCheck();
     return Application::out();
+}
+
+/*!
+ * This function sets the exit requested flag. It must be safe to be
+ * called from a signal handler, so it must obey the rules for it https://man7.org/linux/man-pages/man7/signal-safety.7.html
+ */
+void Zypper::requestExit(bool do_exit)
+{
+  _exit_requested = do_exit ? 1 : 0;
+}
+
+/*!
+ * This function sets the exit requested flag. It must be safe to be
+ * called from a signal handler, so it must obey the rules for it https://man7.org/linux/man-pages/man7/signal-safety.7.html
+ */
+void Zypper::requestImmediateExit()
+{
+  _exit_requested = 2;
 }
 
 void print_command_help_hint( Zypper & zypper )

--- a/src/Zypper.h
+++ b/src/Zypper.h
@@ -72,7 +72,6 @@ struct RuntimeData
   , rpm_pkg_current( 0 )
   , seen_verify_hint( false )
   , action_rpm_download( false )
-  , waiting_for_input( false )
   , entered_commit( false )
   , tmpdir( zypp::myTmpDir() / "zypper" )
   {
@@ -121,8 +120,6 @@ struct RuntimeData
   bool seen_verify_hint;
   bool action_rpm_download;
 
-  //! \todo move this to a separate Status struct
-  bool waiting_for_input;
   bool entered_commit;	// bsc#946750 - give ZYPPER_EXIT_ERR_COMMIT priority over ZYPPER_EXIT_ON_SIGNAL
 
   //! Temporary directory for any use, e.g. for temporary repositories.
@@ -136,7 +133,7 @@ class Zypper : public ztui::Application
 public:
   typedef std::vector<std::string>  ArgList;
 
-  static Zypper & instance();
+  static Zypper & instance( bool inSignalHandler = false );
 
   int main( int argc, char ** argv );
 
@@ -165,8 +162,8 @@ public:
   bool runningHelp() const			{ return _running_help; }
 
   unsigned exitRequested() const		{ return _exit_requested; }
-  void requestExit( bool do_exit = true )	{ _exit_requested = do_exit ? 1 : 0; }
-  void requestImmediateExit()			{ _exit_requested = 2; }
+  void requestExit( bool do_exit = true );
+  void requestImmediateExit();
 
 private:
   struct SigExitTreasureT {


### PR DESCRIPTION
This patch updates the SIGINT handling strategy to be signal safe. Meaning the signal handler will do not much more than setting a flag, which we are going to check in the normal program flow as much as possible.