### PR TITLE
bash completion lr vs ls fix

### DIFF
--- a/src/bash-completion.sh
+++ b/src/bash-completion.sh
@@ -130,8 +130,8 @@ _zypper() {
 			;;
 			removerepo | rr | modifyrepo | mr | renamerepo | nr | refresh | ref)
 				opts=(${opts[@]}$(echo; LC_ALL=POSIX $ZYPPER -q lr | \
-					sed -rn '/^[0-9]/{
-						s/^[0-9]+[[:blank:]]*\|[[:blank:]]*([^|]+).*/\1/
+					sed -rn '/^[[:blank:]]*[0-9]/{
+						s/^[[:blank:]]*[0-9]+[[:blank:]]*\|[[:blank:]]*([^|]+).*/\1/
 						s/[[:blank:]]*$//
 						/^$/d
 						p
@@ -139,8 +139,8 @@ _zypper() {
 			;;
 			addservice | as | modifyservice | ms | removeservice | rs)
 				opts=(${opts[@]}$(echo; LC_ALL=POSIX $ZYPPER -q ls | \
-					sed -rn '/^[0-9]/{
-						s/^[0-9]+[[:blank:]]*\|[[:blank:]]*([^|]+).*/\1/
+					sed -rn '/^[[:blank:]]*[0-9]/{
+						s/^[[:blank:]]*[0-9]+[[:blank:]]*\|[[:blank:]]*([^|]+).*/\1/
 						s/[[:blank:]]*$//
 						/^$/d
 						p
@@ -148,8 +148,8 @@ _zypper() {
 			;;
 			removelock | rl)
 				opts=(${opts[@]}$(echo; LC_ALL=POSIX $ZYPPER -q ll | \
-					sed -rn '/^[0-9]/{
-						s/^[0-9]+[[:blank:]]*\|[[:blank:]]*([^|]+).*/\1/p
+					sed -rn '/^[[:blank:]]*[0-9]/{
+						s/^[[:blank:]]*[0-9]+[[:blank:]]*\|[[:blank:]]*([^|]+).*/\1/p
 						s/[[:blank:]]*$//
 						/^$/d
 						p

--- a/src/commands/services/list.cc
+++ b/src/commands/services/list.cc
@@ -14,6 +14,7 @@ void service_list_tr( Zypper & zypper,
                       Table & tbl,
                       const repo::RepoInfoBase_Ptr & srv,
                       unsigned reponumber,
+                      unsigned reponumberfieldw,
                       const RSCommonListOptions::RSCommonListFlags & flags )
 {
   ServiceInfo_Ptr service = dynamic_pointer_cast<ServiceInfo>(srv);
@@ -29,12 +30,12 @@ void service_list_tr( Zypper & zypper,
   if ( flags & RSCommonListOptions::ServiceRepo )
   {
     if ( repo && ! repo->enabled() )
-      tr << ColorString( repoGpgCheck._tagColor, "-" ).str();
+      tr << ColorString( repoGpgCheck._tagColor, str::form( "%*c", reponumberfieldw, '-' ) ).str();
     else
       tr << "";
   }
   else
-    tr << ColorString( repoGpgCheck._tagColor, str::numstring(reponumber) ).str();
+    tr << ColorString( repoGpgCheck._tagColor, str::numstring(reponumber, reponumberfieldw) ).str();
 
   // alias
   tr << ColorString( repoGpgCheck._tagColor, srv->alias() );
@@ -123,6 +124,7 @@ void ListServicesCmd::printServiceList( Zypper &zypper )
   bool show_enabled_only = _listOptions._flags.testFlag( RSCommonListOptions::ShowEnabledOnly );
 
   int i = 0;
+  unsigned nindent = services.size() > 9 ? services.size() > 99 ? 3 : 2 : 1;
   for_( it, services.begin(), services.end() )
   {
     ++i; // continuous numbering including skipped ones
@@ -148,11 +150,11 @@ void ListServicesCmd::printServiceList( Zypper &zypper )
 
         if ( !servicePrinted )
         {
-          service_list_tr( zypper, tbl, *it, i, _listOptions._flags );
+          service_list_tr( zypper, tbl, *it, i, nindent, _listOptions._flags );
           servicePrinted = true;
         }
         // ServiceRepo: we print repos of the current service
-        service_list_tr( zypper, tbl, ptr, i, _listOptions._flags | RSCommonListOptions::ServiceRepo );
+        service_list_tr( zypper, tbl, ptr, i, nindent, _listOptions._flags | RSCommonListOptions::ServiceRepo );
       }
     }
     if ( servicePrinted )
@@ -163,7 +165,7 @@ void ListServicesCmd::printServiceList( Zypper &zypper )
     if ( show_enabled_only && !(*it)->enabled() )
       continue;
 
-    service_list_tr( zypper, tbl, *it, i, _listOptions._flags );
+    service_list_tr( zypper, tbl, *it, i, nindent, _listOptions._flags );
   }
 
   if ( tbl.empty() )


### PR DESCRIPTION
Bash completion failed if numbers in the 1st column are right-adjusted.
On the fly fixed `ls` to use the same adjustment as `lr` (right-adjusted)