### PR TITLE
Change the number field alignment to the left.

### DIFF
--- a/src/bash-completion.sh
+++ b/src/bash-completion.sh
@@ -130,8 +130,8 @@ _zypper() {
 			;;
 			removerepo | rr | modifyrepo | mr | renamerepo | nr | refresh | ref)
 				opts=(${opts[@]}$(echo; LC_ALL=POSIX $ZYPPER -q lr | \
-					sed -rn '/^[0-9]/{
-						s/^[0-9]+[[:blank:]]*\|[[:blank:]]*([^|]+).*/\1/
+					sed -rn '/[[:blank:]]*[0-9]/{
+						s/[[:blank:]]*[0-9]+[[:blank:]]*\|[[:blank:]]*([^|]+).*/\1/
 						s/[[:blank:]]*$//
 						/^$/d
 						p
@@ -139,8 +139,8 @@ _zypper() {
 			;;
 			addservice | as | modifyservice | ms | removeservice | rs)
 				opts=(${opts[@]}$(echo; LC_ALL=POSIX $ZYPPER -q ls | \
-					sed -rn '/^[0-9]/{
-						s/^[0-9]+[[:blank:]]*\|[[:blank:]]*([^|]+).*/\1/
+					sed -rn '/[[:blank:]]*[0-9]/{
+						s/[[:blank:]]*[0-9]+[[:blank:]]*\|[[:blank:]]*([^|]+).*/\1/
 						s/[[:blank:]]*$//
 						/^$/d
 						p
@@ -148,8 +148,8 @@ _zypper() {
 			;;
 			removelock | rl)
 				opts=(${opts[@]}$(echo; LC_ALL=POSIX $ZYPPER -q ll | \
-					sed -rn '/^[0-9]/{
-						s/^[0-9]+[[:blank:]]*\|[[:blank:]]*([^|]+).*/\1/p
+					sed -rn '/[[:blank:]]*[0-9]/{
+						s/[[:blank:]]*[0-9]+[[:blank:]]*\|[[:blank:]]*([^|]+).*/\1/p
 						s/[[:blank:]]*$//
 						/^$/d
 						p

--- a/src/commands/repos/list.cc
+++ b/src/commands/repos/list.cc
@@ -297,7 +297,8 @@ void ListReposCmd::printRepoList( Zypper & zypper, const std::list<RepoInfo> & r
     RepoGpgCheckStrings repoGpgCheck( repo );	// color strings for tag/enabled/gpgcheck
 
     // number
-    tr << ColorString( repoGpgCheck._tagColor, str::numstring( i, nindent ) ).str();
+    // minus sign in '-nident' aligns the number to the left of the field.
+    tr << ColorString( repoGpgCheck._tagColor, str::numstring( i, -nindent ) ).str();
     // alias
     if ( all || showalias ) tr << ColorString( repoGpgCheck._tagColor, repo.alias() );
     // name


### PR DESCRIPTION
This change changes to align line number to the right in output of the 'zypper lr' command. That is consistent with the output of 'zypper ls' and helps to solve the bash-completion issues.