### PR TITLE
patch: add  --skip-not-applicable-patches to  autoresolve not applicable patches

### DIFF
--- a/doc/zypper.8.txt
+++ b/doc/zypper.8.txt
@@ -650,6 +650,12 @@ This command is similar to *zypper update -t patch*.
 	*--updatestack-only*::
 		Install only patches which affect the package management itself and exit.
 
+	*--skip-not-applicable-patches*::
+		Skip needed patches which do not apply without conflict. In normal operation mode those conflicts have to be resolved interactively, otherwise the *patch* command fails.
++
+In scripted and unattended environments it may be desired to try to apply at least as many patches as possible so the system is not left completely without updates. It is highly recommended to run *zypper patch-check* afterwards in order to
+see whether needed patches are still waiting to be resolved interactively.
+
 	*--with-update*::
 		Additionally try to update all packages not covered by patches. This is basically the same as running *zypper update* afterwards.
 +

--- a/src/Summary.h
+++ b/src/Summary.h
@@ -19,6 +19,22 @@
 #include <zypp/ResPool.h>
 #include "utils/ansi.h"
 
+/// \brief Information collected in SolveAndCommit which is to be shown in the summary.
+struct SummaryHints
+{
+  void clear() { *this = SummaryHints(); }
+
+  bool haveSkippedPatches() const
+  { return _skippedPatches && not _skippedPatches->empty(); }
+
+  std::set<PoolItem> & skippedPatchesSet()
+  { if ( not _skippedPatches ) _skippedPatches = std::set<PoolItem>(); return *_skippedPatches; }
+
+private:
+  std::optional<std::set<PoolItem>> _skippedPatches; ///< --skip-not-applicable-patches
+};
+
+
 class Summary : private zypp::base::NonCopyable
 {
 public:
@@ -60,7 +76,7 @@ public:
   typedef enum _view_options ViewOptions;
 
 public:
-  Summary( const zypp::ResPool & pool, const ViewOptions options = DEFAULT );
+  Summary( const zypp::ResPool & pool, SummaryHints summaryHints, const ViewOptions options = DEFAULT );
   ~Summary() {}
 
   void setViewOptions( const ViewOptions options )	{ _viewop = options; }
@@ -89,6 +105,7 @@ public:
   void writeDownloadAndInstalledSizeSummary( std::ostream & out );
   void writeLocked( std::ostream & out );
   void writeRebootNeeded( std::ostream & out );
+  void writeAutoResolved( std::ostream & out );
 
   unsigned packagesToGetAndInstall() const		{ return _inst_pkg_total; }
 
@@ -129,6 +146,7 @@ private:
   bool showNeedRebootHInt() const;
 
 private:
+  SummaryHints _summaryHints;   ///< additional info collected during dependency resolution
   ViewOptions _viewop;
   mutable unsigned _wrap_width;
   bool _force_no_color;

--- a/src/commands/patch.cc
+++ b/src/commands/patch.cc
@@ -46,6 +46,9 @@ zypp::ZyppFlags::CommandGroup PatchCmd::cmdOptions() const
   return {
     {
       CommonFlags::updateStackOnlyFlag( that->_updateStackOnly),
+      { "skip-not-applicable-patches", '\0', ZyppFlags::NoArgument, ZyppFlags::BoolType( &that->_skipNotApplicablePatches, ZyppFlags::StoreTrue, _skipNotApplicablePatches ),
+            _("Skip needed patches which do not apply without conflict.")
+      },
       { "with-update", '\0', ZyppFlags::NoArgument, ZyppFlags::BoolType( &that->_withUpdate, ZyppFlags::StoreTrue, _withUpdate ),
             _("Additionally try to update all packages not covered by patches. The option is ignored, if the patch command must update the update stack first. Can not be combined with --updatestack-only.")
       },
@@ -120,6 +123,11 @@ int PatchCmd::execute( Zypper &zypper, const std::vector<std::string> &positiona
     viewOpts = static_cast<Summary::ViewOptions> ( viewOpts | Summary::ViewOptions::PATCH_REBOOT_RULES );
   }
 
-  solve_and_commit( zypper, SolveAndCommitPolicy( ).summaryOptions( viewOpts ).downloadMode( _downloadModeOpts.mode() ) );
+  SolveAndCommitPolicy p;
+  p.summaryOptions( viewOpts );
+  p.downloadMode( _downloadModeOpts.mode() );
+  p.skipNotApplicablePatches( _skipNotApplicablePatches );
+  solve_and_commit( zypper, std::move(p) );
+
   return zypper.exitCode();
 }

--- a/src/commands/patch.h
+++ b/src/commands/patch.h
@@ -21,6 +21,7 @@ public:
 
 private:
   bool _updateStackOnly = false;
+  bool _skipNotApplicablePatches = false;
   bool _withUpdate = false;
   bool _details = false;
 

--- a/src/solve-commit.h
+++ b/src/solve-commit.h
@@ -37,6 +37,12 @@ struct SolveAndCommitPolicy {
   bool forceCommit () const;
   SolveAndCommitPolicy &forceCommit ( bool enable );
 
+  /**
+   * Auto skip not applicable patches.
+   */
+  bool skipNotApplicablePatches() const;
+  SolveAndCommitPolicy & skipNotApplicablePatches( bool enable );
+
   /*!
    * Changes the amount of information included by the summary
    */
@@ -50,8 +56,12 @@ struct SolveAndCommitPolicy {
   SolveAndCommitPolicy &downloadMode(DownloadMode dlMode);
   DownloadMode downloadMode() const;
 
+  /** Information collected in SolveAndCommit which is to be shown in the Summary. */
+  SummaryHints summaryHints;
+
 private:
-  bool _forceCommit    = false;
+  bool _forceCommit = false;
+  bool _skipNotApplicablePatches = false;
   Summary::ViewOptions _summaryOptions = Summary::DEFAULT;
   ZYppCommitPolicy _zyppCommitPolicy;
 };

--- a/src/utils/misc.cc
+++ b/src/utils/misc.cc
@@ -657,14 +657,12 @@ Pathname cache_rpm( const std::string & rpm_uri_str, const Pathname & cache_dir 
   return Pathname();
 }
 
-std::string & indent( std::string & text, int columns )
+std::string indent( std::string text, int columns )
 {
-  std::string indent( columns, ' ');
+  std::string indent( columns, ' ' );
+  text.insert( 0, indent );
   indent.insert( 0, 1, '\n' );
-  DBG << "to: '" << indent << "'" << endl;
-  text = str::gsub( text, "\n", indent );
-  text.insert( 0, std::string( columns, ' ' ) );
-  return text;
+  return str::replaceAll( text, "\n", indent );
 }
 
 /**

--- a/src/utils/misc.h
+++ b/src/utils/misc.h
@@ -217,7 +217,8 @@ bool looks_like_rpm_file( const std::string & s );
  */
 Pathname cache_rpm( const std::string & rpm_uri_str, const Pathname & cache_dir );
 
-std::string & indent( std::string & text, int columns );
+/// Indent each line in \a text to \a columns
+std::string indent( std::string text, int columns );
 
 // comparator for RepoInfo set
 struct RepoInfoAliasComparator

--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -26,7 +26,7 @@ BuildRequires:  boost-devel >= 1.33.1
 BuildRequires:  cmake >= 3.1
 BuildRequires:  gcc-c++ >= 7
 BuildRequires:  gettext-devel >= 0.15
-BuildRequires:  libzypp-devel >= 17.31.31
+BuildRequires:  libzypp-devel >= 17.31.32
 BuildRequires:  readline-devel >= 5.1
 BuildRequires:  libxml2-devel
 Requires:       procps

--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -26,7 +26,7 @@ BuildRequires:  boost-devel >= 1.33.1
 BuildRequires:  cmake >= 3.1
 BuildRequires:  gcc-c++ >= 7
 BuildRequires:  gettext-devel >= 0.15
-BuildRequires:  libzypp-devel >= 17.31.29
+BuildRequires:  libzypp-devel >= 17.31.31
 BuildRequires:  readline-devel >= 5.1
 BuildRequires:  libxml2-devel
 Requires:       procps


### PR DESCRIPTION
(closes #514)
The first commits are fixes and enhancements to the patch. The last one introduces the feature.

If multiple problems are to be reported, zypper uses a 1st pass to quickly list all problems and a 2nd pass to ask to resolve each problem. 

We use the 1st pass to check for auto-applicable solutions and re-solve if solutions were applied. If problems still remain at the end, we ask.

The draft is basically ready. Remaining tasks:

- [x] Remember skipped patches and show them in the summary.
- [x] Upadte man page.