### PR TITLE
make_obs_url fix platform for newer Leap releases

### DIFF
--- a/src/utils/misc.cc
+++ b/src/utils/misc.cc
@@ -569,8 +569,8 @@ Url make_obs_url( const std::string & obsuri )
         }
         else if ( platform == "Leap" && pdata.vendor() == "openSUSE" )
         {
-          // bsc#1187425 Hotfix
-          platform = "openSUSE_Leap_$releasever";
+          // openSUSE Leap 15.3+ uses simply "15.X" as a reference to the codestream
+          platform = "$releasever";
         }
         else
           platform += "_$releasever";


### PR DESCRIPTION
We no longer use openSUSE_Leap_15.6 for Leap repositories. Nowadays it's just 15.6 (in fact since 15.3 I believe).


```
lkocman@localhost:~> sudo zypper ar obs://devel:tools:ide:vscode devel_tools_ide_vscode
[sudo] password for root: 
Guessed: platform = openSUSE_Leap_$releasever
Adding repository 'devel_tools_ide_vscode' ................................................................................................................................................................[done]
Repository 'devel_tools_ide_vscode' successfully added

URI         : https://download.opensuse.org/repositories/devel:/tools:/ide:/vscode/openSUSE_Leap_15.6
Enabled     : Yes
GPG Check   : Yes
Autorefresh : No
Priority    : 99 (default priority)

Repository priorities are without effect. All enabled repositories share the same priority.

```

The url should be https://download.opensuse.org/repositories/devel:/tools:/ide:/vscode/15.6