### PR TITLE
Let zypper dup fail in case of (temporarily) unaccessible repos

### DIFF
--- a/doc/zypper.8.txt
+++ b/doc/zypper.8.txt
@@ -752,6 +752,7 @@ It might be less tedious to persistently set *$releasever* to the target distrib
 +
 'Note:' distribution upgrades in openSUSE are currently only supported between consecutive releases. To upgrade multiple releases, upgrade each consecutive release one at a time. For more details see *http://en.opensuse.org/SDB:System_upgrade* and the _openSUSE release notes_ at *http://doc.opensuse.org/release-notes/*.
 +
+'Note:' Due to the treatment of orphaned packages dist-upgrade depends on a proper repository setup more than any other command. It must not continue if enabled repositories fail to refresh. This may severely damage the system. If a failing repository is actually not needed, it must be disabled.
 --
 	*--from* _alias_|_name_|_#_|_URI_::
 		The option can be used multiple times and restricts the upgrade to the specified repositories only. Nevertheless all enabled repositories are visible to the resolver and will be considered to satisfy dependency problems.

--- a/src/commands/basecommand.cc
+++ b/src/commands/basecommand.cc
@@ -175,6 +175,15 @@ int ZypperBaseCommand::defaultSystemSetup( Zypper &zypper, SetupSystemFlags flag
     init_repos( zypper );
     if ( zypper.exitCode() != ZYPPER_EXIT_OK )
       return zypper.exitCode();
+    else if ( flags_r.testFlag( FailIfReposFail ) && zypper.exitInfoCode() != ZYPPER_EXIT_OK ) {
+      // Fail as demanded by FailIfReposFail. Commands may tune or explain
+      // this by overriding systemSetup (e.g. distupgrade).
+      // NOTE: Since several exitInfoCodes are documented to be returned as a kind
+      // of annotation, if the command would otherwise have returned 0, we indicate
+      // a real error here. Just in case the command does not amend it later.
+      zypper.setExitCode( ZYPPER_EXIT_ERR_ZYPP ); // intentionally an error and NOT the exitInfoCode
+      return zypper.exitInfoCode();               // but return the exitInfoCode
+    }
   }
 
   DtorReset _tmp( zypper.configNoConst().disable_system_resolvables );

--- a/src/commands/basecommand.h
+++ b/src/commands/basecommand.h
@@ -56,7 +56,8 @@ enum SetupSystemBits
  LoadRepoResolvables    = (1 << 6),
  LoadResolvables        = LoadTargetResolvables |  LoadRepoResolvables,            //< Load resolvables
  Resolve                = (1 << 9),             //< compute status of PPP (NOP - since libzypp 17.23.0 the PPP status is auto established)
- DefaultSetup           = ResetRepoManager | InitTarget | InitRepos | LoadResolvables | Resolve
+ DefaultSetup           = ResetRepoManager | InitTarget | InitRepos | LoadResolvables | Resolve,
+ FailIfReposFail        = (1 << 10),            //< do not tolerate failing repos (returning ZYPPER_EXIT_INF_REPOS_SKIPPED)
 };
 ZYPP_DECLARE_FLAGS( SetupSystemFlags, SetupSystemBits );
 

--- a/src/commands/distupgrade.cc
+++ b/src/commands/distupgrade.cc
@@ -44,6 +44,22 @@ zypp::ZyppFlags::CommandGroup DistUpgradeCmd::cmdOptions() const
   });
 }
 
+int DistUpgradeCmd::systemSetup( Zypper &zypper )
+{
+  // bsc#1228434, bsc#1236939, bsc#961719, bsc#961724, et.al.
+  // dup must not continue if repositories failed to refresh.
+  SetupSystemFlags flags = DefaultSetup | FailIfReposFail;
+  int res = defaultSystemSetup( zypper, flags );
+  if ( res == ZYPPER_EXIT_INF_REPOS_SKIPPED ) {
+    // FailIfReposFail
+    zypper.out().taggedPar( 4, MSG_ERRORString( command()[0]+":" ), _("Due to the treatment of orphaned packages dist-upgrade depends on a proper repository setup more than any other command. It must not continue if enabled repositories fail to refresh. This may severely damage the system. If a failing repository is actually not needed, it must be disabled.")
+      +std::string(" ")
+      +_("See 'man zypper' for more information about this command.") );
+    zypper.setExitCode( ZYPPER_EXIT_ERR_ZYPP );
+  }
+  return zypper.exitCode();
+}
+
 void DistUpgradeCmd::doReset()
 {
   DupSettings::reset();

--- a/src/commands/distupgrade.h
+++ b/src/commands/distupgrade.h
@@ -31,6 +31,7 @@ private:
   // ZypperBaseCommand interface
 protected:
   zypp::ZyppFlags::CommandGroup cmdOptions() const override;
+  int systemSetup(Zypper &zypper) override;
   void doReset() override;
   int execute(Zypper &zypper, const std::vector<std::string> &positionalArgs_r) override;
   std::vector<BaseCommandConditionPtr> conditions() const override;

--- a/src/repos.cc
+++ b/src/repos.cc
@@ -934,10 +934,12 @@ void do_init_repos( Zypper & zypper )
   if ( skip_count )
   {
     zypper.out().error(_("Some of the repositories have not been refreshed because of an error.") );
-    // TODO: A user abort during repo refresh as well as unavailable metadata
-    // should probably lead to ZYPPER_EXIT_ERR_ZYPP right here. Ignored refresh
-    // errors may continue. For now at least remember the refresh error to prevent
-    // a 0 exit code after the action completed. (bsc#961719, bsc#961724, et.al.)
+    // A user abort during repo refresh as well as unavailable metadata
+    // could lead to ZYPPER_EXIT_ERR_ZYPP right here. Ignored refresh
+    // errors may continue. For now at least remember the refresh error
+    // to prevent a 0 exit code after the action completed.
+    // Commands should override ZypperBaseCommand::systemSetup to decide whether
+    // they fail if repos fail to refresh (dup!) or continue.
     // zypper.setExitCode( ZYPPER_EXIT_ERR_ZYPP );
     zypper.setExitInfoCode( ZYPPER_EXIT_INF_REPOS_SKIPPED );
   }


### PR DESCRIPTION
 (bsc#1228434, bsc#1236939, fixes#446)