### PR TITLE
Do not double encode URL strings passed on the commandline (bsc#1237587)

### DIFF
--- a/src/utils/misc.cc
+++ b/src/utils/misc.cc
@@ -413,7 +413,7 @@ bool looks_like_url( const std::string& s )
 Url make_url( const std::string & url_s )
 {
   Url u;
-  std::string urlstr( url::encode( url_s, URL_SAFE_CHARS ) );
+  std::string urlstr;
 
   if ( !url_s.empty() && !looks_like_url(url_s) )
   {
@@ -445,6 +445,10 @@ Url make_url( const std::string & url_s )
       ERR << "specified local path does not exist or is not accessible" << endl;
       return u;
     }
+  }
+  else
+  {
+    urlstr = url::encode( url_s, URL_SAFE_CHARS, url::E_ENCODED );
   }
 
   try {


### PR DESCRIPTION
[bsc#1237587](https://bugzilla.suse.com/show_bug.cgi?id=1237587)
URLs passed on the commandline must have their special chars encoded already. We just want to check and encode forgotten unsafe chars like a blank. A '%' however must not be encoded again.

Because non-Url arguments may denote a local path, the encoding check was moved into the else-part. Otherwise we may accidentally encode an  argument string which was meant to be a local pathname.
