### PR TITLE
Fixing minor grammar issue in summary output

### DIFF
--- a/src/Summary.cc
+++ b/src/Summary.cc
@@ -1582,8 +1582,8 @@ void Summary::writeDownloadAndInstalledSizeSummary( std::ostream & out )
   {
     // installed size change info
     if ( _inst_size_change > 0 )
-      // TrasnlatorExplanation %s will be substituted by a byte count e.g. 212 K
-      s << str::Format(_("After the operation, additional %s will be used.")) % _inst_size_change.asString( 0 , 1, 1 );
+      // TranslatorExplanation %s will be substituted by a byte count e.g. 212 K
+      s << str::Format(_("After the operation, an additional %s will be used.")) % _inst_size_change.asString( 0 , 1, 1 );
     else if ( _inst_size_change == 0 )
       s << _("No additional space will be used or freed after the operation.");
     else
@@ -1591,7 +1591,7 @@ void Summary::writeDownloadAndInstalledSizeSummary( std::ostream & out )
       // get the absolute size
       ByteCount abs;
       abs = (-_inst_size_change);
-      // TrasnlatorExplanation %s will be substituted by a byte count e.g. 212 K
+      // TranslatorExplanation %s will be substituted by a byte count e.g. 212 K
       s << str::Format(_("After the operation, %s will be freed.")) % abs.asString( 0, 1, 1 );
     }
   }


### PR DESCRIPTION
In the zypper summary output when a package (or packages) are being added, it summarises, but does so with a minor grammatical error, where the word "an" is missing before "additional". Incredibly minor, but it bugs me :)