### PR TITLE
Prefer unaliased `grep` to avoid unexpected/wrong completions.

### DIFF
--- a/src/bash-completion.sh
+++ b/src/bash-completion.sh
@@ -24,14 +24,14 @@ _strip()
 
 _installed_packages() {
 	! [[ $cur =~ / ]] || return
-	\grep -s --no-filename "^$cur" "/var/cache/zypp/solv/@System/solv.idx" | cut -f1
+	command grep -s --no-filename "^$cur" "/var/cache/zypp/solv/@System/solv.idx" | cut -f1
 }
 
 _available_solvables2() {
 	local lcur=$1
 	! [[ $cur =~ / ]] || return # for installing local packages
 	set +o noglob
-	\grep -s --no-filename "^$lcur" /var/cache/zypp/solv/*/solv.idx |\
+	command grep -s --no-filename "^$lcur" /var/cache/zypp/solv/*/solv.idx |\
 		cut -f1 | sort --unique
 	set -o noglob
 }

--- a/src/bash-completion.sh
+++ b/src/bash-completion.sh
@@ -24,14 +24,14 @@ _strip()
 
 _installed_packages() {
 	! [[ $cur =~ / ]] || return
-	grep -s --no-filename "^$cur" "/var/cache/zypp/solv/@System/solv.idx" | cut -f1
+	\grep -s --no-filename "^$cur" "/var/cache/zypp/solv/@System/solv.idx" | cut -f1
 }
 
 _available_solvables2() {
 	local lcur=$1
 	! [[ $cur =~ / ]] || return # for installing local packages
 	set +o noglob
-	grep -s --no-filename "^$lcur" /var/cache/zypp/solv/*/solv.idx |\
+	\grep -s --no-filename "^$lcur" /var/cache/zypp/solv/*/solv.idx |\
 		cut -f1 | sort --unique
 	set -o noglob
 }


### PR DESCRIPTION
If

```shell
alias grep='grep -n'
```

is set before zypper's programmable completion script is sourced, the latter malfunctions. For instance, typing `zypper remove ` and then pressing <kbd>TAB</kbd><kbd>TAB</kbd><kbd>y</kbd><kbd>q</kbd> results in the following.

```console
$ zypper remove 
Display all 2075 possibilities? (y or n)
1000\:libpaper                                    1935\:xfwm4-lang
1001\:libpaper-tools                              1936\:xhost
1002\:libpaper2                                   1937\:xiccd
1003\:libparted-fs-resize0                        1938\:xinit
1004\:libparted2                                  1939\:xkbcomp
1005\:libpathplan4                                193\:farstream-data
1006\:libpci3                                     1940\:xkeyboard-config
1007\:libpciaccess0                               1941\:xkeyboard-config-lang
1008\:libpcre1                                    1942\:xli
1009\:libpcre2-16-0                               1943\:xmessage
100\:bzip2                                        1944\:xml-commons-apis
1010\:libpcre2-32-0                               1945\:xmodmap
1011\:libpcre2-8-0                                1946\:xorg-x11-Xvnc
1012\:libpcre2-posix3                             1947\:xorg-x11-Xvnc-module
1013\:libpcsclite1                                1948\:xorg-x11-driver-video
1014\:libpeas-1_0-0                               1949\:xorg-x11-essentials
1015\:libpeas-gtk-1_0-0                           194\:fdupes
1016\:libpeas-lang                                1950\:xorg-x11-fonts
1017\:libpeas-loader-python3                      1951\:xorg-x11-fonts-converted
1018\:libpgm-5_3-0                                1952\:xorg-x11-fonts-core
1019\:libpipeline1                                1953\:xorg-x11-fonts-legacy
101\:ca-certificates                              1954\:xorg-x11-libX11-ccache
1020\:libpipewire-0_3-0                           1955\:xorg-x11-server
1021\:libpixman-1-0                               1956\:xorg-x11-server-Xvfb
1022\:libpkgconf3                                 1957\:xorg-x11-server-extra
$ zypper remove 
```

A simple fix is to use `\grep` instead of `grep`. Though this does raise the question: should `cut` and `sed` get the same treatment?

## Notes
* Homebrew does the [same thing](https://github.com/Homebrew/brew/blob/eacdf7aa60a1a8a64acc71853ec5559cfd2329c3/completions/bash/brew#L108).
* bash-completion uses `command` to achieve [the](https://github.com/scop/bash-completion/blob/7881365bc2f8eaa09e85cb013a4a93d286b5d3b0/completions/rpm#L123) [same](https://github.com/scop/bash-completion/blob/7881365bc2f8eaa09e85cb013a4a93d286b5d3b0/completions/java#L72) [effect](https://github.com/scop/bash-completion/blob/7881365bc2f8eaa09e85cb013a4a93d286b5d3b0/completions/dict#L63).