### PR TITLE
refresh: add --include-all-archs (fixes #598)

### DIFF
--- a/doc/zypper.8.txt
+++ b/doc/zypper.8.txt
@@ -1367,6 +1367,9 @@ include::{incdir}/option_Repo_Aggregates.txt[]
 	*-D*, *--download-only*::
 		Only download the raw metadata, don't parse it or build the database.
 
+	*--include-all-archs*::
+		Multi-Arch repos: Download raw metadata for all offered architectures even if the repo supports filtering. Otherwise we'd download only the metadata for architectures compatible with the local system. You do not need this unless you want zypper to provide the full metadata for the purpose of mirroring the repository.
+
 	*-s*, *--services*::
 		Refresh also services before refreshing repositories.
 --

--- a/src/commands/repos/refresh.cc
+++ b/src/commands/repos/refresh.cc
@@ -99,6 +99,11 @@ zypp::ZyppFlags::CommandGroup RefreshRepoCmd::cmdOptions() const
             // translators: -D, --download-only
             _("Only download raw metadata, don't build the database.")
       },
+      {"include-all-archs", 0, ZyppFlags::NoArgument,
+            ZyppFlags::BitFieldType( that->_flags, AllArchs ),
+            // translators: --include-all-archs
+            _("Multi-Arch repos: Download raw metadata for all offered architectures even if the repo supports filtering.")
+      },
       {"repo", 'r', ZyppFlags::RequiredArgument | ZyppFlags::Repeatable,
             ZyppFlags::StringVectorType( &that->_repos, ARG_REPOSITORY),
             // translators: -r, --repo <ALIAS|#|URI>
@@ -176,6 +181,13 @@ int RefreshRepoCmd::execute( Zypper &zypper , const std::vector<std::string> &po
 bool RefreshRepoCmd::refreshRepository(Zypper &zypper, const RepoInfo &repo, RefreshFlags flags_r)
 {
   MIL << "going to refresh repo '" << repo.alias() << "'" << endl;
+
+  // https://code.opensuse.org/leap/features/issue/193
+  // https://github.com/openSUSE/zypper/issues/598
+  // --include-all-archs is a stub for SUMA(MLM) in case #193 is implemented
+  // and honoured by libzypp. Actually we'd prefer using the single-arch
+  // repos rather than filtering, but we will see how Leap evolves.
+#warning RefreshFlagsBits::AllArchs is a NO-OP - propagate it to libzypp
 
   // raw metadata refresh
   bool error = false;

--- a/src/commands/repos/refresh.h
+++ b/src/commands/repos/refresh.h
@@ -21,7 +21,8 @@ public:
     ForceBuild    = 1 << 1,
     ForceDownload = 1 << 2,
     BuildOnly     = 1 << 3,
-    DownloadOnly  = 1 << 4
+    DownloadOnly  = 1 << 4,
+    AllArchs      = 1 << 5,
   };
   ZYPP_DECLARE_FLAGS(RefreshFlags,RefreshFlagsBits);
 

--- a/zypper.spec.cmake
+++ b/zypper.spec.cmake
@@ -51,6 +51,7 @@ Provides:       zypper(auto-agree-with-product-licenses)
 Provides:       zypper(oldpackage)
 Provides:       zypper(updatestack-only)
 Provides:       zypper(purge-kernels)
+Provides:       zypper(include-all-archs)
 %if 0%{?suse_version}
 Requires:       libaugeas0 >= 1.10.0
 %requires_ge    libzypp


### PR DESCRIPTION
Future multi-arch repos may allow to download only those metadata which refer to packages actually compatible with the systems architecture. Some tools however want zypp to provide the full metadata of a repository without filtering incompatible architectures.