### PR TITLE
Add an --ids-only flag

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Afrikaans <https://l10n.opensuse.org/projects/zypper/master/"
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "Berei installasie voor ..."
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Onverwagte uitsondering."
 
@@ -1396,12 +1396,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 #, fuzzy
 msgid "Non-option program arguments: "
 msgstr "Programargumente met geen opsie nie:"
@@ -2113,24 +2113,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2200,7 +2206,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2386,22 +2392,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2452,49 +2458,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2598,11 +2608,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Naam"
 
@@ -2613,8 +2623,8 @@ msgstr "regstelling"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Soort"
@@ -2622,7 +2632,7 @@ msgstr "Soort"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 #, fuzzy
 msgid "Repository"
@@ -3054,7 +3064,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "Bediener"
@@ -3219,120 +3229,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3371,12 +3381,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3418,118 +3428,122 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Ontsper"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 #, fuzzy
 msgid "GPG Check"
 msgstr "DNS-nagaan"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 #, fuzzy
 msgid "Autorefresh"
 msgstr "Outovernuwe"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 #, fuzzy
 msgid "On"
 msgstr "nee"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Keep Packages"
 msgstr "Stelselarea-items"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 #, fuzzy
 msgid "Path Prefix"
 msgstr "Skakelvoorafkode"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "Bediener"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 #, fuzzy
 msgid "Error reading repositories:"
 msgstr "Fout in die skryf van lêer '%1'"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Kan lêer nie vir skryf open nie."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3537,21 +3551,21 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Vernuwe"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "Outovernuwe"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3652,7 +3666,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 #, fuzzy
 msgid "Specified repositories: "
 msgstr "Fout in die skryf van lêer '%1'"
@@ -3662,7 +3676,7 @@ msgstr "Fout in die skryf van lêer '%1'"
 msgid "Refreshing repository '%s'."
 msgstr "Fout in die skryf van lêer '%1'"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Fout in die skryf van lêer '%1'"
@@ -3672,7 +3686,7 @@ msgstr "Fout in die skryf van lêer '%1'"
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3701,7 +3715,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3754,12 +3768,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 #, fuzzy
 msgid "Error while modifying the repository:"
 msgstr "'n Fout het voorgekom terwyl die opgawe gelees is."
@@ -4192,27 +4206,27 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Outovernuwe"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "Geen klank nie"
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 #, fuzzy
 msgid "See the above message for a hint."
 msgstr "Maak asseblief die fout reg en probeer weer."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4303,7 +4317,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Fout in die skryf van lêer '%1'"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4323,21 +4337,25 @@ msgstr "&Verwyder skakel"
 msgid "Service '%s' has been removed."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5229,15 +5247,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Weergawe"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arg."
 
@@ -5375,13 +5393,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -5419,7 +5437,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5687,98 +5705,98 @@ msgstr[1] "Woordrykheid"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, fuzzy, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Fout in die skryf van lêer '%1'"
 
 # power-off message
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Wil u die stelsel nou stop?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Fout in die skryf van lêer '%1'"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, fuzzy, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Lees van lêerlys vanaf %s"
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 #, fuzzy
 msgid "Please see the above error message for a hint."
 msgstr "Maak asseblief die fout reg en probeer weer."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, fuzzy, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "'n Fout het voorgekom terwyl die opgawe gelees is."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 #, fuzzy
 msgid "No alias defined for this repository."
 msgstr "'n Fout het voorgekom terwyl die opgawe gelees is."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, fuzzy, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Fout in die skryf van lêer '%1'"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 #, fuzzy
 msgid "Forcing building of repository cache"
 msgstr "Waarskuwing: Onbekende metadatasoort"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, fuzzy, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Fout in die skryf van lêer '%1'"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5786,42 +5804,42 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, fuzzy, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 #, fuzzy
 msgid "Error building the cache:"
 msgstr "Fout tydens ontleding van die sertifikaat."
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Fout in die skryf van lêer '%1'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, fuzzy, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Fout in die skryf van lêer '%1'"
@@ -5829,267 +5847,267 @@ msgstr "Fout in die skryf van lêer '%1'"
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Inisialiseer van Teiken"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 #, fuzzy
 msgid "Target initialization failed:"
 msgstr "Inisialisasie het misluk"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, fuzzy, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Fout in die skryf van lêer '%1'"
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, fuzzy, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Fout in die skryf van lêer '%1'"
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, fuzzy, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Fout in die skryf van lêer '%1'"
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, fuzzy, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Lees van pakkette vanaf %s"
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 #, fuzzy
 msgid "Cleaning installed packages cache."
 msgstr "Nagaan van geïnstalleerde RPM-pakkette ..."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 #, fuzzy
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "kon hulpbronne nie kopieer nie (databasisfout)"
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 #, fuzzy
 msgid "Could not clean the repositories because of errors."
 msgstr "kon hulpbronne nie kopieer nie (databasisfout)"
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 #, fuzzy
 msgid "Specified repositories have been cleaned up."
 msgstr "Fout in die skryf van lêer '%1'"
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 #, fuzzy
 msgid "All repositories have been cleaned up."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, fuzzy, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Fout in die skryf van lêer '%1'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 #, fuzzy
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Waarskuwing: Onbekende metadatasoort"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 #, fuzzy
 msgid "Please check whether the specified URI is accessible."
 msgstr "skriplêer is ontoeganklik"
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 #, fuzzy
 msgid "Unknown problem when adding repository:"
 msgstr "Waarskuwing: Onbekende metadatasoort"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, fuzzy, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Lees van produk vanaf %s"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, fuzzy, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Lees van produk vanaf %s"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, fuzzy, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Lees van produk vanaf %s"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 #, fuzzy
 msgid "Problem accessing the file at the specified URI"
 msgstr "Waarskuwing: Onbekende metadatasoort"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 #, fuzzy
 msgid "Please check if the URI is valid and accessible."
 msgstr "skriplêer is ontoeganklik"
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 #, fuzzy
 msgid "Problem parsing the file at the specified URI"
 msgstr "Waarskuwing: Onbekende metadatasoort"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 #, fuzzy
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Waarskuwing: Onbekende metadatasoort"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 #, fuzzy
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Fout in die skryf van lêer '%1'"
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Fout in die skryf van lêer '%1'"
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Fout in die skryf van lêer '%1'"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Fout in die skryf van lêer '%1'"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, fuzzy, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, fuzzy, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Fout in die skryf van lêer '%1'"
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, fuzzy, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Waarskuwing: Onbekende metadatasoort"
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 #, fuzzy
 msgid "Loading repository data..."
 msgstr "Fout in die skryf van lêer '%1'"
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 #, fuzzy
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
@@ -6098,43 +6116,43 @@ msgstr ""
 "Waarskuwing: Geen bronne nie. Werk slegs met die geïnstalleerde oplossings. "
 "Niks kan geïnstalleer word nie."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Fout in die skryf van lêer '%1'"
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "Diens is nie aan die loop nie"
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6142,32 +6160,32 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "Nagaan van geïnstalleerde RPM-pakkette ..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "’n Fout het voorgekom tydens lees vanaf die installasiebron."
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6176,28 +6194,28 @@ msgstr ""
 msgid "System Packages"
 msgstr "Stelselarea-items"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 #, fuzzy
 msgid "No patterns found."
 msgstr "Geen klank nie"
 
-#: src/search.cc:450
+#: src/search.cc:453
 #, fuzzy
 msgid "No packages found."
 msgstr "Geen klank nie"
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "Interne fout"
 
-#: src/search.cc:544
+#: src/search.cc:549
 #, fuzzy
 msgid "No products found."
 msgstr "Geen klank nie"
@@ -6587,7 +6605,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 #, fuzzy
 msgid "Patches"
 msgstr "regstelling"
@@ -6612,7 +6630,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "Hierdie pakkette moet geïnstalleer word:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 #, fuzzy
 msgid "No updates found."
 msgstr "Geen klank nie"
@@ -6623,56 +6641,56 @@ msgstr "Geen klank nie"
 msgid "The following updates are also available:"
 msgstr "Die volgende hulpbronne word verander"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 #, fuzzy
 msgid "Pattern updates"
 msgstr "Batterystatus"
 
-#: src/update.cc:706
+#: src/update.cc:713
 #, fuzzy
 msgid "Product updates"
 msgstr "Produk"
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "Huidige verbinding"
 
-#: src/update.cc:795
+#: src/update.cc:801
 #, fuzzy
 msgid "Available Version"
 msgstr "Beskikbare geheue"
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "Geen klank nie"
 
-#: src/update.cc:978
+#: src/update.cc:986
 #, fuzzy
 msgid "The following matches in issue numbers have been found:"
 msgstr "Hierdie pakkette moet geïnstalleer word:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -11,11 +11,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Arabic <https://l10n.opensuse.org/projects/zypper/master/ar/>"
-"\n"
+"Language-Team: Arabic <https://l10n.opensuse.org/projects/zypper/master/ar/"
+">\n"
 "Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -312,8 +312,8 @@ msgid ""
 "Additionally use disabled repositories providing a specific keyword. Try '--"
 "plus-content debug' to enable repos indicating to provide debug packages."
 msgstr ""
-"استخدام المستودعات المعطلة التي توفر كلمة أساسية محددة بشكل إضافي. استخدم "
-"'--plus-content debug' لتمكين المستودع الذي يشير إلى توفير حزم تصحيح الأخطاء."
+"استخدام المستودعات المعطلة التي توفر كلمة أساسية محددة بشكل إضافي. استخدم '--"
+"plus-content debug' لتمكين المستودع الذي يشير إلى توفير حزم تصحيح الأخطاء."
 
 #: src/Config.cc:491
 msgid "Repositories disabled, using the database of installed packages only."
@@ -1082,8 +1082,8 @@ msgstr[1] ""
 "%d حزمة تالية موصى بها، ولكن لن يتم تثبيتها لأنه غير مرغوب فيها (تمت إزالتها "
 "من قبل يدوياً):"
 msgstr[2] ""
-"الحزمتان التاليتان %d موصى بهما، ولكن لن يتم تثبيتها لأنه غير مرغوب فيها ("
-"تمت إزالتها من قبل يدوياً):"
+"الحزمتان التاليتان %d موصى بهما، ولكن لن يتم تثبيتها لأنه غير مرغوب فيها "
+"(تمت إزالتها من قبل يدوياً):"
 msgstr[3] ""
 "%d الحزم التالية موصى بها، ولكن لن يتم تثبيتها لأنه غير مرغوب فيها (تمت "
 "إزالتها من قبل يدوياً):"
@@ -1103,7 +1103,8 @@ msgid_plural ""
 "The following %d packages are recommended, but will not be installed due to "
 "conflicts or dependency issues:"
 msgstr[0] "يوصي بالحزمة التالية، ولكن لن يتم تثبيتها بسبب التعارض أو التبعية:"
-msgstr[1] "يوصي بالحزمة التالية %d ولكن لن يتم تثبيتها بسبب التعارض أو التبعية:"
+msgstr[1] ""
+"يوصي بالحزمة التالية %d ولكن لن يتم تثبيتها بسبب التعارض أو التبعية:"
 msgstr[2] ""
 "يوصي بالحزمتان التاليتان %d ولكن لن يتم تثبيتهما بسبب التعارض أو التبعية:"
 msgstr[3] "يوصي بالحزم التالية %d ولكن لن يتم تثبيتها بسبب التعارض أو التبعية:"
@@ -1749,7 +1750,7 @@ msgstr "PackageKit قيد التشغيل بالفعل (من المحتمل أن 
 msgid "Try again?"
 msgstr "هل تريد المحاولة مرة أخرى؟"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "استثناء غير متوقع."
 
@@ -1780,12 +1781,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "لا يُحدث الخيار %s أي تأثير هنا، تجاهل."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "وسيطات برنامج غير الخيار: "
 
@@ -2517,17 +2518,17 @@ msgid "Commands:"
 msgstr "الأمران:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "عرض ملخص التثبيت التفصيلي."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "نوع الحزمة (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2535,9 +2536,15 @@ msgstr ""
 "تحديد أسلوب 'أفضل جهد' للتحديث. يتم قبول التحديثات التي تكون أقل من الإصدار "
 "الأخير."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "عدم مراعاة إلا التصحيحات التي تؤثر على إدارة الحزم نفسها."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2612,7 +2619,7 @@ msgstr "zypper [--خيارات عامة] <command> [--خيارات الأوام�
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <subcommand> [--خيارات الأوامر] [الوسائط]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "تعليمات الطباعة"
 
@@ -2814,22 +2821,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [خيارات]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "سرد كل التصحيحات القابلة للتطبيق."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "سرد كل التصحيحات، وليست التصحيحات القابلة للتطبيق فقط."
 
@@ -2884,35 +2891,39 @@ msgstr ""
 "بكل المناطق اللغوية المتاحة عن طريق استدعاء '%s'."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [OPTIONS] [LOCALE] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "سرد المناطق اللغوية المطلوبة (رموز اللغات)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "سرد المناطق اللغوية المطلوبة والحزم المتوافقة."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "عرض الحزم المتوافقة."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "سرد كل المناطق اللغوية المتاحة."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr "تجاهل الوسائط الموضعية لأنه --تم إدخال كل الوسائط."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "المناطق اللغوية التي يجب طباعة المعلومات لها."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2920,15 +2931,15 @@ msgstr ""
 "الحصول على كل المناطق اللغوية برمز اللغة 'en' التي لها رمز دولة خاص بها، "
 "باستثناء اللغة الاحتياطية 'en':"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr "الحصول على كل المناطق اللغوية برمز اللغة 'en' سواء برمز دولة أو بدونه:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "الحصول على المنطقة اللغوية التي تتطابق مع الوسيطة تمامًا: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "الحصول على قائمة الحزم المتاحة لأجل 'de' و'en':"
 
@@ -3040,11 +3051,11 @@ msgstr[5] "إزالة %lu أقفال."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "الاسم"
 
@@ -3054,8 +3065,8 @@ msgstr "المطابقات"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "النوع"
@@ -3063,7 +3074,7 @@ msgstr "النوع"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "المخزن"
@@ -3511,7 +3522,7 @@ msgid "Command"
 msgstr "الأمر"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "الخدمة"
 
@@ -3678,120 +3689,120 @@ msgid "Show detailed information for products."
 msgstr "إظهار المعلومات التفصيلية للمنتجات."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [OPTIONS] [REPOSITORY] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "سرد كل الحزم المتاحة."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "سرد كل الحزم المتوفرة في المخازن المحددة."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "إظهار الحزم المقترحة."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "إظهار الحزم الموصى بها."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "إظهار الحزم غير اللازمة."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "فرز القائمة حسب اسم الحزمة."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "فرز القائمة حسب المخزن."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [REPOSITORY] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "سرد كل التصحيحات المتاحة."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "سرد كل التصحيحات المتاحة في المخازن المحددة."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "سرد كل الأنماط المتاحة."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "سرد كافة الأنماط المتاحة في المخازن المحددة."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [OPTIONS] [REPOSITORY] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "سرد كل المنتجات المتاحة."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "سرد كافة المنتجات المتاحة في المخازن المحددة."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr "مخرجات XML فقط: إحالة حرفية لعلامات XML في ملف المنتج."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "خيار %1% ليس له تأثير بدون الخيار العالمي  %2%."
@@ -3832,12 +3843,12 @@ msgstr "عدم فحص URI ولكن فحصه لاحقًا أثناء التحدي
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr "يتم اكتشاف هذا النوع من المستودع تلقائيًا دائمًا. تم تجاهل هذا الخيار."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "تعذر استخدام %s مع %s. استخدام إعداد %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr "في حالة استخدام وسيطة واحدة فقط، يجب أن يشير URI إلى ملف .repo."
@@ -3879,111 +3890,115 @@ msgstr "تنظيف ذاكرة التخزين المؤقت لبيانات الت�
 msgid "Clean both metadata and package caches."
 msgstr "تنظيف الذاكرتين المؤقتتين لبيانات التعريف والحزم."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "الاسم المستعار"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "مُمكّن"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "التحقق من GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "الأولوية"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "تجديد تلقائي"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "تشغيل"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "إيقاف تشغيل"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "الاحتفاظ بالحزم"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI الخاص بمفتاح GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "بادئة المسار"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "الخدمة الرئيسية"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "الكلمات الأساسية"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "مسار معلومات المخزن"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "مسار ذاكرة التخزين المؤقت لـ MD"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [خيارات] [repo] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "إدراج كل المخازن المحددة."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "تصدير كل المخازن المحددة كملف .repo محلي فردي."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "حدث خطأ أثناء قراءة المخازن:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "تعذر فتح %s للكتابة."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "هل من الممكن ألا يكون لديك أذونات كتابة؟"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "تم تصدير المخازن بنجاح إلى %s."
@@ -3991,20 +4006,20 @@ msgstr "تم تصدير المخازن بنجاح إلى %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "تجديد"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "لم يتم تحديد أي مخازن."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr "استخدم الأمر 'zypper addrepo' لإضافة مخزن واحد أو أكثر."
 
@@ -4109,7 +4124,7 @@ msgstr "لا يُحدث الخيار العام '%s' أي تأثير هنا."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "غير مسموح بالوسيطات في حالة استخدام '%s'."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "المخازن المحددة: "
 
@@ -4118,7 +4133,7 @@ msgstr "المخازن المحددة: "
 msgid "Refreshing repository '%s'."
 msgstr "تحديث المستودع '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "مسح محتويات المخزن '%s' الذي تم تعطيله."
@@ -4128,7 +4143,7 @@ msgstr "مسح محتويات المخزن '%s' الذي تم تعطيله."
 msgid "Skipping disabled repository '%s'"
 msgstr "تخطي المخزن '%s' الذي تم تعطيله"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "تخطي المخزن '%s' بسبب الخطأ أعلاه."
@@ -4155,7 +4170,7 @@ msgstr "استخدم الأمرين '%s' أو '%s' لإضافة مخازن أو 
 msgid "Could not refresh the repositories because of errors."
 msgstr "تعذر تجديد المخازن بسبب حدوث أخطاء."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "لم يتم تجديد بعض المخازن بسبب حدوث خطأ."
 
@@ -4212,12 +4227,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "تمت إعادة تسمية المخزن '%s' إلى '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "المخزن بالاسم '%s' موجود بالفعل. الرجاء استخدام اسم مستعار آخر."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "حدث خطأ أثناء تعديل المخزن:"
 
@@ -4656,25 +4671,25 @@ msgstr ""
 "Like --details, بالمعلومات الإضافية التي تطابق البحث (مفيد في حالة البحث في "
 "التبعيات)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "تم تعطيل المخزن المحدد '%s'."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "لم يتم العثور على عناصر مطابقة."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "حدثت مشكلة أثناء تهيئة استعلام البحث أو تنفيذه"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "راجع الرسالة أعلاه للحصول على تلميح."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "قد يؤدي تشغيل 'zypper refresh' كجذر إلى حل المشكلة."
 
@@ -4765,7 +4780,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "حدثت مشكلة أثناء استرداد ملف فهرس المخازن للخدمة '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "تخطي خدمة '%s' بسبب حدوث الخطأ أعلاه."
@@ -4784,22 +4799,26 @@ msgstr "إزالة الخدمة '%s':"
 msgid "Service '%s' has been removed."
 msgstr "تمت إزالة الخدمة '%s'."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "خدمات (ls) [OPTIONS]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "سرد كل الخدمات المعرَّفة."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "إدراج الخدمات المحددة."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr "لم يتم تعريف أية خدمة. استخدم الأمر '%s' لإضافة خدمة واحدة أو أكثر."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5718,15 +5737,15 @@ msgstr "%s أقدم من %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "الإصدار"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "الهيكل"
 
@@ -5864,13 +5883,13 @@ msgstr "(فارغ)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "التبعية"
 
@@ -5907,7 +5926,7 @@ msgid "Flavor"
 msgstr "صفة"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "هو أساس"
 
@@ -6170,57 +6189,57 @@ msgstr[5] "%1% مستودعات"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "التحقق من ضرورة تجديد بيانات التعريف لـ %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "المخزن '%s' حديث."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "تم تأخير فحص التحديث '%s'."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "فرض تجديد بيانات التعريف الأولية"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "استرداد بيانات تعريف '%s' للمخزن"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "هل تريد تعطيل المخزن %s بشكل دائم؟"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "حدث خطأ أثناء تعطيل المخزن '%s'."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "حدثت مشكلة أثناء استرداد الملفات من '%s'."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "الرجاء مراجعة رسالة الخطأ أعلاه للحصول على تلميح."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "لم يتم تعريف أية محددات URI لـ '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -6228,38 +6247,38 @@ msgid ""
 msgstr ""
 "الرجاء إضافة إدخال URI أساسي (baseurl=URI) واحد أو أكثر إلى %s للمخزن '%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "لم يتم تعريف أي اسم مستعار لهذا المخزن."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "المخزن '%s' غير صالح."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 "الرجاء التحقق مما إذا كانت محددات URI المعرَّفة لهذا المخزن تشير إلى مخزن صالح."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "حدث خطأ أثناء استرداد بيانات التعريف لـ '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "فرض بناء ذاكرة التخزين المؤقت للمخزن"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "حدث خطأ أثناء تحليل بيانات التعريف لـ '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6271,44 +6290,44 @@ msgstr ""
 "خطأ وذلك باتباع الإرشادات الموجودة على http://en.opensuse.org/"
 "Zypper#Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 "لم يتم العثور على بيانات تعريف المخزن لـ '%s' في ذاكرة التخزين المؤقت "
 "المحلية."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "خطأ في إنشاء ذاكرة التخزين المؤقت:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 "لم يتم العثور على المخزن '%s' حسب الاسم المستعار أو الرقم أو URI الخاص به."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "استخدم '%s' للحصول على قائمة بالمخازن المعرَّفة."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "تجاهل المخزن '%s' الذي تم تعطيله"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr "يمكن استخدام الأمرالعام '%s' لتمكين المستودعات مؤقتًا."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "تجاهل المخزن '%s' بسبب الخيار '%s'."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "تمكين المخزن '%s' مؤقتًا."
@@ -6316,14 +6335,14 @@ msgstr "تمكين المخزن '%s' مؤقتًا."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr "المخزن '%s' قديم. يمكنك تشغيل 'zypper refresh' كجذر لتحديثه."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6332,79 +6351,79 @@ msgstr ""
 "يلزم بناء الذاكرة المؤقتة لبيانات التعريف لمخزن '%s'. يمكنك تشغيل 'zypper "
 "refresh' كجذر للقيام بذلك."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "المخزن '%s' لا يزال معطلاً."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "تهيئة الهدف"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "فشلت تهيئة الهدف:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "تنظيف ذاكرة التخزين المؤقت لبيانات التعريف لـ '%s'."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "تنظيف ذاكرة التخزين المؤقت لبيانات التعريف الأولية لـ '%s'."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "الاحتفاظ بذاكرة التخزين المؤقت لبيانات التعريف الأولية لـ %s '%s'."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "تنظيف الحزم لـ  '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "تعذر تنظيف المخزن '%s' بسبب حدوث خطأ."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "تنظيف ذاكرة التخزين المؤقت للحزم المثبَّتة."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "لا يمكن تنظيف ذاكرة التخزين المؤقت للحزم المثبتة لوجود خطأ."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "تعذر تنظيف المخازن بسبب حدوث أخطاء."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "لم يتم تنظيف بعض المخازن بسبب حدوث خطأ."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "تم تنظيف المخازن المحددة."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "تم تنظيف كل المخازن."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr "هذه وسائط (CD/DVD) للقراءة فقط قابلة للتغيير، تعطيل التجديد التلقائي."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "الاسم المستعار للمخزن غير صالح: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6412,25 +6431,25 @@ msgstr ""
 "تعذر تحديد نوع المخزن. الرجاء التحقق مما إذا كانت محددات URI (انظر أدناه) "
 "تشير إلى مخزن صالح:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "تعذر العثور على مخزن صالح في الموقع المحدد:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "حدثت مشكلة أثناء نقل بيانات المخزن من URI المحدد:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "الرجاء التحقق من إمكانية الوصول إلى URI المحدد."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "حدثت مشكلة غير معروفة أثناء إضافة المخزن:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6439,135 +6458,135 @@ msgstr ""
 "تم تعطيل التحقق من مفتاح GPG في إعداد مستودع '%1%'. لا يمكن التحقق من سلامة "
 "وأصل الحزم."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "تمت إضافة المخزن '%s' بنجاح"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "قراءة البيانات من وسائط '%s'"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "حدثت مشكلة أثناء قراءة البيانات من وسائط '%s'"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "الرجاء التحقق من صلاحية وسائط التثبيت وقابليتها للقراءة."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "تم تأخير قراءة البيانات من وسائط '%s' حتى التجديد التالي."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "قراءة البيانات من وسائط '%s'"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "حدثت مشكلة أثناء قراءة البيانات من وسائط '%s'"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "الرجاء التحقق من صلاحية وسائط التثبيت وقابليتها للقراءة."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "حدثت مشكلة أثناء الوصول إلى الملف في URI المحدد"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "الرجاء التحقق من صلاحية URI وإمكانية الوصول إليه."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "حدثت مشكلة أثناء تحليل الملف في URI المحدد"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "هل هو ملف .repo؟"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "حدثت مشكلة أثناء محاولة قراءة الملف في URI المحدد"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "تم العثور على مخزن بدون أي اسم مستعار تم تعريفه، تخطي."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "لا يحتوي المخزن '%s' على أي محدد URI معرَّف، تخطي."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "تمت إزالة المخزن '%s'."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "لم يتم تغيير الأولوية للمخزن '%s' مطلقًا (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "تم تمكين المخزن '%s' بنجاح."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "تم تعطيل المخزن '%s' بنجاح."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "تم تمكين التجديد التلقائي للمخزن '%s'."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "تم تعطيل التجديد التلقائي للمخزن '%s'."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "تم تمكين التخزين المؤقت لملفات RPM للمخزن '%s'."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "تم تعطيل التخزين المؤقت لملفات RPM للمخزن '%s'."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "تم تمكين التحقق من GPG للمخزن '%s'."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "تم تعطيل التحقق من GPG للمخزن '%s'."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "تم تعيين أولوية المخزن '%s' إلى %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "تم تعيين اسم المخزن '%s' إلى '%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "لم يطرأ أي تغيير على المخزن '%s'."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "ترك المخزن %s دون تغيير."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "يتم الآن تحميل بيانات المخزن..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6575,43 +6594,43 @@ msgstr ""
 "لم يتم تحديد أي مخازن. يتم التشغيل بالتبعيات القابلة للتحليل المثبتة فقط. "
 "ولا يمكن تثبيت أي شيء آخر."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "يتم الآن استرداد بيانات المخزن '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "لم يتم تخزين المخزن '%s' مؤقتًا. يتم الآن التخزين المؤقت..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "حدثت مشكلة أثناء تحميل البيانات من '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "تعذر تجديد المخزن '%s'. استخدام ذاكرة التخزين المؤقت القديمة."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "لم يتم تحميل التبعيات القابلة للتحليل من '%s' بسبب حدوث خطأ."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "جرب '%s'، أو حتى '%s' قبل القيام بذلك."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6619,30 +6638,30 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "تتم الآن قراءة الحزم المثبَّتة..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "حدثت مشكلة أثناء قراءة الحزم المثبتة:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' يبدو كملف RPM. سنحاول إنزاله."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "حدثت مشكلة في ملف RPM المحدد كـ '%s'، تخطي."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "حدثت مشكلة أثناء قراءة رأس RPM الخاص بـ %s. هل هذا ملف RPM؟"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "ذاكرة التخزين المؤقت لملفات RPM العادية"
 
@@ -6650,25 +6669,25 @@ msgstr "ذاكرة التخزين المؤقت لملفات RPM العادية"
 msgid "System Packages"
 msgstr "حزم النظام"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "لم يتم العثور على أية تصحيحات ضرورية."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "لم يتم العثور على أية أنماط."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "لم يتم العثور على أية حزم."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "الاسم الداخلي"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "لم يتم العثور على أية منتجات."
 
@@ -7106,7 +7125,7 @@ msgid "Updatestack"
 msgstr "Updatestack"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "التصحيحات"
 
@@ -7129,7 +7148,7 @@ msgstr "الفئات المضمنة"
 msgid "Needed software management updates will be installed first:"
 msgstr "سيتم تثبيت تحديثات إدارة البرامج المطلوبة أولاً:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "لم يتم العثور على أية تحديثات."
 
@@ -7138,50 +7157,50 @@ msgstr "لم يتم العثور على أية تحديثات."
 msgid "The following updates are also available:"
 msgstr "التحديثات التالية متوفرة أيضًا:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "تحديثات الحزم"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "تحديثات الأنماط"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "تحديثات المنتجات"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "الإصدار الحالي"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "الإصدار المتوفر"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "لم يتم العثور على مشكلات مطابقة."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "تم العثور على المطابقات التالية في أرقام المشكلات:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "تم العثور على المطابقات في أوصاف التصحيح الخاصة بالتصحيحات التالية:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr "لم يتم العثور على إصلاح لرقم مشكلة bugzilla %s أو أنه غير مطلوب."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "لم يتم العثور على إصلاح لرقم مشكلة CVE %s أو أنه غير مطلوب."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "لم يتم العثور على إصلاح لرقم مشكلة %s %s أو أنه غير مطلوب."

--- a/po/ast.po
+++ b/po/ast.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Asturian <https://l10n.opensuse.org/projects/zypper/master/"
@@ -856,7 +856,8 @@ msgid "The following recommended product was automatically selected:"
 msgid_plural ""
 "The following %d recommended products were automatically selected:"
 msgstr[0] "Esbillóse automáticamente'l productu recomendáu de darréu:"
-msgstr[1] "Esbilláronse automáticamente los %d productos recomendaos de darréu:"
+msgstr[1] ""
+"Esbilláronse automáticamente los %d productos recomendaos de darréu:"
 
 #: src/Summary.cc:1094
 #, c-format, boost-format
@@ -1360,7 +1361,7 @@ msgstr "PackageKit entá ta executándose (quiciabes tea ocupáu)."
 msgid "Try again?"
 msgstr "¿Tentar de nueves?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Esceición inesperada."
 
@@ -1388,12 +1389,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Equí nun tien efeutu dalu la opción %s, inorando."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -1627,7 +1628,8 @@ msgstr "Falló la verificación de robla pal ficheru «%1%»."
 #: src/callbacks/keyring.h:389
 #, boost-format
 msgid "Signature verification failed for file '%1%' from repository '%2%'."
-msgstr "Falló la verificación de robla pal ficheru «%1%» del repositoriu «%2%»."
+msgstr ""
+"Falló la verificación de robla pal ficheru «%1%» del repositoriu «%2%»."
 
 #: src/callbacks/keyring.h:438
 msgid ""
@@ -2092,24 +2094,30 @@ msgid "Commands:"
 msgstr "Comandos:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2182,7 +2190,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Amuesa l'ayuda"
 
@@ -2363,22 +2371,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [OPCIONES]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Llista tolos parches aplicables."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Llista tolos parches, non solo los aplicables."
 
@@ -2429,49 +2437,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2573,11 +2585,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Nome"
 
@@ -2587,8 +2599,8 @@ msgstr ""
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Triba"
@@ -2596,7 +2608,7 @@ msgstr "Triba"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Repositoriu"
@@ -3016,7 +3028,7 @@ msgid "Command"
 msgstr "Comandu"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Serviciu"
 
@@ -3180,120 +3192,120 @@ msgid "Show detailed information for products."
 msgstr "Amuesa información detallada pa productos."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3333,12 +3345,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "Nun pue usase %s xunto con %s. Usando l'axuste %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3382,111 +3394,115 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Nomatu"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr ""
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr ""
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Prioridá"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr ""
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI de clave GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Serviciu pá"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Pallabres clave"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Fallu lleendo los repositorios:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Nun pue abrise %s pa escritura."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3494,20 +3510,20 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr ""
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Nun se definieron repositorios."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3608,7 +3624,7 @@ msgstr "Equí nun tien efeutu dalu la opción global «%s»."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Nun s'almiten los argumentos si s'usa «%s»."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Repositorios especificaos: "
 
@@ -3617,7 +3633,7 @@ msgstr "Repositorios especificaos: "
 msgid "Refreshing repository '%s'."
 msgstr "Resfrescando'l repositoriu «%s»."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Escaniando'l conteníu del repositoriu deshabilitáu «%s»."
@@ -3627,7 +3643,7 @@ msgstr "Escaniando'l conteníu del repositoriu deshabilitáu «%s»."
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3655,7 +3671,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "Nun pudieron refrescase los repositorios pola mor de fallos."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Nun se refrescaron dellos repositorios pola mor d'un fallu."
 
@@ -3708,12 +3724,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr ""
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "Yá esiste'l repositoriu nomáu «%s». Usa otru nomatu, por favor."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Fallu entrín se modificaba'l repositoriu:"
 
@@ -4141,25 +4157,25 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "El repositoriu «%s» ta deshabilitáu."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Nun s'alcontraron elementos que concasen."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "Executar «zypper refresh» quiciabes igüe'l problema."
 
@@ -4249,7 +4265,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr ""
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4268,23 +4284,27 @@ msgstr "Desaniciando'l serviciu «%s»:"
 msgid "Service '%s' has been removed."
 msgstr "Desanicióse con ésitu'l serviciu «%s»."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Nun se definieron servicios. Usa'l comandu «%s» p'amestar ún o más servicios."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5166,15 +5186,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Versión"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arq."
 
@@ -5308,13 +5328,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr ""
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Dependencia"
 
@@ -5351,7 +5371,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Ye base"
 
@@ -5611,94 +5631,94 @@ msgstr[1] "%1% repositorios"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "El repositoriu «%s» ta anováu."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr ""
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Forciando'l refrescu de datos meta en bruto"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Recibiendo datos meta del repositoriu «%s»"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "¿Quies deshabilitar dafechu'l repositoriu %s?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Fallu entrín se deshabilitaba'l repositoriu «%s»."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Problemes recibiendo ficheros de «%s»."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr ""
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr ""
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "El reposituriu «%s» nun ye váldu."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Fallu recibiendo los datos meta pa «%s»:"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Fallu analizando datos meta pa «%s»:"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5706,41 +5726,41 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Fallu construyendo la caché:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Nun s'alcontró'l repositoriu «%s» pol so alcuñu, númberu o URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Inorando'l repositoriu deshabilitáu «%s»"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Inorando'l repositoriu «%s» pola mor de la opción «%s»."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr ""
@@ -5748,296 +5768,296 @@ msgstr ""
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr ""
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr ""
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr ""
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Llimpiando caché de datos meta pa «%s»."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Llimpiando caché de datos meta en bruto pa «%s»."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Calteniendo la caché de datos meta en bruto pa %s «%s»."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Llimpiando paquetes pa «%s»."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Nun pue llimpiase'l repositoriu «%s» pola mor d'un fallu."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Llimpiando cache de paquetes instalaos."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Nun puen llimpiase los paquetes pola mor d'un fallu."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Nun pudieron llimpiase los repositorios pola mor de fallos."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Nun se llimpiaron dellos repositorios pols mor d'un fallu."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Llimpiáronse los repositorios especificaos."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Llimpiáronse tolos repositorios."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Nomatu non válidu de repositoriu: «%s»"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Nun pue alcontrase un repositoriu válidu nel allugamientu dau:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Comprueba si l'URI especificáu ye accesible, por favor."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Problema desconocíu al amestar el repositoriu:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Amestóse con ésitu'l repositoriu «%s»"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Lleendo datos del mediu «%s»"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Lleendo datos del mediu «%s»"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "¿Ye un ficheru .repo?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 "Alcontróse un problema entrín se tentaba de lleer el ficheru nel URI "
 "especificáu"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Desanicióse'l repositoriu «%s»."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr ""
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr ""
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr ""
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr ""
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr ""
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr ""
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr ""
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Recibiendo los datos del repositoriu «%s»..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Problema cargando los datos de «%s»"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6045,30 +6065,30 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Lleendo los paquetes instalaos..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Asocedió un fallu entrín se lleíen los paquetes instalaos:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "«%s» paez un ficheru RPM. Tentará baxase."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Problema lleendo la testera RPM de %s. ¿Ye un ficheru RPM?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6076,25 +6096,25 @@ msgstr ""
 msgid "System Packages"
 msgstr "Paquetes del sistema"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Nun s'alcontraron los parches precisos."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Nun s'alcontraron patrones."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Nun s'alcontraron paquetes."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Nome internu"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Nun s'alcontraron productos."
 
@@ -6123,7 +6143,8 @@ msgstr ""
 #: src/solve-commit.cc:138
 msgid "Choose the above solution using '1' or skip, retry or cancel"
 msgid_plural "Choose from above solutions by number or skip, retry or cancel"
-msgstr[0] "Escueyi la solución d'enriba usando «1» o saltar, retentar o encaboxar"
+msgstr[0] ""
+"Escueyi la solución d'enriba usando «1» o saltar, retentar o encaboxar"
 msgstr[1] ""
 "Escueyi les soluciones d'enriba colos númberos o saltar, retentar o encaboxar"
 
@@ -6387,7 +6408,8 @@ msgstr ""
 
 #: src/solve-commit.cc:1045
 msgid "Problem occurred during or after installation or removal of packages:"
-msgstr "Asocedieron problemes dempués o na instalación o desaniciu de paquetes:"
+msgstr ""
+"Asocedieron problemes dempués o na instalación o desaniciu de paquetes:"
 
 #: src/solve-commit.cc:1084
 msgid ""
@@ -6470,7 +6492,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr ""
 
@@ -6493,7 +6515,7 @@ msgstr "Estayes incluyíes"
 msgid "Needed software management updates will be installed first:"
 msgstr ""
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Nun s'alcontraron anovamientos."
 
@@ -6502,50 +6524,50 @@ msgstr "Nun s'alcontraron anovamientos."
 msgid "The following updates are also available:"
 msgstr "Tamién tán disponibles los anovamientos de darréu:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr ""
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr ""
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Versión actual"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Versión disponible"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr ""
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/be.po
+++ b/po/be.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Belarusian <https://l10n.opensuse.org/projects/zypper/master/"
@@ -237,7 +237,8 @@ msgstr ""
 #. translators: --reposd-dir, -D <DIR>
 #: src/Config.cc:397
 msgid "Use alternative repository definition file directory."
-msgstr "Выкарыстоўваць альтэрнатыўны каталог файлаў з азначэннямі рэпазіторыяў."
+msgstr ""
+"Выкарыстоўваць альтэрнатыўны каталог файлаў з азначэннямі рэпазіторыяў."
 
 #. translators: --cache-dir, -C <DIR>
 #: src/Config.cc:412
@@ -1438,7 +1439,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "Запуск усталёўкі..."
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr ""
 
@@ -1466,12 +1467,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2213,17 +2214,17 @@ msgid "Commands:"
 msgstr "Каманды:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Паказаць дэтальны працэс усталёўкі."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Тып пакета (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2231,10 +2232,16 @@ msgstr ""
 "Выкарыстоўваць падыход \"найлепшых дзеянняў\" для абнаўлення. Абнаўлення да "
 "не самых апошніх версій таксама прынімаюцца."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr ""
 "Выкарыстоўваць толькі патчы, якія уплываюць адразу на кіраўніцтва пакетамі."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2303,7 +2310,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2484,22 +2491,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2550,49 +2557,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2695,11 +2706,11 @@ msgstr[2] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr ""
 
@@ -2709,8 +2720,8 @@ msgstr ""
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Тып"
@@ -2718,7 +2729,7 @@ msgstr "Тып"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Сховішча"
@@ -3137,7 +3148,7 @@ msgid "Command"
 msgstr "Каманды:"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "Прыстасаванне"
@@ -3298,120 +3309,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3450,12 +3461,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3497,115 +3508,119 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Уключаны"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr ""
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 #, fuzzy
 msgid "Autorefresh"
 msgstr "Абнавіць"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 #, fuzzy
 msgid "On"
 msgstr "Аман"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr ""
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "Прыстасаванне"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 #, fuzzy
 msgid "Error reading repositories:"
 msgstr "Дадаць уключаныя сховішчы"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr ""
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3613,22 +3628,22 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 #, fuzzy
 msgid "Refresh"
 msgstr "Абнавіць"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "Выдаліць непатрэбныя сховішчы"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3729,7 +3744,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 #, fuzzy
 msgid "Specified repositories: "
 msgstr "Дадаць уключаныя сховішчы"
@@ -3739,7 +3754,7 @@ msgstr "Дадаць уключаныя сховішчы"
 msgid "Refreshing repository '%s'."
 msgstr "Дадаць выключаныя сховішчы"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Даданне выключаных сховішчаў..."
@@ -3749,7 +3764,7 @@ msgstr "Даданне выключаных сховішчаў..."
 msgid "Skipping disabled repository '%s'"
 msgstr "Даданне выключаных сховішчаў..."
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3777,7 +3792,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3830,12 +3845,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr ""
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr ""
 
@@ -4267,25 +4282,25 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Выдаліць непатрэбныя сховішчы"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr ""
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4375,7 +4390,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr ""
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4394,21 +4409,25 @@ msgstr "Запускаюцца сервісы..."
 msgid "Service '%s' has been removed."
 msgstr ""
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5289,15 +5308,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr ""
 
@@ -5432,13 +5451,13 @@ msgstr "(пуста)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr ""
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -5475,7 +5494,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5730,95 +5749,95 @@ msgstr[2] "Сховішча"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr ""
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr ""
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr ""
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr ""
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Дадаць выключаныя сховішчы"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr ""
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr ""
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 #, fuzzy
 msgid "No alias defined for this repository."
 msgstr "Не вызначана паслядоўнасць для гэтага рэжыму ўсталёўкі."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr ""
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr ""
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5826,41 +5845,41 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr ""
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Даданне выключаных сховішчаў..."
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr ""
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Дадаць выключаныя сховішчы"
@@ -5868,296 +5887,296 @@ msgstr "Дадаць выключаныя сховішчы"
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Выдаліць непатрэбныя сховішчы"
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 #, fuzzy
 msgid "Initializing Target"
 msgstr "Ініцыялізацыя"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr ""
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr ""
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr ""
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, fuzzy, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Дадаць выключаныя сховішчы"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr ""
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr ""
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr ""
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr ""
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr ""
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Даданне выключаных сховішчаў..."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Даданне выключаных сховішчаў..."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr ""
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr ""
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr ""
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 #, fuzzy
 msgid "Loading repository data..."
 msgstr "<p>Чытанне сховішчаў. Калі ласка,пачакайце...</p>"
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Выдаленне непатрэбных сховішчаў..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6165,32 +6184,32 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "Усталяванне пакетаў..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Усталяванне пакетаў..."
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6198,26 +6217,26 @@ msgstr ""
 msgid "System Packages"
 msgstr ""
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr ""
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr ""
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "Імя модуля"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr ""
 
@@ -6595,7 +6614,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr ""
 
@@ -6618,7 +6637,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr ""
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr ""
 
@@ -6627,52 +6646,52 @@ msgstr ""
 msgid "The following updates are also available:"
 msgstr ""
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr ""
 
-#: src/update.cc:706
+#: src/update.cc:713
 #, fuzzy
 msgid "Product updates"
 msgstr "&Прадукт"
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "Бягучы стан"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr ""
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr ""
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Bulgarian <https://l10n.opensuse.org/projects/zypper/master/"
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "Подготовка на инсталацията..."
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr ""
 
@@ -1402,12 +1402,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2107,24 +2107,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2194,7 +2200,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2377,22 +2383,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2443,49 +2449,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2589,11 +2599,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Име"
 
@@ -2604,8 +2614,8 @@ msgstr "кръпка"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Тип"
@@ -2613,7 +2623,7 @@ msgstr "Тип"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr ""
@@ -3039,7 +3049,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "Сървър"
@@ -3203,120 +3213,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3355,12 +3365,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3402,118 +3412,122 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Разрешено"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 #, fuzzy
 msgid "GPG Check"
 msgstr "DNS проверка"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 #, fuzzy
 msgid "Autorefresh"
 msgstr "Авто-опресняване"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 #, fuzzy
 msgid "On"
 msgstr "не"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Keep Packages"
 msgstr "пакет"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 #, fuzzy
 msgid "Path Prefix"
 msgstr "Префикс при набиране"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "Печатащ сървър"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 #, fuzzy
 msgid "Error reading repositories:"
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Файлът не може да бъде отворен за запис."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3521,21 +3535,21 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Опресняване"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "Не са открити хранилища."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3636,7 +3650,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 #, fuzzy
 msgid "Specified repositories: "
 msgstr "Грешка при четенето на сектор %u."
@@ -3646,7 +3660,7 @@ msgstr "Грешка при четенето на сектор %u."
 msgid "Refreshing repository '%s'."
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Грешка при четенето на сектор %u."
@@ -3656,7 +3670,7 @@ msgstr "Грешка при четенето на сектор %u."
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3686,7 +3700,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "Избраният ред не може да бъде премахнат."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 #, fuzzy
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Избраният ред не може да бъде премахнат."
@@ -3740,12 +3754,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Хостът %s не бе открит."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 #, fuzzy
 msgid "Error while modifying the repository:"
 msgstr ""
@@ -4199,26 +4213,26 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Авто-опресняване"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "Не са открити грешки."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4309,7 +4323,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Грешка при четенето на сектор %u."
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, fuzzy, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Избраният ред не може да бъде премахнат."
@@ -4328,21 +4342,25 @@ msgstr "&Премахване на връзка"
 msgid "Service '%s' has been removed."
 msgstr "Хостът %s не бе открит."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5235,15 +5253,15 @@ msgstr "%s е необходим на %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Версия"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Архитектура"
 
@@ -5386,13 +5404,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr ""
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 #, fuzzy
 msgid "Dependency"
 msgstr "Зависимости"
@@ -5431,7 +5449,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5694,52 +5712,52 @@ msgstr[1] "Хостът %s не бе открит."
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Хостът %s не бе открит."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, fuzzy, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Хостът %s не бе открит."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Грешка при четенето на сектор %u."
 
 # power-off message
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Желаете ли да спрете сега системата?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr ""
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, fuzzy, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr ""
@@ -5748,14 +5766,14 @@ msgstr ""
 "%s"
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 #, fuzzy
 msgid "No alias defined for this repository."
 msgstr ""
@@ -5763,34 +5781,34 @@ msgstr ""
 "\n"
 "%s"
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Хостът %s не бе открит."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, fuzzy, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 #, fuzzy
 msgid "Forcing building of repository cache"
 msgstr "Зареждане на кеша..."
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, fuzzy, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Грешка при четенето на сектор %u."
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5798,12 +5816,12 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, fuzzy, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Хостът %s не бе открит."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 #, fuzzy
 msgid "Error building the cache:"
 msgstr ""
@@ -5811,32 +5829,32 @@ msgstr ""
 "\n"
 "%s"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Хостът %s не бе открит."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, fuzzy, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Избраният ред не може да бъде премахнат."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Грешка при четенето на сектор %u."
@@ -5844,309 +5862,309 @@ msgstr "Грешка при четенето на сектор %u."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Хостът %s не бе открит."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 #, fuzzy
 msgid "Initializing Target"
 msgstr "Инициализация на паралелния порт..."
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 #, fuzzy
 msgid "Target initialization failed:"
 msgstr "Инсталационни носители"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, fuzzy, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, fuzzy, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, fuzzy, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Грешка при четенето на сектор %u."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, fuzzy, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Избраният ред не може да бъде премахнат."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 #, fuzzy
 msgid "Cleaning installed packages cache."
 msgstr "Инсталирани пакети"
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 #, fuzzy
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Избраният ред не може да бъде премахнат."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 #, fuzzy
 msgid "Could not clean the repositories because of errors."
 msgstr "Избраният ред не може да бъде премахнат."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 #, fuzzy
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Избраният ред не може да бъде премахнат."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 #, fuzzy
 msgid "Specified repositories have been cleaned up."
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 #, fuzzy
 msgid "All repositories have been cleaned up."
 msgstr "Хостът %s не бе открит."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, fuzzy, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 #, fuzzy
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 #, fuzzy
 msgid "Unknown problem when adding repository:"
 msgstr "Грешка при четенето на сектор %u."
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 #, fuzzy
 msgid "Problem accessing the file at the specified URI"
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 #, fuzzy
 msgid "Problem parsing the file at the specified URI"
 msgstr "Грешка при четенето на сектор %u."
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 #, fuzzy
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 #, fuzzy
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Хостът %s не бе открит."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Хостът %s не бе открит."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Хостът %s не бе открит."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Хостът %s не бе открит."
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Хостът %s не бе открит."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Хостът %s не бе открит."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Хостът %s не бе открит."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, fuzzy, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Хостът %s не бе открит."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, fuzzy, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, fuzzy, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 #, fuzzy
 msgid "Loading repository data..."
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Грешка при четенето на сектор %u."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "Хостът %s не бе открит."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6154,32 +6172,32 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "Инсталирани пакети"
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Инсталирани пакети"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6187,29 +6205,29 @@ msgstr ""
 msgid "System Packages"
 msgstr ""
 
-#: src/search.cc:261
+#: src/search.cc:262
 #, fuzzy
 msgid "No needed patches found."
 msgstr "Не са намерени нови драйвери"
 
-#: src/search.cc:342
+#: src/search.cc:344
 #, fuzzy
 msgid "No patterns found."
 msgstr "Не са открити грешки."
 
-#: src/search.cc:450
+#: src/search.cc:453
 #, fuzzy
 msgid "No packages found."
 msgstr "Не са открити грешки."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "Вътрешна грешка"
 
-#: src/search.cc:544
+#: src/search.cc:549
 #, fuzzy
 msgid "No products found."
 msgstr "Не са открити грешки."
@@ -6593,7 +6611,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 #, fuzzy
 msgid "Patches"
 msgstr "кръпка"
@@ -6618,7 +6636,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "Пропускане на %s: вече е инсталиран"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 #, fuzzy
 msgid "No updates found."
 msgstr "Не са открити грешки."
@@ -6629,56 +6647,56 @@ msgstr "Не са открити грешки."
 msgid "The following updates are also available:"
 msgstr "Пропускане на %s: вече е инсталиран"
 
-#: src/update.cc:700
+#: src/update.cc:707
 #, fuzzy
 msgid "Package updates"
 msgstr "Управление на пакетите"
 
-#: src/update.cc:704
+#: src/update.cc:711
 #, fuzzy
 msgid "Pattern updates"
 msgstr "Скрити кръпки"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr ""
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "Текуща връзка"
 
-#: src/update.cc:795
+#: src/update.cc:801
 #, fuzzy
 msgid "Available Version"
 msgstr "Налични кръпки"
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "Не са открити грешки."
 
-#: src/update.cc:978
+#: src/update.cc:986
 #, fuzzy
 msgid "The following matches in issue numbers have been found:"
 msgstr "Пропускане на %s: вече е инсталиран"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/bn.po
+++ b/po/bn.po
@@ -2,11 +2,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Bengali <https://l10n.opensuse.org/projects/zypper/master/bn/>"
-"\n"
+"Language-Team: Bengali <https://l10n.opensuse.org/projects/zypper/master/bn/"
+">\n"
 "Language: bn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1369,7 +1369,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "ইন্সটল করার প্রস্তুতি নিচ্ছে..."
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "অপ্রত্যাশিত ব্যতিক্রম।"
 
@@ -1397,12 +1397,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2122,24 +2122,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2209,7 +2215,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2394,22 +2400,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2460,49 +2466,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2606,11 +2616,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "নাম"
 
@@ -2621,8 +2631,8 @@ msgstr "প্যাচ"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "ধরন"
@@ -2630,7 +2640,7 @@ msgstr "ধরন"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr ""
@@ -3057,7 +3067,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "সার্ভিস"
@@ -3221,120 +3231,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3373,12 +3383,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3420,117 +3430,121 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "সক্রিয় হয়েছে"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 #, fuzzy
 msgid "GPG Check"
 msgstr "DNS যাচাই"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 #, fuzzy
 msgid "Autorefresh"
 msgstr "স্বয়ং রিফ্রেশ"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 #, fuzzy
 msgid "On"
 msgstr "না"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Keep Packages"
 msgstr "সিস্টেমের ক্ষেত্রের বিষয়গুলি"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 #, fuzzy
 msgid "Path Prefix"
 msgstr "ডায়াল প্রিফিক্স"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "সার্ভিস"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr ""
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "লেখার জন্যে ফাইল খুলতে পারে না।"
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3538,21 +3552,21 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "রিফ্রেশ"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "স্বয়ং রিফ্রেশ"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3653,7 +3667,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr ""
 
@@ -3662,7 +3676,7 @@ msgstr ""
 msgid "Refreshing repository '%s'."
 msgstr "%s প্যাচ পড়ছে"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "%s প্যাচ পড়ছে"
@@ -3672,7 +3686,7 @@ msgstr "%s প্যাচ পড়ছে"
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3702,7 +3716,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "নির্বাচিত লিপিবদ্ধকরণটি অপসারিত করা যাবে না।"
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 #, fuzzy
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "নির্বাচিত লিপিবদ্ধকরণটি অপসারিত করা যাবে না।"
@@ -3756,12 +3770,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 #, fuzzy
 msgid "Error while modifying the repository:"
 msgstr "অনুরোধ বিশ্লেষণ করতে গিয়ে ত্রুটি"
@@ -4194,26 +4208,26 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "স্বয়ং রিফ্রেশ"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "কোনও শব্দ নয়"
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4304,7 +4318,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "সেক্টর %u পড়ায় ত্রুটি।"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, fuzzy, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "নির্বাচিত লিপিবদ্ধকরণটি অপসারিত করা যাবে না।"
@@ -4324,21 +4338,25 @@ msgstr "সরাও"
 msgid "Service '%s' has been removed."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5231,15 +5249,15 @@ msgstr "%s এর %s দরকার"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "ভার্সন    "
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "আর্ক"
 
@@ -5377,13 +5395,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 #, fuzzy
 msgid "Dependency"
 msgstr "নির্ভরতা"
@@ -5422,7 +5440,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5689,95 +5707,95 @@ msgstr[1] "নির্দিষ্ট করা AC প্রণালীটি 
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, fuzzy, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "%s প্যাচ পড়ছে"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "আপনি কি সিস্টেমটিকে এখন সাময়িকভাবে থামাতে চান?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "%s প্যাচ পড়ছে"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, fuzzy, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "%s থেকে পণ্য পড়ছে"
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, fuzzy, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "অনুরোধ বিশ্লেষণ করতে গিয়ে ত্রুটি"
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 #, fuzzy
 msgid "No alias defined for this repository."
 msgstr "অনুরোধ বিশ্লেষণ করতে গিয়ে ত্রুটি"
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, fuzzy, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "%s থেকে পণ্য পড়ছে"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, fuzzy, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "%s থেকে পণ্য পড়ছে"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5785,42 +5803,42 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, fuzzy, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 #, fuzzy
 msgid "Error building the cache:"
 msgstr "সার্টিফিকেট বিশ্লেষম করতে গিয়ে ত্রুটি"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "%s প্যাচ পড়ছে"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, fuzzy, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "নির্বাচিত লিপিবদ্ধকরণটি অপসারিত করা যাবে না।"
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "%s প্যাচ পড়ছে"
@@ -5828,308 +5846,308 @@ msgstr "%s প্যাচ পড়ছে"
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "লক্ষ্য চালু করছে"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 #, fuzzy
 msgid "Target initialization failed:"
 msgstr "শুরু করা ব্যর্থ হয়েছে"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, fuzzy, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "%s থেকে পণ্য পড়ছে"
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, fuzzy, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "%s থেকে পণ্য পড়ছে"
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, fuzzy, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "%s থেকে পণ্য পড়ছে"
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, fuzzy, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "%s থেকে প্যাকেজ পড়ছে"
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, fuzzy, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "নির্বাচিত লিপিবদ্ধকরণটি অপসারিত করা যাবে না।"
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 #, fuzzy
 msgid "Cleaning installed packages cache."
 msgstr "প্যাকেজ আনইনস্টল করার আদেশ"
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 #, fuzzy
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "নির্বাচিত লিপিবদ্ধকরণটি অপসারিত করা যাবে না।"
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 #, fuzzy
 msgid "Could not clean the repositories because of errors."
 msgstr "নির্বাচিত লিপিবদ্ধকরণটি অপসারিত করা যাবে না।"
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 #, fuzzy
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "নির্বাচিত লিপিবদ্ধকরণটি অপসারিত করা যাবে না।"
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 #, fuzzy
 msgid "Specified repositories have been cleaned up."
 msgstr "নির্বাচিত লিপিবদ্ধকরণটি অপসারিত করা যাবে না।"
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 #, fuzzy
 msgid "All repositories have been cleaned up."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, fuzzy, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "%s প্যাচ পড়ছে"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 #, fuzzy
 msgid "Please check whether the specified URI is accessible."
 msgstr "স্ক্রিপ্ট ফাইল অপ্রবেশযোগ্য"
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 #, fuzzy
 msgid "Unknown problem when adding repository:"
 msgstr "অনুরোধ বিশ্লেষণ করতে গিয়ে ত্রুটি"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, fuzzy, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "%s থেকে পণ্য পড়ছে"
-
-#: src/repos.cc:1275
-#, fuzzy, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "%s থেকে পণ্য পড়ছে"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, fuzzy, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "%s থেকে পণ্য পড়ছে"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, fuzzy, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "%s থেকে পণ্য পড়ছে"
+
+#: src/repos.cc:1273
+#, fuzzy, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "%s থেকে পণ্য পড়ছে"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 #, fuzzy
 msgid "Problem accessing the file at the specified URI"
 msgstr "%s থেকে পণ্য পড়ছে"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 #, fuzzy
 msgid "Please check if the URI is valid and accessible."
 msgstr "স্ক্রিপ্ট ফাইল অপ্রবেশযোগ্য"
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 #, fuzzy
 msgid "Problem parsing the file at the specified URI"
 msgstr "%s থেকে পণ্য পড়ছে"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 #, fuzzy
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "%s প্যাচ পড়ছে"
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "%s প্যাচ পড়ছে"
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "%s প্যাচ পড়ছে"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "%s প্যাচ পড়ছে"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, fuzzy, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, fuzzy, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "%s প্যাচ পড়ছে"
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr ""
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 #, fuzzy
 msgid "Loading repository data..."
 msgstr "%s প্যাচ পড়ছে"
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "%s প্যাচ পড়ছে"
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, fuzzy, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "%s থেকে পণ্য পড়ছে"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "নির্দিষ্ট করা AC প্রণালীটি পাওয়া যায় নি।"
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6137,32 +6155,32 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "প্যাকেজ আনইনস্টল করার আদেশ"
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "প্যাকেজ আনইনস্টল করার আদেশ"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6171,28 +6189,28 @@ msgstr ""
 msgid "System Packages"
 msgstr "সিস্টেমের ক্ষেত্রের বিষয়গুলি"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 #, fuzzy
 msgid "No patterns found."
 msgstr "কোনও শব্দ নয়"
 
-#: src/search.cc:450
+#: src/search.cc:453
 #, fuzzy
 msgid "No packages found."
 msgstr "কোনও শব্দ নয়"
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "অভ্যন্তরীণ ত্রুটি"
 
-#: src/search.cc:544
+#: src/search.cc:549
 #, fuzzy
 msgid "No products found."
 msgstr "কোনও শব্দ নয়"
@@ -6581,7 +6599,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 #, fuzzy
 msgid "Patches"
 msgstr "প্যাচ"
@@ -6606,7 +6624,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "নিম্নলিখিত vpnc VPN সংযোগ তৈরি করা হবে:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 #, fuzzy
 msgid "No updates found."
 msgstr "কোনও শব্দ নয়"
@@ -6617,57 +6635,57 @@ msgstr "কোনও শব্দ নয়"
 msgid "The following updates are also available:"
 msgstr "নিচের সংস্থানগুলি পরিমার্জিত"
 
-#: src/update.cc:700
+#: src/update.cc:707
 #, fuzzy
 msgid "Package updates"
 msgstr "প্যাকেজ"
 
-#: src/update.cc:704
+#: src/update.cc:711
 #, fuzzy
 msgid "Pattern updates"
 msgstr "অবস্থা"
 
-#: src/update.cc:706
+#: src/update.cc:713
 #, fuzzy
 msgid "Product updates"
 msgstr "পণ্য রিভিশন"
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "বর্তমান সংযোগ"
 
-#: src/update.cc:795
+#: src/update.cc:801
 #, fuzzy
 msgid "Available Version"
 msgstr "প্রাপ্তিসাধ্য স্পেস (শূণ্যস্থান)"
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "কোনও শব্দ নয়"
 
-#: src/update.cc:978
+#: src/update.cc:986
 #, fuzzy
 msgid "The following matches in issue numbers have been found:"
 msgstr "নিম্নলিখিত vpnc VPN সংযোগ তৈরি করা হবে:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/bs.po
+++ b/po/bs.po
@@ -8,11 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Bosnian <https://l10n.opensuse.org/projects/zypper/master/bs/>"
-"\n"
+"Language-Team: Bosnian <https://l10n.opensuse.org/projects/zypper/master/bs/"
+">\n"
 "Language: bs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "Pripremam instalaciju..."
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr ""
 
@@ -1478,12 +1478,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2178,24 +2178,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2265,7 +2271,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2447,22 +2453,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2513,49 +2519,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2661,11 +2671,11 @@ msgstr[2] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Naziv"
 
@@ -2675,8 +2685,8 @@ msgstr ""
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Vrsta"
@@ -2684,7 +2694,7 @@ msgstr "Vrsta"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr ""
@@ -3111,7 +3121,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "Uređaji"
@@ -3272,120 +3282,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3424,12 +3434,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3471,113 +3481,117 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr ""
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr ""
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 #, fuzzy
 msgid "On"
 msgstr "Oman"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr ""
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "Uređaji"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr ""
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Can't run %s.  Exiting."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3585,21 +3599,21 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr ""
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3700,7 +3714,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr ""
 
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Refreshing repository '%s'."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr ""
@@ -3722,7 +3736,7 @@ msgstr ""
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3749,7 +3763,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3802,12 +3816,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 #, fuzzy
 msgid "Error while modifying the repository:"
 msgstr ""
@@ -4264,26 +4278,26 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Novi moduli nisu pronađeni."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4377,7 +4391,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr ""
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4396,21 +4410,25 @@ msgstr ""
 msgid "Service '%s' has been removed."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5300,15 +5318,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr ""
 
@@ -5445,13 +5463,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr ""
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -5488,7 +5506,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5749,36 +5767,36 @@ msgstr[2] "Novi moduli nisu pronađeni."
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, fuzzy, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr ""
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr ""
@@ -5786,17 +5804,17 @@ msgstr ""
 "\n"
 "%s"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr ""
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, fuzzy, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr ""
@@ -5805,14 +5823,14 @@ msgstr ""
 "%s"
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 #, fuzzy
 msgid "No alias defined for this repository."
 msgstr ""
@@ -5820,33 +5838,33 @@ msgstr ""
 "\n"
 "%s"
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr ""
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5854,12 +5872,12 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, fuzzy, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 #, fuzzy
 msgid "Error building the cache:"
 msgstr ""
@@ -5867,32 +5885,32 @@ msgstr ""
 "\n"
 "%s"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr ""
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, fuzzy, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr ""
@@ -5903,114 +5921,114 @@ msgstr ""
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 #, fuzzy
 msgid "Initializing Target"
 msgstr "Inicijaliziram paralelni port..."
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr ""
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr ""
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 #, fuzzy
 msgid "Cleaning installed packages cache."
 msgstr "Pripremam instalaciju..."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 #, fuzzy
 msgid "All repositories have been cleaned up."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr ""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 #, fuzzy
 msgid "Unknown problem when adding repository:"
 msgstr ""
@@ -6020,186 +6038,186 @@ msgstr ""
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 #, fuzzy
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, fuzzy, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr ""
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 #, fuzzy
 msgid "Loading repository data..."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr ""
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6207,32 +6225,32 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "Pripremam instalaciju..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Pripremam instalaciju..."
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6240,29 +6258,29 @@ msgstr ""
 msgid "System Packages"
 msgstr ""
 
-#: src/search.cc:261
+#: src/search.cc:262
 #, fuzzy
 msgid "No needed patches found."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/search.cc:342
+#: src/search.cc:344
 #, fuzzy
 msgid "No patterns found."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/search.cc:450
+#: src/search.cc:453
 #, fuzzy
 msgid "No packages found."
 msgstr "Novi moduli nisu pronađeni."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "Naziv"
 
-#: src/search.cc:544
+#: src/search.cc:549
 #, fuzzy
 msgid "No products found."
 msgstr "Novi moduli nisu pronađeni."
@@ -6644,7 +6662,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr ""
 
@@ -6667,7 +6685,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr ""
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 #, fuzzy
 msgid "No updates found."
 msgstr "Novi moduli nisu pronađeni."
@@ -6677,51 +6695,51 @@ msgstr "Novi moduli nisu pronađeni."
 msgid "The following updates are also available:"
 msgstr ""
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr ""
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr ""
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr ""
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr ""
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "Novi moduli nisu pronađeni."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -8,11 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Catalan <https://l10n.opensuse.org/projects/zypper/master/ca/>"
-"\n"
+"Language-Team: Catalan <https://l10n.opensuse.org/projects/zypper/master/ca/"
+">\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -871,7 +871,8 @@ msgid "The following recommended package was automatically selected:"
 msgid_plural ""
 "The following %d recommended packages were automatically selected:"
 msgstr[0] "El paquet recomanat següent s'ha seleccionat automàticament:"
-msgstr[1] "Els %d paquets recomanats següents s'han seleccionat automàticament:"
+msgstr[1] ""
+"Els %d paquets recomanats següents s'han seleccionat automàticament:"
 
 #: src/Summary.cc:1079
 #, c-format, boost-format
@@ -879,7 +880,8 @@ msgid "The following recommended patch was automatically selected:"
 msgid_plural ""
 "The following %d recommended patches were automatically selected:"
 msgstr[0] "El pedaç recomanat següent s'ha seleccionat automàticament:"
-msgstr[1] "Els %d pedaços recomanats següents s'han seleccionat automàticament:"
+msgstr[1] ""
+"Els %d pedaços recomanats següents s'han seleccionat automàticament:"
 
 #: src/Summary.cc:1084
 #, c-format, boost-format
@@ -887,7 +889,8 @@ msgid "The following recommended pattern was automatically selected:"
 msgid_plural ""
 "The following %d recommended patterns were automatically selected:"
 msgstr[0] "El patró recomanat següent s'ha seleccionat automàticament:"
-msgstr[1] "Els %d patrons recomanats següents s'han seleccionat automàticament:"
+msgstr[1] ""
+"Els %d patrons recomanats següents s'han seleccionat automàticament:"
 
 #: src/Summary.cc:1089
 #, c-format, boost-format
@@ -895,7 +898,8 @@ msgid "The following recommended product was automatically selected:"
 msgid_plural ""
 "The following %d recommended products were automatically selected:"
 msgstr[0] "El producte recomanat següent s'ha seleccionat automàticament:"
-msgstr[1] "Els %d productes recomanats següents s'han seleccionat automàticament:"
+msgstr[1] ""
+"Els %d productes recomanats següents s'han seleccionat automàticament:"
 
 #: src/Summary.cc:1094
 #, c-format, boost-format
@@ -926,8 +930,8 @@ msgid_plural ""
 "The following %d packages are recommended, but will not be installed (only "
 "required packages will be installed):"
 msgstr[0] ""
-"El paquet següent està recomanat, però no s'instal·larà (només s'instal·"
-"laran els paquets necessaris):"
+"El paquet següent està recomanat, però no s'instal·larà (només "
+"s'instal·laran els paquets necessaris):"
 msgstr[1] ""
 "Els s%d paquets següents estan recomanats, però no s'instal·laran (només "
 "s'instal·laran els paquets necessaris):"
@@ -941,8 +945,8 @@ msgid_plural ""
 "The following %d packages are recommended, but will not be installed because "
 "they are unwanted (were manually removed before):"
 msgstr[0] ""
-"El paquet següent està recomanat, però no s'instal·larà perquè no és volgut ("
-"abans es va suprimir manualment):"
+"El paquet següent està recomanat, però no s'instal·larà perquè no és volgut "
+"(abans es va suprimir manualment):"
 msgstr[1] ""
 "Els %d paquets següents estan recomanats, però no s'instal·laran perquè no "
 "són volguts (abans es van suprimir manualment):"
@@ -992,7 +996,8 @@ msgid "The following application is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d applications are recommended, but will not be installed:"
 msgstr[0] "La següent aplicació està recomanada, però no s'instal·larà:"
-msgstr[1] "Les següents %d aplicacions estan recomanades, però no s'instal·laran:"
+msgstr[1] ""
+"Les següents %d aplicacions estan recomanades, però no s'instal·laran:"
 
 #: src/Summary.cc:1228
 #, c-format, boost-format
@@ -1032,7 +1037,8 @@ msgid "The following application is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d applications are suggested, but will not be installed:"
 msgstr[0] "La següent aplicació està suggerida, però no s'instal·larà:"
-msgstr[1] "Les següents %d aplicacions estan suggerides, però no s'instal·laran:"
+msgstr[1] ""
+"Les següents %d aplicacions estan suggerides, però no s'instal·laran:"
 
 #: src/Summary.cc:1274
 #, c-format, boost-format
@@ -1435,7 +1441,7 @@ msgstr "El PackageKit encara està actiu (probablement ocupat)."
 msgid "Try again?"
 msgstr "Ho torno a intentar?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Excepció inesperada."
 
@@ -1465,12 +1471,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "L'opció %s no té cap efecte aquí, ignorant-la."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Arguments del programa sense opcions: "
 
@@ -1766,8 +1772,8 @@ msgid ""
 "installation the new keys will be imported into the rpm database."
 msgstr ""
 "Aquestes claus addicionals solen usar-se per signar paquets enviats pel "
-"repositori. Per tal de validar aquests paquets a la descàrrega i la instal·"
-"lació, les claus noves s'importaran a la base de dades d'rpm."
+"repositori. Per tal de validar aquests paquets a la descàrrega i la "
+"instal·lació, les claus noves s'importaran a la base de dades d'rpm."
 
 #: src/callbacks/keyring.h:474
 msgid "New:"
@@ -1911,7 +1917,8 @@ msgstr "a/r/i/u/s"
 
 #: src/callbacks/media.cc:79
 msgid "Disable SSL certificate authority check and continue."
-msgstr "Desactiva la comprovació de l'autoritat de certificació SSL i continua."
+msgstr ""
+"Desactiva la comprovació de l'autoritat de certificació SSL i continua."
 
 #. translators: this is a prompt text
 #: src/callbacks/media.cc:82 src/callbacks/media.cc:174
@@ -2128,9 +2135,9 @@ msgid ""
 "in advance in order to access their file lists. See option '%1%' in the "
 "zypper manual page for details."
 msgstr ""
-"Comprovar els conflictes entre fitxers requereix que els paquets no instal·"
-"lats es baixin abans per tal d'accedir a la seva llista de fitxers. Vegeu "
-"l'opció \"%1%\" al manual del zypper per a més detalls."
+"Comprovar els conflictes entre fitxers requereix que els paquets no "
+"instal·lats es baixin abans per tal d'accedir a la seva llista de fitxers. "
+"Vegeu l'opció \"%1%\" al manual del zypper per a més detalls."
 
 #. TranslatorExplanation %1%(number of conflicts); detailed list follows
 #: src/callbacks/rpm.h:523
@@ -2226,17 +2233,17 @@ msgid "Commands:"
 msgstr "Ordres:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Mostra el resum detallat de la instal·lació."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Tipus de paquet (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2244,9 +2251,15 @@ msgstr ""
 "Fes 'el millor possible' per actualitzar. Les actualitzacions per a versions "
 "més baixes que l'última també s'accepten."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "Considera només els pedaços que afectin el gestor de paquets mateix."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2328,7 +2341,7 @@ msgstr "zypper [--opcions globals] <ordre> [--opcions de l'ordre] [arguments]"
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <subordre> [--opcions de l'ordre] [arguments]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Imprimeix l'ajuda"
 
@@ -2551,22 +2564,22 @@ msgstr ""
 "d'actualització oficials."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [OPCIONS]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Llista els pedaços disponibles."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Llista tots els pedaços aplicables."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Llista tots els pedaços, no només els aplicables."
 
@@ -2622,37 +2635,41 @@ msgstr ""
 "Obtingueu una llista de totes les llengües disponibles amb l'ordre \"%s\"."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [OPCIONS] [LLLENGUA] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Llista les llengües sol·licitades (codis de llengua)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Llista les llengües sol·licitades i els paquets corresponents."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Mostra els paquets corresponents."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Llista totes les llengües disponibles."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
-"S'ignoren els arguments posicionals perquè s'ha proporcionat l'argument "
-"--all."
+"S'ignoren els arguments posicionals perquè s'ha proporcionat l'argument --"
+"all."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "Les llengües de les quals s'ha d'imprimir la informació."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2660,15 +2677,15 @@ msgstr ""
 "Obtén totes les llengües amb el codi \"en\" que tinguin codi de país propi, "
 "excloent-ne l'opció alternativa \"en\":"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr "Obtén totes les llengües amb el codi \"en\" amb o sense codi de país:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "Obtén la llengua que coincideixi exactament amb l'argument: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 "Obtén la llista de paquets que estan disponibles per als codis \"de\" i "
@@ -2698,7 +2715,8 @@ msgstr ""
 
 #: src/commands/locale/removelocalecmd.cc:46
 msgid "Do not remove corresponding packages for given locale(s)."
-msgstr "No suprimeixis els paquets corresponents de les llengües especificades."
+msgstr ""
+"No suprimeixis els paquets corresponents de les llengües especificades."
 
 #. translators: command synopsis; do not translate the command 'name (abbreviations)' or '-option' names
 #: src/commands/locks/add.cc:29
@@ -2730,8 +2748,8 @@ msgid ""
 msgstr ""
 "El formulari bàsic bloquejarà totes les edicions dels elements coincidents. "
 "Opcionalment, podeu restringir el bloqueig perquè coincideixi amb una edició "
-"o un interval d’edició específics fent servir =, <, <=, >, >= o != seguit d’"
-"una EDICIÓ."
+"o un interval d’edició específics fent servir =, <, <=, >, >= o != seguit "
+"d’una EDICIÓ."
 
 #: src/commands/locks/add.cc:46
 msgid "Restrict the lock to the specified repository."
@@ -2782,11 +2800,11 @@ msgstr[1] "Suprimits %lu bloquejos."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Nom"
 
@@ -2796,8 +2814,8 @@ msgstr "Coincideix amb"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Tipus"
@@ -2805,7 +2823,7 @@ msgstr "Tipus"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Repositori"
@@ -3268,7 +3286,7 @@ msgid "Command"
 msgstr "Ordre"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Servei"
 
@@ -3442,40 +3460,41 @@ msgid "Show detailed information for products."
 msgstr "Mostra informació detallada dels productes."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [OPCIONS] [REPOSITORI] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Lista tots els paquets disponibles.."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Llista tots els paquets disponibles als repositoris especificats."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 "Mostra els paquets instal·lats seleccionats automàticament pel resolutor."
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
-msgstr "Mostra els paquets instal·lats seleccionats explícitament per l'usuari."
+msgstr ""
+"Mostra els paquets instal·lats seleccionats explícitament per l'usuari."
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 "Mostra els paquets instal·lats que no són proporcionats per cap repositori."
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
@@ -3484,84 +3503,84 @@ msgstr ""
 "candidat d'actualització)."
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Mostra paquets suggerits."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Mostra paquets recomanats."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Mostra paquets innecessaris."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Classifica per nom."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Classifica per repositori."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [REPOSITORI] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Lista tots els pedaços disponibles."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Llista tots els pedaços disponibles als repositoris especificats."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [OPCIONS] [REPOSITORI] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Lista tots els patrons disponibles."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Llista tots els patrons disponibles als repositoris especificats."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [OPCIONS] [REPOSITORI] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Lista tots els productes disponibles."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Llista tots els productes disponibles als repositoris especificats."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Només sortida XML: reenvia literalment les etiquetes XML que es troben en un "
 "fitxer del producte."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "L'opció %1% no té efecte sense l'opció global %2%."
@@ -3602,18 +3621,18 @@ msgstr "No en comprovis l'URI, prova-ho més tard, durant el refresc."
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr "El tipus de repositori sempre s'autodetecta. Aquesta opció s'ignora."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 "No es pot fer servir %s conjuntament amb %s. Utilitzant el paràmetre %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
-"Si només es fa servir un argument, ha de ser un URI que apunti a un fitxer "
-".repo."
+"Si només es fa servir un argument, ha de ser un URI que apunti a un "
+"fitxer .repo."
 
 #: src/commands/repos/add.cc:130
 msgid "Specified type is not a valid repository type:"
@@ -3655,111 +3674,115 @@ msgid "Clean both metadata and package caches."
 msgstr "Neteja les dues coses: metadades i memòria cau dels paquets."
 
 # DZ
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Àlies"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI (adreça del recurs)"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Habilitat"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Comprovació GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Prioritat"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Refresca automàticament"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Engegat"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Apagat"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Manté els paquets"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI de la clau GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Prefix del camí"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Servei pare"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Paraules clau"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Repo Info Ruta"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Ruta MD de la memòria cau"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [OPCIONS] [REPO] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Llista tots els repositoris definits."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "Exporta tots els repositoris definis a un sol fitxer .repo."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Error llegint els repositoris:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "No es pot obrir %s per a l'escriptura."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Potser no teniu els permisos necessaris per fer-hi canvis?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "S'han exportat correctament els repositoris a %s."
@@ -3767,20 +3790,20 @@ msgstr "S'han exportat correctament els repositoris a %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Refresca"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "Mantén"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "No hi ha repositoris definits."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr "Useu l'ordre \"zypper addrepo\" per afegir-hi un o més repositoris."
 
@@ -3887,7 +3910,7 @@ msgstr "L'opció global \"%s\" no té cap efecte aquí."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "No es permeten arguments si no es fa servir \"%s\" ."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Repositoris especificats: "
 
@@ -3896,7 +3919,7 @@ msgstr "Repositoris especificats: "
 msgid "Refreshing repository '%s'."
 msgstr "Refrescant el repositori %s."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Escanejant el contingut del repositori inhabilitat %s."
@@ -3906,7 +3929,7 @@ msgstr "Escanejant el contingut del repositori inhabilitat %s."
 msgid "Skipping disabled repository '%s'"
 msgstr "Se salta el repositori inhabilitat %s."
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Se salta el repositori %s a causa de l'error anterior."
@@ -3934,7 +3957,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "No s'han pogut refrescar els repositoris a causa d'errors."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Alguns dels repositoris no s'han refrescat a causa d'un error."
 
@@ -3989,13 +4012,13 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "El repositori %s ha canviat al nom de \"%s\"."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 "El repositori amb el nom %s ja existeix. Si us plau, useu un altre àlies."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Error en modificar el repositori:"
 
@@ -4462,25 +4485,25 @@ msgstr ""
 "Com --details, amb la informació addicional d'on la cerca ha coincidit (útil "
 "per a cerques a les dependències)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "El repositori especificat '%s' està inhabilitat."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "No s'ha trobat cap element que coincideixi."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Problema a l'hora d'iniciar o executar l'ordre de cerca"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Llegiu l'error anterior per tenir-ne una pista."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 "Amb l'ordre \"zypper refresh\" com a administrador es podria resoldre el "
@@ -4578,7 +4601,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Error en obtenir el fitxer d'índex del repositori per al servei %s:"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Se salta el servei %s a causa de l'error anterior."
@@ -4597,23 +4620,27 @@ msgstr "Suprimint el servei %s:"
 msgid "Service '%s' has been removed."
 msgstr "El servei %s s'ha suprimit."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [opcions]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Llista tots els serveis definits."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Llista de serveis definits."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "No hi ha serveis definits. Feu servir l'ordre \"%s\" per afegir-ne un o més."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4710,7 +4737,8 @@ msgstr "El nom del servei %s s'ha establert a \"%s\"."
 msgid "Repository '%s' has been added to enabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been added to enabled repositories of service '%s'"
-msgstr[0] "El repositori %s s'ha afegit als repositoris habilitats del servei %s."
+msgstr[0] ""
+"El repositori %s s'ha afegit als repositoris habilitats del servei %s."
 msgstr[1] ""
 "Els repositoris %s s'han afegit als repositoris habilitats del servei %s."
 
@@ -4930,7 +4958,8 @@ msgstr "Si s'ha de permetre canviar els noms dels resolubles instal·lats."
 
 #: src/commands/solveroptionset.cc:91
 msgid "Whether to allow changing the architecture of installed resolvables."
-msgstr "Si s'ha de permetre canviar l'arquitectura dels resolubles instal·lats."
+msgstr ""
+"Si s'ha de permetre canviar l'arquitectura dels resolubles instal·lats."
 
 #: src/commands/solveroptionset.cc:93
 msgid "Whether to allow changing the vendor of installed resolvables."
@@ -5079,8 +5108,8 @@ msgstr ""
 "\n"
 "Si no es troba una subordre a zypper_execdir, l'embolcall\n"
 "la buscarà a la resta del vostre $PATH. Així, és possible\n"
-"escriure les extensions locals del zypper que no viuen a l'espai del sistema."
-"\n"
+"escriure les extensions locals del zypper que no viuen a l'espai del "
+"sistema.\n"
 
 #: src/commands/subcommand.cc:458
 #, boost-format
@@ -5182,9 +5211,9 @@ msgid ""
 "Zypper does not keep track of installed source packages. To install the "
 "latest source package and its build dependencies, use '%s'."
 msgstr ""
-"El Zypper no controla els paquets de codi font ja instal·lats. Per instal·"
-"lar l'últim paquet de codi font i les seves dependències construïdes, feu "
-"servir '%s'."
+"El Zypper no controla els paquets de codi font ja instal·lats. Per "
+"instal·lar l'últim paquet de codi font i les seves dependències construïdes, "
+"feu servir '%s'."
 
 #: src/commands/update.cc:83
 msgid ""
@@ -5477,8 +5506,8 @@ msgid ""
 "installed at all, the value is empty if the --terse global option is used."
 msgstr ""
 "Si el producte de base no proporciona aquesta entrada, o si no hi ha cap "
-"producte de base instal·lat, el valor és buit si s'usa l'opció global "
-"--terse."
+"producte de base instal·lat, el valor és buit si s'usa l'opció global --"
+"terse."
 
 #: src/commands/utils/targetos.cc:26
 msgid ""
@@ -5558,15 +5587,15 @@ msgstr "%s és més antic que %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Versió"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arquitectura"
 
@@ -5703,13 +5732,13 @@ msgstr "(buit)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Dependència"
 
@@ -5746,7 +5775,7 @@ msgid "Flavor"
 msgstr "Gust"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "És Base"
 
@@ -6014,57 +6043,57 @@ msgstr[1] "%1% repositoris"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Comprovant si s'han de refrescar les metadades per a %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "El repositori %s està al dia."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "La comprovació d'actualització de %s s'ha ajornat."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Forçant el refresc de metadades en cru"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Obtenint metadades del repositori %s"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Voleu inhabilitar el repositori %s de manera permanent?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Error a l'hora d'inhabilitar el repositori %s."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Problema obtenint els fitxers de %s."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Si us plau, llegiu l'error anterior."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "No URI definits per a \"%s\"."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -6073,16 +6102,16 @@ msgstr ""
 "Si us plau, afegiu una o més entrades d'URI de base (baseurl=URI) a %s per "
 "al repositori %s."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "No hi ha àlies definit per a aquest repositori."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "El repositori %s no és vàlid."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -6090,22 +6119,22 @@ msgstr ""
 "Si us plau, comproveu si els URI definits per a aquest repositori apunten a "
 "un repositori vàlid."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Error obtenint metadades per a %s:"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Forçant la construcció de la memòria cau del repositori"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Error analitzant les metadades per a %s:"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6117,43 +6146,43 @@ msgstr ""
 "plau, denuncieu l'error seguint les instruccions que trobareu a http://"
 "en.opensuse.org/Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 "No s'han trobat les metadades de repositori per a %s a la memòria cau local."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Error construint la memòria cau:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "El repositori %s no s'ha trobat per l'àlies, número o URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Feu servir \"%s\" per obtenir la llista de repositoris definits."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Ignorant el repositori inhabilitat %s"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "Es pot usar l'opció global \"%s\" per habilitar repositoris temporalment."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Ignorant el repositori %s a causa de l'opció \"%s\"."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Habilitant temporalment el repositori %s."
@@ -6161,7 +6190,7 @@ msgstr "Habilitant temporalment el repositori %s."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6170,7 +6199,7 @@ msgstr ""
 "El repositori %s no està actualitzat. Feu servir \"zypper refresh\" com a "
 "administrador per actualitzar-lo."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6179,81 +6208,81 @@ msgstr ""
 "La memòria cau de metadades s'ha de construir per al repositori %s. Podeu "
 "fer servir \"zypper refresh\" com a administrador per fer-ho."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "El repositori %s roman inhabilitat."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Iniciant la destinació"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Ha fallat l'inici de la destinació:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Netejant les metadades de %s."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Netejant la memòria cau de metadades per a %s."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Guardant les metadades en cru de la memòria cau per a %s '%s'."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Netejant els paquets per a %s."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "No s'ha pogut netejar el repositori %s a causa d'un error."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Netejant la memòria cau de paquets instal·lats."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "No s'han pogut netejar els paquets instal·lats a causa d'un error."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "No s'han pogut netejar els repositoris a causa d'errors."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Alguns dels repositoris no s'han netejat a causa d'un error."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "S'han netejat els repositoris especificats."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "S'han netejat tots els repositoris."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Aquest és un mitjà canviable només de lectura (CD/DVD), desactivant "
 "l'autorefresc."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Àlies de repositori no vàlid: \"%s\""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6261,25 +6290,26 @@ msgstr ""
 "No s'ha pogut determinar el tipus de repositori. Si us plau, comproveu si "
 "els URI definits (vegeu-ne la llista) apunten a un repositori vàlid:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "No es pot trobar un repositori vàlid en aquest lloc:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
-msgstr "Problema transferint les dades del repositori des de l'URI especificat:"
+msgstr ""
+"Problema transferint les dades del repositori des de l'URI especificat:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Si us plau, comproveu si l'URI especificat és accessible."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Problema desconegut en afegir el repositori:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6288,136 +6318,137 @@ msgstr ""
 "La comprovació GPG està inhabilitada a la configuració del repositori '%1%'. "
 "No es poden verificar la integritat ni l'origen dels paquets."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "El repositori %s s'ha afegit correctament."
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Llegint la informació del mitjà %s"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Problema llegint les dades del mitjà %s"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-"Si us plau, comproveu que el mitjà d'instal·lació sigui vàlid i llegible."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "S'ha ajornat la lectura de dades del mitjà %s fins al nou refresc."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Llegint la informació del mitjà %s"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Problema llegint les dades del mitjà %s"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+"Si us plau, comproveu que el mitjà d'instal·lació sigui vàlid i llegible."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Problema accedint al fitxer a l'adreça (URI) especificada"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Si us plau, comproveu si l'URI especificat és vàlid i accessible."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Problema en analitzar el fitxer a l'URI especificat."
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "És un fitxer .repo?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
-msgstr "S'ha trobat un problema intentant llegir el fitxer a l'URI especificat."
+msgstr ""
+"S'ha trobat un problema intentant llegir el fitxer a l'URI especificat."
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Repositori sense àlies definit trobat al fitxer, s'omet."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "El repositori %s no té URI definit, s'omet."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "El repositori %s s'ha suprimit correctament."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "La prioritat del repositori %s s'ha deixat sense canviar (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "El repositori %s s'ha habilitat correctament."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "El repositori %s s'ha inhabilitat correctament."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "L'autorefresc s'ha activat per al repositori %s."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "L'autorefresc s'ha desactivat per al repositori %s."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "La còpia cau dels fitxers RPM s'ha activat per al repositori %s."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "La còpia cau dels fitxers RPM s'ha desactivat per al repositori %s."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "La comprovació GPG s'ha activat per al repositori %s."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "La comprovació GPG s'ha desactivat per al repositori %s."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "La prioritat del repositori %s s'ha establert a %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "El nom del repositori %s s'ha establert a \"%s\"."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "No hi ha res per canviar del repositori %s."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Deixant el repositori %s sense canvis."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Carregant les dades del repositori..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6425,44 +6456,44 @@ msgstr ""
 "No hi ha repositoris definits. Operant només amb els recursos instal·lats. "
 "No hi ha res per instal·lar."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Obtenint les dades del repositori %s..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "El repositori %s no és a la memòria cau. Fent-ho..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Problema carregant la informació des de %s"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 "El repositori %s no s'ha pogut refrescar. Es fa servir la memòria cau antiga."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "No s'han carregat els elements de %s a causa d'un error."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "Les metadades del repositori %1% estan caducades des del %2%."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Proveu de fer un \"%s\", o fins i tot un \"%s\" abans."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6475,30 +6506,30 @@ msgstr ""
 "que useu una rèplica malmesa o que el servidor hagi deixat d'oferir el "
 "repositori."
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Llegint els paquets instal·lats..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Hi ha hagut un problema mentre es llegien els paquets instal·lats:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' sembla un fitxer RPM. Es provarà de baixar-lo."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Problema amb el fitxer RPM especificat com a \"%s\", s'omet."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Problema llegint la capçalera RPM de %s. És un fitxer RPM?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Memòria cau de fitxers RPM simple"
 
@@ -6506,25 +6537,25 @@ msgstr "Memòria cau de fitxers RPM simple"
 msgid "System Packages"
 msgstr "Paquets de sistema"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "No s'ha trobat cap pedaç necessari."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "No s'ha trobat cap patró."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "No s'ha trobat cap paquet."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Nom intern"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "No s'ha trobat cap producte."
 
@@ -6554,8 +6585,8 @@ msgstr "Informació detallada: "
 msgid "Choose the above solution using '1' or skip, retry or cancel"
 msgid_plural "Choose from above solutions by number or skip, retry or cancel"
 msgstr[0] ""
-"Trieu la solució anterior marcant \"1\" o salteu-ho, reintenteu-ho o cancel"
-"·leu-ho."
+"Trieu la solució anterior marcant \"1\" o salteu-ho, reintenteu-ho o "
+"cancel·leu-ho."
 msgstr[1] ""
 "Trieu la solució marcant-ne el número corresponent o salteu-ho, reintenteu-"
 "ho o cancel·leu-ho."
@@ -6933,7 +6964,7 @@ msgid "Updatestack"
 msgstr "Pila d'actualització"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Pedaços"
 
@@ -6958,7 +6989,7 @@ msgstr ""
 "Primer s'instal·laran les actualitzacions de gestió de programari "
 "necessàries:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "No s'ha trobat cap actualització."
 
@@ -6967,47 +6998,47 @@ msgstr "No s'ha trobat cap actualització."
 msgid "The following updates are also available:"
 msgstr "Les següents actualitzacions també estan disponibles:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Actualitzacions de paquets"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Actualitzacions de patrons"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Actualitzacions de productes"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Versió actual"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Versió disponible"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "No s'ha trobat cap assumpte que coincideixi."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "S'han trobat les següents coincidències d'aspecte numèric:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 "S'han trobat coincidències en descripcions de pedaços dels pedaços següents:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "La reparació de l'assumpte de Bugzilla amb el número %s no s'ha trobat o no "
 "es necessita."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
@@ -7015,7 +7046,7 @@ msgstr ""
 "necessita."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""
@@ -7287,8 +7318,8 @@ msgid ""
 "provided as a subcommand or plug-in (see '%2%')."
 msgstr ""
 "En cas que \"%1%\" no sigui un error tipogràfic, és probable que no sigui "
-"una ordre incorporada sinó que es proporcioni com a subordre o connector ("
-"vegeu \"%2%\")."
+"una ordre incorporada sinó que es proporcioni com a subordre o connector "
+"(vegeu \"%2%\")."
 
 #. translators: %1% and %2% are plug-in packages which might provide it.
 #. translators: The word 'subcommand' also refers to a zypper command and should not be translated.

--- a/po/cs.po
+++ b/po/cs.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Czech <https://l10n.opensuse.org/projects/zypper/master/cs/>\n"
@@ -215,8 +215,8 @@ msgid ""
 "Patches having the flag rebootSuggested set will not be treated as "
 "interactive."
 msgstr ""
-"Opravy, které mají nastavený příznak \"navrhovanýRestart\" (rebootSuggested)"
-", nebudou považovány za interaktivní."
+"Opravy, které mají nastavený příznak \"navrhovanýRestart\" "
+"(rebootSuggested), nebudou považovány za interaktivní."
 
 #. translators: --non-interactive-include-reboot-patches
 #: src/Config.cc:347
@@ -981,14 +981,14 @@ msgid_plural ""
 "The following %d packages are recommended, but will not be installed because "
 "they are unwanted (were manually removed before):"
 msgstr[0] ""
-"Tento balíček je doporučen, ale nebude nainstalován, protože je nežádoucí ("
-"byl dříve ručně odebrán):"
+"Tento balíček je doporučen, ale nebude nainstalován, protože je nežádoucí "
+"(byl dříve ručně odebrán):"
 msgstr[1] ""
 "Jsou doporučeny %d balíčky, ale nebudou nainstalovány, protože jsou "
 "nežádoucí (byly dříve ručně odebrány):"
 msgstr[2] ""
-"Je doporučeno %d balíčků, ale nebudou nainstalovány, protože jsou nežádoucí ("
-"byly dříve ručně odebrány):"
+"Je doporučeno %d balíčků, ale nebudou nainstalovány, protože jsou nežádoucí "
+"(byly dříve ručně odebrány):"
 
 #: src/Summary.cc:1169
 #, c-format, boost-format
@@ -1194,8 +1194,10 @@ msgid_plural ""
 "The following %d packages need additional customer contract to get support:"
 msgstr[0] ""
 "Tento balíček potřebuje k získání podpory dodatečnou zákaznickou smlouvu:"
-msgstr[1] "%d balíčky potřebují k získání podpory dodatečnou zákaznickou smlouvu:"
-msgstr[2] "%d balíčků potřebuje k získání podpory dodatečnou zákaznickou smlouvu:"
+msgstr[1] ""
+"%d balíčky potřebují k získání podpory dodatečnou zákaznickou smlouvu:"
+msgstr[2] ""
+"%d balíčků potřebuje k získání podpory dodatečnou zákaznickou smlouvu:"
 
 #: src/Summary.cc:1417
 msgid "was superseded by"
@@ -1524,7 +1526,7 @@ msgstr "PackageKit stále běží (pravděpodobně je zaneprázdněn)."
 msgid "Try again?"
 msgstr "Zkusit znovu?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Neočekávaná výjimka."
 
@@ -1555,12 +1557,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Volba %s zde nemá žádný efekt, ignoruji ji."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Parametry programu mimo volby: "
 
@@ -1736,7 +1738,8 @@ msgstr "Obdržen nový klíč podepisující balíček nebo úložiště:"
 #. translators: this message is shown after showing description of the key
 #: src/callbacks/keyring.h:284
 msgid "Do you want to reject the key, trust temporarily, or trust always?"
-msgstr "Chcete klíč odmítnout, důvěřovat mu dočasně nebo mu důvěřovat natrvalo?"
+msgstr ""
+"Chcete klíč odmítnout, důvěřovat mu dočasně nebo mu důvěřovat natrvalo?"
 
 #. translators: this message is shown after showing description of the key
 #: src/callbacks/keyring.h:287
@@ -2307,17 +2310,17 @@ msgid "Commands:"
 msgstr "Příkazy:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Zobrazit podrobný instalační souhrn."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Typ závislosti (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2325,9 +2328,15 @@ msgstr ""
 "Provede aktualizaci metodou největšího úsilí. Aktualizace na nižší verzi než "
 "nejnovější jsou také přijatelné."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "Týká se jen oprav ovlivňujících samu správu balíčků."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2403,7 +2412,7 @@ msgstr "zypper [--globální-volby] <příkaz> [--volby-příkazu] [parametry]"
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <podpříkaz> [--volby-příkazu] [parametry]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Zobraz nápovědu"
 
@@ -2486,8 +2495,8 @@ msgid ""
 "Remove packages with specified capabilities. A capability is NAME[.ARCH]"
 "[OP<VERSION>], where OP is one of <, <=, =, >=, >."
 msgstr ""
-"Odinstaluje závislosti se zadanými schopnostmi. Schopnost má tvar NÁZEV"
-"[.ARCHITEKTURA][OP<VERZE>], kde OP je jeden z operátorů <, <=, =, >=, >."
+"Odinstaluje závislosti se zadanými schopnostmi. Schopnost má tvar "
+"NÁZEV[.ARCHITEKTURA][OP<VERZE>], kde OP je jeden z operátorů <, <=, =, >=, >."
 
 #: src/commands/installremove.cc:104 src/commands/installremove.cc:234
 #: src/utils/messages.cc:53
@@ -2618,22 +2627,22 @@ msgstr ""
 "aktualizovanými verzemi."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [VOLBY]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Vypsat dostupné záplaty."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Vypsat všechny použitelné opravy."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Vypsat všechny opravy, ne pouze ty použitelné."
 
@@ -2688,35 +2697,39 @@ msgstr ""
 "dostupných lokalizací získejte voláním '% s'."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [VOLBY] [LOKALIZACE] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Seznam požadovaných lokalizací (kódy jazyků)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Seznam požadovaných lokalizací a odpovídajících balíčků."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Ukázat příslušné balíčky."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Seznam všech dostupných lokalizací."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr "Bylo zadáno --all, proto ignoruji poziční argumenty."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "Budou vytištěny údaje těchto lokalizací."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2724,15 +2737,15 @@ msgstr ""
 "Získat všetky lokalizace s kódom jazyka 'en' a vlastním kódem země (kromě "
 "nouzového 'en'):"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr "Získat všechny lokalizace s kódem jazyka 'en', s kódem země i bez něj:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "Získat lokalizaci přesně odpovídající argumentu: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "Získat seznam balíčků dostupných pro 'de' a 'en':"
 
@@ -2845,11 +2858,11 @@ msgstr[2] "Odstraněno %lu zámků."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Název"
 
@@ -2859,8 +2872,8 @@ msgstr "Odpovídá"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Typ"
@@ -2868,7 +2881,7 @@ msgstr "Typ"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Úložiště"
@@ -3144,8 +3157,8 @@ msgid ""
 "download-as-needed disables the fileconflict check."
 msgstr ""
 "Nainstalovat balíčky i tehdy, když nahradí soubory druhých, již "
-"nainstalovaných, balíčků. Výchozí je brát konflikty souborů jako chybu. "
-"--download-as-needed vypíná kontrolu konfliktu souborů."
+"nainstalovaných, balíčků. Výchozí je brát konflikty souborů jako chybu. --"
+"download-as-needed vypíná kontrolu konfliktu souborů."
 
 #. translators: -y, --no-confirm
 #: src/commands/optionsets.cc:291
@@ -3326,7 +3339,7 @@ msgid "Command"
 msgstr "Příkaz"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Služba"
 
@@ -3495,40 +3508,40 @@ msgid "Show detailed information for products."
 msgstr "Zobrazí podrobné informace o produktech."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [volby] [repozitář] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Vypíše všechny dostupné balíčky."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Vypsat všechny balíčky, které jsou dostupné v zadaném repozitáři."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 "Zobrazit instalované balíčky, které byly automaticky vybrány překladačem."
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr "Zobrazit instalované balíčky, které uživatel výslovně vybral."
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 "Zobrazit instalované balíčky, které nejsou poskytovány žádným úložištěm."
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
@@ -3537,83 +3550,83 @@ msgstr ""
 "aktualizaci)."
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Zobrazit balíčky, které jsou navrhované."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Zobrazit balíčky, které jsou doporučené."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Zobrazit balíčky, které jsou nepotřebné."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Seřadit seznam podle názvu balíčku."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Seřadit seznam podle repozitáře."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [repozitář] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Vypíše všechny dostupné opravy."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Vypíše všechny opravy dostupné v zadaných repozitářích."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [volby] [repozitář] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Vypíše všechny dostupné profily."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Vypíše všechny profily dostupné v zadaných depozitářích."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [volby] [repozitář] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Vypíše všechny dostupné produkty."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Vypíše všechny produkty dostupné v zadaných repozitářích."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Pouze XML výstup: Doslovně přepošle XML tagy nalezené v produktovém souboru."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "Volba %1% nemá žádný efekt bez globální volby %2%."
@@ -3653,14 +3666,15 @@ msgstr ""
 
 #: src/commands/repos/add.cc:46
 msgid "The repository type is always autodetected. This option is ignored."
-msgstr "Typ repozitáře je vždy detekován automaticky. Tato volba je ignorována."
+msgstr ""
+"Typ repozitáře je vždy detekován automaticky. Tato volba je ignorována."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "%s nelze použít společně s %s. Bude použito nastavení %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3710,112 +3724,116 @@ msgstr "Vyčistí vyrovnávací paměti metadat i balíčků."
 # printers.ycp.noloc:1270
 # printers.ycp.noloc:1270
 # printers.ycp.noloc:1270
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "Adresa URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "povoleno"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Kontrola GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Priorita"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Automatické obnovení"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Zapnuto"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Vypnuto"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Podržet balíčky"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI GPG klíče"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Předpona cesty"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Rodičovská služba"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Klíčová slova"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Informační cesta repozitáře"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Cesta k vyrovnávací paměti MD"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [volby] [repozitář] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Vypsat všechny definované repozitáře."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 "Exportovat všechny definované repozitáře jako jeden místní .repo soubor."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Chyba při čtení repozitářů:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Nelze otevřít soubor '%s' pro zápis."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Pravděpodobně nemáte oprávnění k zápisu?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Repozitáře byly úspěšně vyexportovány do %s."
@@ -3823,20 +3841,20 @@ msgstr "Repozitáře byly úspěšně vyexportovány do %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Obnovit"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Nejsou definovány žádné repozitáře."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 "Pro přidání jednoho nebo více repozitářů použijte příkaz 'zypper addrepo'."
@@ -3942,7 +3960,7 @@ msgstr "Globální volba '%s' zde nemá žádný účinek."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Pokud je použito '%s', argumenty nejsou povoleny."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Zadané repozitáře: "
 
@@ -3951,7 +3969,7 @@ msgstr "Zadané repozitáře: "
 msgid "Refreshing repository '%s'."
 msgstr "Obnovuje se repozitář '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Prohledávání obsahu zakázaného repozitáře '%s'."
@@ -3961,7 +3979,7 @@ msgstr "Prohledávání obsahu zakázaného repozitáře '%s'."
 msgid "Skipping disabled repository '%s'"
 msgstr "Přeskakuji zakázaný repozitář '%s'"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Přeskakuji repozitář '%s' z důvodu uvedené chyby."
@@ -3988,7 +4006,7 @@ msgstr "Použijte příkazy '%s' nebo '%s' k přidání a povolení repozitář�
 msgid "Could not refresh the repositories because of errors."
 msgstr "Repozitáře nelze z důvodu chyby obnovit."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Některé repozitáře nebyly z důvodu chyby obnoveny."
 
@@ -4043,12 +4061,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Repozitář '%s' byl přejmenován na '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "Repozitář s názvem '%s' již existuje. Použijte jiný alias."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Chyba při změně repozitáře:"
 
@@ -4508,25 +4526,25 @@ msgstr ""
 "Má podobnou funkci jako parametr --details s dalšími informacemi o shodách "
 "vyhledávání (užitečné při vyhledávání v závislostech)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Zadaný repozitář '%s' je zakázán."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Nebyly nalezeny žádné odpovídající položky."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Problém nastal při inicializaci nebo spouštění vyhledávacího dotazu"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Nápovědu naleznete v předchozí zprávě."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "Spuštění 'zypper refresh' jako root by mohlo vyřešit problém."
 
@@ -4617,7 +4635,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Problém při získávání souboru se seznamem repozitáře pro službu '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Přeskakuji službu '%s' z důvodu výše uvedené chyby."
@@ -4636,24 +4654,28 @@ msgstr "Odebírá se služba'%s':"
 msgid "Service '%s' has been removed."
 msgstr "Služba '%s' byla odstraněna."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [volby]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Vypíše všechny definované služby."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Seznam definovaných služeb."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Nejsou definovány žádné služby. Přidejte jednu nebo více služeb příkazem "
 "'%s'."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5146,7 +5168,8 @@ msgstr ""
 #: src/commands/subcommand.cc:485
 #, boost-format
 msgid "Type '%1%' to get subcommand-specific help if available."
-msgstr "Chcete-li zobrazit případnou nápovědu k podpříkazu, zadejte příkaz %1%."
+msgstr ""
+"Chcete-li zobrazit případnou nápovědu k podpříkazu, zadejte příkaz %1%."
 
 #. translators: %1% - command name
 #: src/commands/subcommand.cc:508
@@ -5192,8 +5215,8 @@ msgstr "Aktualizuje nainstalované balíčky na novější verze."
 msgid ""
 "Update all or specified installed packages with newer versions, if possible."
 msgstr ""
-"Aktualizovat všechny nebo specifikované instalované balíčky na nové verze ("
-"pokud lze)."
+"Aktualizovat všechny nebo specifikované instalované balíčky na nové verze "
+"(pokud lze)."
 
 #: src/commands/update.cc:69 src/commands/update.cc:76
 #: src/commands/update.cc:123
@@ -5217,7 +5240,8 @@ msgstr ""
 #: src/commands/update.cc:83
 msgid ""
 "Cannot use multiple types when specific packages are given as arguments."
-msgstr "Když je jako argument použit konkrétní balíček, nelze použít více typů."
+msgstr ""
+"Když je jako argument použit konkrétní balíček, nelze použít více typů."
 
 #: src/commands/utils/download.cc:129 src/commands/utils/source-download.cc:212
 #, c-format, boost-format
@@ -5431,7 +5455,8 @@ msgstr "Stahování vyžadovaných zdrojových balíčků..."
 #: src/commands/utils/source-download.cc:428
 #, c-format, boost-format
 msgid "Source package '%s' is not provided by any repository."
-msgstr "Zdrojový balíček '%s' není poskytován v žádném z dostupných repozitářů."
+msgstr ""
+"Zdrojový balíček '%s' není poskytován v žádném z dostupných repozitářů."
 
 #: src/commands/utils/source-download.cc:446
 #: src/commands/utils/source-download.cc:460
@@ -5578,15 +5603,15 @@ msgstr "%s je starší než %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Verze"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Architektura"
 
@@ -5723,13 +5748,13 @@ msgstr "(žádné)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Závislost"
 
@@ -5766,7 +5791,7 @@ msgid "Flavor"
 msgstr "Varianta"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "V základu"
 
@@ -6029,57 +6054,57 @@ msgstr[2] "%1% repozitářů"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Kontroluje se, zda je třeba obnovit metadata pro %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Repozitář '%s' je aktuální."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Kontrola aktuálnosti '%s' byla odložena."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Vynucuje se obnovení nezpracovaných metadat"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Načítání metadat repozitáře '%s'"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Chcete zakázat repozitář %s trvale?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Chyba při zakazování repozitáře '%s'."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Problém při stahování souborů z '%s'."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Nápovědu naleznete v uvedené chybové zprávě."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Pro '%s' nejsou definovány žádné adresy URI."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -6088,16 +6113,16 @@ msgstr ""
 "Přidejte jednu nebo více základních adres URI (baseurl=URI) do %s pro "
 "repozitář '%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Pro tento repozitář není definovaný žádný alias."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Repozitář '%s' je neplatný."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -6105,22 +6130,22 @@ msgstr ""
 "Zkontrolujte, zda adresy URI definované pro tento repozitář ukazují na "
 "platný repozitář."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Chyba při získávání metadat pro '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Vynucuje se vytvoření vyrovnávací paměti repozitáře"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Chyba při analýze metadat pro '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6131,41 +6156,41 @@ msgstr ""
 "metadat. Ve druhém případě a v případě pochybností odešlete zprávu o chybě "
 "podle pokynů na stránce http://en.opensuse.org/Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Metadata repozitáře '%s' nebyla nalezena v místní vyrovnávací paměti."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Chyba při vytváření vyrovnávací paměti:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Repozitář '%s' nebyl podle aliasu, čísla, nebo URI nalezen."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Použijte '%s' pro získání seznamu definovaných repozitářů."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Ignoruji zakázaný repozitář '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr "Lze použít globální možnost %s k dočasnému povolení repozitářů."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Ignoruji repozitář '%s' z důvodu volby '%s'."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Dočasné povolování repozitáře '%s'."
@@ -6173,7 +6198,7 @@ msgstr "Dočasné povolování repozitáře '%s'."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6182,7 +6207,7 @@ msgstr ""
 "Repozitář '%s' není aktuální. Můžete ho aktualizovat spuštěním příkazu "
 "'zypper refresh' jako uživatel root."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6191,107 +6216,107 @@ msgstr ""
 "Pro repozitář '%s' je třeba vytvořit mezipaměť metadat. Můžete ji vytvořit "
 "spuštěním příkazu 'zypper refresh' jako uživatel root."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Repozitář '%s' zůstává zakázaný."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Inicializace cíle"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Inicializace cíle selhala:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Čistí se paměť metadat pro '%s'."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Čistí se paměť nezpracovaných metadat pro '%s'."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Zachovávám surová metadata pro %s '%s'."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Čistí se balíčky pro '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Repozitář '%s' nelze z důvodu chyby vyčistit."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Čistí se mezipaměť nainstalovaných balíčků."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Z důvodu chyby nelze vyčistit mezipaměť nainstalovaných balíčků."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Repozitáře nelze z důvodu chyby vyčistit."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Některé repozitáře nebyly z důvodu chyby vyčištěny."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Zadané repozitáře byly vyčištěny."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Všechny repozitáře byly vyčištěny."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Toto médium je výměnné a pouze pro čtení (CD/DVD), vypíná se automatické "
 "obnovení."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Neplatný alias repozitáře: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
-"Typ repozitáře se nepodařilo určit. Zkontrolujte, zda definované adresy URI ("
-"uvedené níže) ukazují na platný repozitář:"
+"Typ repozitáře se nepodařilo určit. Zkontrolujte, zda definované adresy URI "
+"(uvedené níže) ukazují na platný repozitář:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Na zadaném umístění nelze najít platný repozitář:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Problém při přenosu dat repozitáře ze zadané adresy URI:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Zkontrolujte, zda je zadaná adresa URI přístupná."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Neznámý problém při přidávání repozitáře:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6300,135 +6325,135 @@ msgstr ""
 "Kontrola GPG je v konfiguraci repozitáře '%1%' zakázána. Integritu a původ "
 "balíčků nelze ověřit."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Repozitář '%s' byl úspěšně přidán"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Načítání dat z média '%s'"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Problém při načítání dat z média '%s'"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Ověřte, zda je instalační médium platné a čitelné."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Čtení dat z média '%s' je zpožděno do dalšího obnovení."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Načítání dat z média '%s'"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Problém při načítání dat z média '%s'"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Ověřte, zda je instalační médium platné a čitelné."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Problém při přístupu k souboru na zadané adrese URI"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Zkontrolujte, zda je zadaná adresa URI platná a přístupná."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Problém při analýze souboru na zadané adrese URI"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Jedná se opravdu o soubor .repo?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Problém při pokusu o načtení souboru na zadané adrese URI"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "V souboru byl nalezen repozitář bez zadaného aliasu a bude přeskočen."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Repozitář '%s' nemá definovanou adresu URI a bude přeskočen."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Repozitář '%s' byl odstraněn."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Priorita repozitáře '%s' byla ponechána na původní hodnotě (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Repozitář '%s' byl úspěšně povolen."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Repozitář '%s' byl úspěšně zakázán."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Automatické obnovení bylo pro repozitář '%s' povoleno."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Automatické obnovení bylo pro repozitář '%s' zakázáno."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Ukládání souborů RPM do mezipaměti bylo pro repozitář '%s' povoleno."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Ukládání souborů RPM do mezipaměti bylo pro repozitář '%s' zakázáno."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Kontrola GPG pro repozitář '%s' byla povolena."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Kontrola GPG pro repozitář '%s' byla zakázána."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Priorita repozitáře '%s' byla nastavena na %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Název repozitáře '%s' byl nastaven na '%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "V repozitáři '%s' není třeba provést žádné změny."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Repozitář %s bude ponechán nezměněný."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Načítání dat repozitáře..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6436,44 +6461,44 @@ msgstr ""
 "Nejsou definovány žádné repozitáře. Pracuje se pouze s nainstalovanými "
 "řešeními. Nic nemůže být nainstalováno."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Načítání dat repozitáře '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Repozitář '%s' není uložen ve vyrovnávací paměti. Ukládá se..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Problém při načítání dat z '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 "Repozitář '%s' nemohl být aktualizován. Používá se stará vyrovnávací paměť."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Závislosti z '%s' nebyly načteny, protože došlo k chybě."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "Metadata úložiště '%1%' vypršela %2%."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Než tak učiníte, vyzkoušejte příkaz '%s' nebo i příkaz '%s'."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6485,30 +6510,30 @@ msgstr ""
 "Nevyřeší-li to problém, asi používáte nefunkční zrcadlo nebo server skutečně "
 "přestal úložiště podporovat."
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Načítají se nainstalované balíčky..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Během čtení instalovaných balíčků nastal problém:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' vypadá jako soubor RPM. Proběhne pokus o jeho stáhnutí."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Problém se souborem RPM určeným jako '%s', soubor bude vynechán."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Problém při čtení RPM hlaviček %s. Jedná se o RPM soubor?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Vyrovnávací paměť souborů RPM"
 
@@ -6516,25 +6541,25 @@ msgstr "Vyrovnávací paměť souborů RPM"
 msgid "System Packages"
 msgstr "Systémové balíčky"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Nebyly nalezeny žádné vyžadované opravy."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Nebyly nalezeny žádné profily."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Nebyly nalezeny žádné balíčky."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Vnitřní jméno"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Nebyly nalezeny žádné produkty."
 
@@ -6943,7 +6968,7 @@ msgid "Updatestack"
 msgstr "Zásobník oprav"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Opravy"
 
@@ -6966,7 +6991,7 @@ msgstr "Zahrnuté kategorie"
 msgid "Needed software management updates will be installed first:"
 msgstr "Nejdříve budou nainstalovány aktualizace správce softwaru:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Nebyly nalezeny žádné aktualizace."
 
@@ -6975,51 +7000,51 @@ msgstr "Nebyly nalezeny žádné aktualizace."
 msgid "The following updates are also available:"
 msgstr "Jsou dostupné také následující aktualizace:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Aktualizace balíčků"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Aktualizace profilu"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Aktualizace produktu"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Současná verze"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Dostupná verze"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Nebyly nalezeny odpovídající problémy."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Byly nalezeny následující shody v číslech problémů:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "Byly nalezeny shody popisu oprav následujících oprav:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "Oprava pro problém v Bugzille číslo %s nebyla nalezena nebo není potřeba."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "Oprava pro CVE problém číslo %s nebyla nalezena nebo není potřeba."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "Oprava pro problém %s číslo %s nebyla nalezena nebo není potřeba."

--- a/po/cy.po
+++ b/po/cy.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Welsh <https://l10n.opensuse.org/projects/zypper/master/cy/>\n"
@@ -1618,7 +1618,7 @@ msgstr ""
 msgid "Try again?"
 msgstr ""
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr ""
 
@@ -1646,12 +1646,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2348,24 +2348,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2435,7 +2441,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2617,22 +2623,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2683,49 +2689,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2833,11 +2843,11 @@ msgstr[4] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr ""
 
@@ -2847,8 +2857,8 @@ msgstr ""
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Math"
@@ -2856,7 +2866,7 @@ msgstr "Math"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr ""
@@ -3278,7 +3288,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "Gweinydd"
@@ -3439,120 +3449,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3591,12 +3601,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3638,113 +3648,117 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr ""
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr ""
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 #, fuzzy
 msgid "Autorefresh"
 msgstr "Nodweddion Hunan-Gychwyn"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr ""
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "Gweinydd"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr ""
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Can't run %s.  Exiting."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3752,21 +3766,21 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr ""
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "Nodweddion Hunan-Gychwyn"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3867,7 +3881,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr ""
 
@@ -3876,7 +3890,7 @@ msgstr ""
 msgid "Refreshing repository '%s'."
 msgstr "Nodweddion Hunan-Gychwyn"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Nodweddion Hunan-Gychwyn"
@@ -3886,7 +3900,7 @@ msgstr "Nodweddion Hunan-Gychwyn"
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3913,7 +3927,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3966,12 +3980,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr ""
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr ""
 
@@ -4398,25 +4412,25 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Nodweddion Hunan-Gychwyn"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr ""
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4506,7 +4520,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr ""
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4525,21 +4539,25 @@ msgstr ""
 msgid "Service '%s' has been removed."
 msgstr ""
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5430,15 +5448,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr ""
 
@@ -5580,13 +5598,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr ""
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -5623,7 +5641,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5881,94 +5899,94 @@ msgstr[4] ""
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr ""
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr ""
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr ""
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr ""
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Nodweddion Hunan-Gychwyn"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr ""
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr ""
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr ""
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr ""
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr ""
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5976,41 +5994,41 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr ""
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr ""
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr ""
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Nodweddion Hunan-Gychwyn"
@@ -6018,294 +6036,294 @@ msgstr "Nodweddion Hunan-Gychwyn"
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Nodweddion Hunan-Gychwyn"
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr ""
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr ""
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr ""
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr ""
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr ""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr ""
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr ""
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr ""
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr ""
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr ""
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Nodweddion Hunan-Gychwyn"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Nodweddion Hunan-Gychwyn"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr ""
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr ""
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr ""
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr ""
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr ""
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6313,30 +6331,30 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr ""
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr ""
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6344,26 +6362,26 @@ msgstr ""
 msgid "System Packages"
 msgstr ""
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr ""
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr ""
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "Defnyddiwr"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr ""
 
@@ -6761,7 +6779,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr ""
 
@@ -6784,7 +6802,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr ""
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr ""
 
@@ -6793,50 +6811,50 @@ msgstr ""
 msgid "The following updates are also available:"
 msgstr ""
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr ""
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr ""
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr ""
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr ""
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr ""
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/da.po
+++ b/po/da.po
@@ -6,11 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Danish <https://l10n.opensuse.org/projects/zypper/master/da/>"
-"\n"
+"Language-Team: Danish <https://l10n.opensuse.org/projects/zypper/master/da/"
+">\n"
 "Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -922,8 +922,8 @@ msgid_plural ""
 "The following %d packages are recommended, but will not be installed because "
 "they are unwanted (were manually removed before):"
 msgstr[0] ""
-"Følgende pakke anbefales, men vil ikke blive installeret da den er uønsket ("
-"blev fjernet manuelt tidligere):"
+"Følgende pakke anbefales, men vil ikke blive installeret da den er uønsket "
+"(blev fjernet manuelt tidligere):"
 msgstr[1] ""
 "Følgende %d pakker anbefales, men vil ikke blive installeret da de er "
 "uønsket (blev fjernet manuelt tidligere):"
@@ -1013,7 +1013,8 @@ msgid "The following application is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d applications are suggested, but will not be installed:"
 msgstr[0] "Følgende program er foreslået, men vil ikke blive installeret:"
-msgstr[1] "Følgende %d programmer er foreslået, men vil ikke blive installeret:"
+msgstr[1] ""
+"Følgende %d programmer er foreslået, men vil ikke blive installeret:"
 
 #: src/Summary.cc:1274
 #, c-format, boost-format
@@ -1109,7 +1110,8 @@ msgid ""
 msgid_plural ""
 "The following %d packages need additional customer contract to get support:"
 msgstr[0] "Følgende pakke behøver yderligere kundekontrakt for at få support:"
-msgstr[1] "Følgende %d pakker behøver yderligere kundekontrakt for at få support:"
+msgstr[1] ""
+"Følgende %d pakker behøver yderligere kundekontrakt for at få support:"
 
 #: src/Summary.cc:1417
 msgid "was superseded by"
@@ -1162,7 +1164,8 @@ msgstr[1] "Følgende %d programopdateringer vil IKKE blive installeret:"
 msgid "The following item is locked and will not be changed by any action:"
 msgid_plural ""
 "The following %d items are locked and will not be changed by any action:"
-msgstr[0] "Følgende element er låst og vil ikke blive ændret af nogen handling:"
+msgstr[0] ""
+"Følgende element er låst og vil ikke blive ændret af nogen handling:"
 msgstr[1] ""
 "Følgende %d elementer er låst og vil ikke blive ændret af nogen handling:"
 
@@ -1406,7 +1409,7 @@ msgstr "PackageKit kører stadig (formentlig optaget)."
 msgid "Try again?"
 msgstr "Prøv igen?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Uventet undtagelse."
 
@@ -1436,12 +1439,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Tilvalget %s har ingen virkning her. Det ignoreres."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Ikke-tilvalg programargumenter: "
 
@@ -2172,17 +2175,17 @@ msgid "Commands:"
 msgstr "Kommandoer:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Vis standard installationsoversigt."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Type af pakke (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2190,9 +2193,15 @@ msgstr ""
 "Opdatér på bedst mulig vis. Opdatering til en lavere version end den "
 "seneste, er også acceptabelt."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "Overvej kun rettelser som påvirker selv pakkehåndteringen."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2261,14 +2270,15 @@ msgstr ""
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/help.cc:22
 msgid "zypper [--GLOBAL-OPTIONS] <COMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
-msgstr "zypper [--globale-tilvalg] <kommando> [--kommando-tilvalg] [argumenter]"
+msgstr ""
+"zypper [--globale-tilvalg] <kommando> [--kommando-tilvalg] [argumenter]"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/help.cc:25
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <underkommando> [--kommando-tilvalg] [argumenter]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Print zypper hjælp"
 
@@ -2378,8 +2388,8 @@ msgid ""
 msgstr ""
 "Installationsstatus for en rettelse bestemmes alene baseret på dens "
 "afhængigheder.\n"
-" Rettelser installeres ikke i betydningen af kopierede filer, databaseindgange,"
-"\n"
+" Rettelser installeres ikke i betydningen af kopierede filer, "
+"databaseindgange,\n"
 " eller lignende."
 
 #: src/commands/installremove.cc:126
@@ -2477,22 +2487,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [TILVALG]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Vis alle anvendelige rettelser."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Vis alle rettelser, ikke kun de anvendelige."
 
@@ -2547,35 +2557,39 @@ msgstr ""
 "alle tilgængelige lokaliteter ved at kalde '%s'."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [TILVALG] [LOKALITET] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Vis anmodende lokaliteter (sprogkoder)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Vis anmodede lokaliteter og tilhørende pakker."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Vis tilhørende pakker."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Vis alle tilgængelige lokaliteter."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr "Ignorerer positionelle argumenter da --all-argument blev angivet."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "Den lokalitet(er) som der skal udskrives information om."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2583,15 +2597,15 @@ msgstr ""
 "Hent alle lokaliteter med sprogkoden 'en' som har deres egen landekode, "
 "eksklusiv reserven 'en':"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr "Hent alle lokaliteter med sprogkoden 'en' med eller uden landekode:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "Hent lokaliteten som matcher argumentet præcist: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "Hent listen over pakker som er tilgængelige for 'de' og 'en':"
 
@@ -2695,11 +2709,11 @@ msgstr[1] "Fjernede %lu låse."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Navn"
 
@@ -2709,8 +2723,8 @@ msgstr "Match"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Type"
@@ -2718,7 +2732,7 @@ msgstr "Type"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Softwarekilde"
@@ -3013,8 +3027,8 @@ msgid ""
 "download-as-needed disables the fileconflict check."
 msgstr ""
 "Installér pakkerne selvom de overskriver filer fra andre, allerede "
-"installerede pakker. Standard er at behandle filkonflikter som en fejl. "
-"--download-as-needed deaktiverer tjek af filkonflikter."
+"installerede pakker. Standard er at behandle filkonflikter som en fejl. --"
+"download-as-needed deaktiverer tjek af filkonflikter."
 
 #. translators: -y, --no-confirm
 #: src/commands/optionsets.cc:291
@@ -3194,7 +3208,7 @@ msgid "Command"
 msgstr "Kommando"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Tjeneste"
 
@@ -3362,122 +3376,122 @@ msgid "Show detailed information for products."
 msgstr "Vis detaljeret information om produkter."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [tilvalg] [softwarekilde] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Vis alle tilgængelige pakker."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Vis alle tilgængelige mønstre i angivne softwarekilder."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Vis pakker som er foreslået."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Vis pakker som er anbefalet."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Vis pakker som ikke behøves."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Sortér listen efter pakkenavn."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Sortér listen efter softwarekilde."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [softwarekilde] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Vis alle tilgængelige rettelser."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Vis alle tilgængelige rettelser i angivne softwarekilder."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [tilvalg] [softwarekilde] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Vis alle tilgængelige mønstre."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Vis alle tilgængelige mønstre i angivne softwarekilder."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [tilvalg] [softwarekilde] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Vis alle tilgængelige produkter."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Vis alle tilgængelige produkter i angivne softwarekilder."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Kun XML-output: Videresend bogstavelig talt XML-taggene fundet i en "
 "produktfil."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "Tilvalget %1% har ingen virkning uden det globale tilvalg %2%."
@@ -3519,17 +3533,17 @@ msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 "Typen af softwarekilde registreres altid automatisk. Tilvalget ignoreres."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "Kan ikke bruge %s sammen med %s. Bruger indstillingen %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
-"Hvis der kun anvendes ét argument, skal det være en URI, der peger på en "
-".repo-fil."
+"Hvis der kun anvendes ét argument, skal det være en URI, der peger på "
+"en .repo-fil."
 
 #: src/commands/repos/add.cc:130
 msgid "Specified type is not a valid repository type:"
@@ -3569,111 +3583,115 @@ msgstr "Ryd rå metadata-cache."
 msgid "Clean both metadata and package caches."
 msgstr "Ryd både metadata- og pakke-cache."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Aktiveret"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "GPG-tjek"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Prioritet"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Automatisk genopfrisk"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Til"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Fra"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Behold pakker"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI til GPG-nøgle"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Sti-præfiks"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Forældertjeneste"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Nøgleord"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Sti til softwarekilde-info"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Sti til MD-cache"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [tilvalg] [softwarekilde] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Vis alle definerede softwarekilder."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "Eksportér alle angivne softwarekilder som en enkelt .repo-fil."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Fejl under læsning af softwarekilder:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Kan ikke åbne %s til skrivning."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Måske har du ikke skrivetilladelse?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Softwarekilder er eksporteret til %s."
@@ -3681,20 +3699,20 @@ msgstr "Softwarekilder er eksporteret til %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Genopfrisk"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Ingen softwarekilder defineret."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 "Brug kommandoen \"zypper addrepo\" for at tilføje en eller flere "
@@ -3801,7 +3819,7 @@ msgstr "Det globale tilvalg \"%s\" har ingen virkning her."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Argumenter tillades ikke, hvis '%s' anvendes."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Angivne softwarekilder: "
 
@@ -3810,7 +3828,7 @@ msgstr "Angivne softwarekilder: "
 msgid "Refreshing repository '%s'."
 msgstr "Genopfrisker softwarekilden '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Scanner indhold af deaktiveret softwarekilde \"%s\"."
@@ -3820,7 +3838,7 @@ msgstr "Scanner indhold af deaktiveret softwarekilde \"%s\"."
 msgid "Skipping disabled repository '%s'"
 msgstr "Springer den deaktiverede softwarekilde '%s' over"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Springer softwarekilden '%s' over pga. den ovennævnte fejl."
@@ -3850,7 +3868,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "Kunne ikke genopfriske softwarekilderne pga. fejl."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Nogle af softwarekilderne blev ikke genopfrisket pga. en fejl."
 
@@ -3905,13 +3923,13 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Softwarekilden '%s' er omdøbt til '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 "En softwarekilde ved navn '%s' eksisterer allerede. Brug et andet alias."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Fejl under ændring af softwarekilde:"
 
@@ -4359,7 +4377,8 @@ msgstr "Udfør versalfølsom søgning."
 #. translators: -s, --details
 #: src/commands/search/search.cc:201
 msgid "Show each available version in each repository on a separate line."
-msgstr "Vis hver tilgængelig version i hver softwarekilde  på en separat linje."
+msgstr ""
+"Vis hver tilgængelig version i hver softwarekilde  på en separat linje."
 
 #. translators: -v, --verbose
 #: src/commands/search/search.cc:205
@@ -4370,25 +4389,26 @@ msgstr ""
 "Ligesom --details, med yderligere information, der hvor  søgningen har "
 "matchet (nyttigt ved søgning i afhængigheder)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Den angivne softwarekilde \"%s\" er deaktiveret."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Ingen matchende elementer fundet."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
-msgstr "Problem opstod under initialisering eller udførsel af søgeforespørgslen"
+msgstr ""
+"Problem opstod under initialisering eller udførsel af søgeforespørgslen"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Se meddelelsen ovenfor for at få et tip."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "At køre 'zypper refresh' som root kan måske løse problemet."
 
@@ -4480,7 +4500,7 @@ msgstr ""
 "Problem med at hente indeksfilen over softwarekilder for tjenesten '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Springer tjenesten '%s' over pga. den ovennævnte fejl."
@@ -4499,24 +4519,28 @@ msgstr "Fjerner tjenesten '%s':"
 msgid "Service '%s' has been removed."
 msgstr "Tjenesten '%s' blev fjernet."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [tilvalg]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Vis alle angivne tjenester."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Vis angivne tjenester."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Ingen softwarekilder angivet. Brug kommandoen '%s' for at tilføje en eller "
 "flere tjenester."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5445,15 +5469,15 @@ msgstr "%s er ældre end %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Version"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arkitektur"
 
@@ -5587,13 +5611,13 @@ msgstr "(tom)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Afhængighed"
 
@@ -5630,7 +5654,7 @@ msgid "Flavor"
 msgstr "Flavor"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Er basis"
 
@@ -5776,7 +5800,8 @@ msgstr ""
 #: src/misc.cc:209
 #, c-format, boost-format
 msgid "Aborting installation due to user disagreement with %s %s license."
-msgstr "Afbryder installationen, da bruger ikke accepterer licensaftalen %s %s."
+msgstr ""
+"Afbryder installationen, da bruger ikke accepterer licensaftalen %s %s."
 
 #: src/misc.cc:248
 msgid "License"
@@ -5892,57 +5917,57 @@ msgstr[1] "%1% softwarekilder"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Tjekker om metadata til %s skal genopfriskes"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Softwarekilden '%s' er ajourført."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Ajourførelsestjek af '%s' er blevet udsat."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Gennemtvinger genopfriskning af 'raw' metadata"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Henter metadata fra softwarekilden '%s'"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Vil du deaktivere softwarekilden %s permanent?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Fejl under deaktivering af softwarekilden \"%s\"."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Problem med at hente filer fra \"%s\"."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Se fejlmeddelelsen ovenfor for at få et tip."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Ingen URIer angivet for '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -5950,16 +5975,16 @@ msgid ""
 msgstr ""
 "Tilføj en eller flere basis-URI (baseurl=URI) til %s for softwarekilden '%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Intet alias angivet for denne softwarekilde."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Softwarekilden '%s' er ugyldig."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -5967,22 +5992,22 @@ msgstr ""
 "Tjek om URI'erne, angivet for denne softwarekilde, peger på en gyldig "
 "softwarekilde."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Fejl under hentning af metadata for '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Gennemtvinger opbygning af softwarekilde-cache"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Fejl under fortolkning af metadata for '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5994,42 +6019,42 @@ msgstr ""
 "venligst en fejlrapport ved at følge instruktionerne på http://"
 "en.opensuse.org/Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Softwarekilde-metadata for '%s' blev ikke fundet i lokal cache."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Fejl under opbygning af cachen:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Softwarekilden '%s' blev ikke fundet ved dens alias, nummer eller URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Brug '%s' for at få en liste over angivne softwarekilder."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Ignorerer den deaktiverede softwarekilde \"%s\""
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "Globale tilvalg '%s' kan bruges til at aktivere softwarekilder midlertidigt."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Ignorerer softwarekilden \"%s\" pga. tilvalget \"%s\"."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Aktiverer softwarekilden \"%s\" midlertidigt."
@@ -6037,7 +6062,7 @@ msgstr "Aktiverer softwarekilden \"%s\" midlertidigt."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6046,7 +6071,7 @@ msgstr ""
 "Softwarekilden '%s' er uddateret. Du kan køre 'zypper refresh' som root for "
 "at ajourføre den."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6055,81 +6080,81 @@ msgstr ""
 "Metadata-cachen skal opbygges for softwarekilden '%s'. Du kan køre 'zypper "
 "refresh' som root for at gøre dette."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Softwarekilden \"%s\" forbliver deaktiveret."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Initialiserer målet"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Initialisering af målet mislykkedes:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Rydder metadata-cache for '%s'."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Rydder 'raw' metadata-cache for '%s'."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Beholder rå metadata-cache for %s \"%s\"."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Rydder pakker for '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Kan ikke rydde softwarekilden '%s' pga. en fejl."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Rydder cache for installerede pakker."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Kan ikke rydde cache for installerede pakker pga. en fejl."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Kunne ikke rydde softwarekilderne pga. fejl."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Nogle af softwarekilderne blev ikke ryddet pga. en fejl."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "De angivne softwarekilder blev ryddet."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Alle softwarekilder blev ryddet."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Dette er et udskifteligt kun-læsbart medie (cd/dvd), deaktiverer automatisk "
 "genopfriskning."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Ugyldigt softwarekildealias: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6137,25 +6162,25 @@ msgstr ""
 "Kunne ikke fastslå typen af softwarekilden. Tjek om de definerede URIer (se "
 "nedenfor) peger på en gyldig softwarekilde:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Kan ikke finde en gyldig softwarekilde på den givne placering:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Problem med at overføre softwarekilde-data fra den angivne URI:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Tjek om den angivne URI er tilgængelig."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Ukendt problem under tilføjelse af softwarekilde:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6164,135 +6189,136 @@ msgstr ""
 "GPG-tjek er deaktiveret i konfigurationen af softwarekilden '%1%'. "
 "Integritet og oprindelse af pakker kan ikke verificeres."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Softwarekilden '%s' tilføjet"
 
-#: src/repos.cc:1269
+#: src/repos.cc:1262
+#, c-format, boost-format
+msgid "Reading data from '%s' media is delayed until next refresh."
+msgstr ""
+"Læsning af data fra mediet \"%s\" udsættes indtil næste genopfriskning."
+
+#: src/repos.cc:1267
 #, c-format, boost-format
 msgid "Reading data from '%s' media"
 msgstr "Læser data fra mediet '%s'"
 
-#: src/repos.cc:1275
+#: src/repos.cc:1273
 #, c-format, boost-format
 msgid "Problem reading data from '%s' media"
 msgstr "Problem med at læse data fra mediet '%s'"
 
-#: src/repos.cc:1276
+#: src/repos.cc:1274
 msgid "Please check if your installation media is valid and readable."
 msgstr "Tjek om dit installationsmedie er gyldigt og læsbart."
 
-#: src/repos.cc:1283
-#, c-format, boost-format
-msgid "Reading data from '%s' media is delayed until next refresh."
-msgstr "Læsning af data fra mediet \"%s\" udsættes indtil næste genopfriskning."
-
-#: src/repos.cc:1352
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Problem med at tilgå filen på den angivne URI"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Tjek om URIen er gyldig og tilgængelig."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Problem med fortolkning af filen på den angivne URI"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Er det en .repo-fil?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Problem opstod under forsøg på at læse filen på den angivne URI"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Softwarekilde uden angivet alias blev fundet i filen. Springer over."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Softwarekilden '%s' har ikke en URI defineret. Springer over."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Softwarekilden '%s' blev fjernet."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Prioritet af softwarekilden '%s' forblev uændret (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Softwarekilden \"%s\" er blevet aktiveret."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Softwarekilden \"%s\" er blevet deaktiveret."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Automatisk genopfriskning blev aktiveret for softwarekilden '%s'."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Automatisk genopfriskning blev deaktiveret for softwarekilden '%s'."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Caching af RPM-filer blev aktiveret for softwarekilden '%s'."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Caching af RPM-filer blev deaktiveret for softwarekilden '%s'."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "GPG-tjek er blevet aktiveret for softwarekilden \"%s\"."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "GPG-tjek er blevet deaktiveret for softwarekilden \"%s\"."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Prioritet for softwarekilden '%s' blev sat til %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Navnet på softwarekilden '%s' blev sat til '%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Intet at ændre for softwarekilden '%s'."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Lader softwarekilden %s forblive uændret."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Indlæser softwarekildedata..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6300,43 +6326,43 @@ msgstr ""
 "Ingen softwarekilder angivet. Der anvendes kun installerede resolvables. "
 "Intet kan installeres."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Henter data for softwarekilden '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Softwarekilden '%s' er ikke cachet. Cacher..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Problem med indlæsning af data fra '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "Softwarekilden \"%s\" kunne ikke genopfriskes. Bruger gammel cache."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Resolvables fra '%s' er ikke indlæst pga. fejl."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Prøv '%s', eller måske endda '%s' før du gør det."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6344,30 +6370,30 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Læser installerede pakker..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Problem opstod ved læsning af de installerede pakker:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' ligner en RPM-fil. Vil prøve at downloade den."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Problem med RPM-filen angivet som '%s'. Springer over."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Problem med at læse RPM-header for %s. Er det en RPM-fil?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Cache for rene RPM-filer"
 
@@ -6375,25 +6401,25 @@ msgstr "Cache for rene RPM-filer"
 msgid "System Packages"
 msgstr "Systempakker"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Ingen nødvendige rettelser fundet."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Ingen mønstre fundet."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Ingen pakker fundet."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Internt navn"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Ingen produkter fundet."
 
@@ -6791,7 +6817,7 @@ msgid "Updatestack"
 msgstr "Opdateringsstak"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Rettelser"
 
@@ -6815,7 +6841,7 @@ msgid "Needed software management updates will be installed first:"
 msgstr ""
 "Krævede opdateringer af softwarehåndteringen vil blive installeret først:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Ingen opdateringer fundet."
 
@@ -6824,47 +6850,47 @@ msgstr "Ingen opdateringer fundet."
 msgid "The following updates are also available:"
 msgstr "De følgende opdateringer er også tilgængelige:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Pakkeopdateringer"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Mønsteropdateringer"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Produktopdateringer"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Nuværende version"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Tilgængelig version"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Ingen matchende problemstillinger fundet."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Følgende matchende problemstillingsnumre er blevet fundet:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 "Der er blevet fundet matchende rettelsesbeskrivelser i følgende rettelser:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "Løsning af Bugzilla problemstillingsnummer %s blev ikke fundet eller er ikke "
 "nødvendig."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
@@ -6872,7 +6898,7 @@ msgstr ""
 "nødvendig."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "Rettelse for %s issue nummer %s blev ikke fundet eller behøves ikke."
@@ -7069,7 +7095,8 @@ msgstr "Opret venligst en fejlrapport om dette."
 #. unless you translate the actual page :)
 #: src/utils/messages.cc:22
 msgid "See http://en.opensuse.org/Zypper/Troubleshooting for instructions."
-msgstr "Du kan få vejledning på http://en.opensuse.org/Zypper/Troubleshooting ."
+msgstr ""
+"Du kan få vejledning på http://en.opensuse.org/Zypper/Troubleshooting ."
 
 #: src/utils/messages.cc:38
 msgid "Too many arguments."
@@ -7388,8 +7415,8 @@ msgid ""
 "If nothing else works enter '#1' to select the 1st option, '#2' for the 2nd "
 "one, ..."
 msgstr ""
-"Hvis intet andet virker så indtast '#1' for at vælge det første tilvalg, '#"
-"2' for det andet, ..."
+"Hvis intet andet virker så indtast '#1' for at vælge det første tilvalg, "
+"'#2' for det andet, ..."
 
 #. TranslatorExplanation These are reasons for various failures.
 #: src/utils/prompt.h:95

--- a/po/de.po
+++ b/po/de.po
@@ -16,11 +16,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper.de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-08-01 14:59+0000\n"
 "Last-Translator: Gemineo <vistatec@gemineo.de>\n"
-"Language-Team: German <https://l10n.opensuse.org/projects/zypper/master/de/>"
-"\n"
+"Language-Team: German <https://l10n.opensuse.org/projects/zypper/master/de/"
+">\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -816,14 +816,16 @@ msgstr[1] "Die folgenden %d Anwendungen werden aktualisiert:"
 msgid "The following package is going to be downgraded:"
 msgid_plural "The following %d packages are going to be downgraded:"
 msgstr[0] "Das folgende Paket wird durch eine ältere Version ausgetauscht:"
-msgstr[1] "Die folgenden %d Pakete werden durch eine ältere Version ausgetauscht:"
+msgstr[1] ""
+"Die folgenden %d Pakete werden durch eine ältere Version ausgetauscht:"
 
 #: src/Summary.cc:871
 #, c-format, boost-format
 msgid "The following patch is going to be downgraded:"
 msgid_plural "The following %d patches are going to be downgraded:"
 msgstr[0] "Der folgende Patch wird durch eine ältere Version ausgetauscht:"
-msgstr[1] "Die folgenden %d Patches werden durch eine ältere Version ausgetauscht:"
+msgstr[1] ""
+"Die folgenden %d Patches werden durch eine ältere Version ausgetauscht:"
 
 #: src/Summary.cc:876
 #, c-format, boost-format
@@ -922,7 +924,8 @@ msgid "The following recommended source package was automatically selected:"
 msgid_plural ""
 "The following %d recommended source packages were automatically selected:"
 msgstr[0] "Das folgende empfohlene Quellpaket wurde automatisch gewählt:"
-msgstr[1] "Die folgenden %d empfohlenen Quellpakete wurden automatisch gewählt:"
+msgstr[1] ""
+"Die folgenden %d empfohlenen Quellpakete wurden automatisch gewählt:"
 
 #: src/Summary.cc:1100
 #, c-format, boost-format
@@ -930,7 +933,8 @@ msgid "The following recommended application was automatically selected:"
 msgid_plural ""
 "The following %d recommended applications were automatically selected:"
 msgstr[0] "Die folgende empfohlene Anwendung wurde automatisch gewählt:"
-msgstr[1] "Die folgenden %d empfohlenen Anwendungen wurden automatisch gewählt:"
+msgstr[1] ""
+"Die folgenden %d empfohlenen Anwendungen wurden automatisch gewählt:"
 
 #: src/Summary.cc:1147
 #, c-format, boost-format
@@ -1036,7 +1040,8 @@ msgstr[1] ""
 msgid "The following pattern is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d patterns are suggested, but will not be installed:"
-msgstr[0] "Das folgende Schema wird vorgeschlagen, wird aber nicht installiert:"
+msgstr[0] ""
+"Das folgende Schema wird vorgeschlagen, wird aber nicht installiert:"
 msgstr[1] ""
 "Die folgenden %d Schemata werden vorgeschlagen, werden aber nicht "
 "installiert:"
@@ -1046,7 +1051,8 @@ msgstr[1] ""
 msgid "The following product is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d products are suggested, but will not be installed:"
-msgstr[0] "Das folgende Produkt wird vorgeschlagen, wird aber nicht installiert:"
+msgstr[0] ""
+"Das folgende Produkt wird vorgeschlagen, wird aber nicht installiert:"
 msgstr[1] ""
 "Die folgenden %d Produkte werden vorgeschlagen, werden aber nicht "
 "installiert:"
@@ -1056,7 +1062,8 @@ msgstr[1] ""
 msgid "The following application is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d applications are suggested, but will not be installed:"
-msgstr[0] "Die folgende Anwendung wird vorgeschlagen, wird aber nicht installiert:"
+msgstr[0] ""
+"Die folgende Anwendung wird vorgeschlagen, wird aber nicht installiert:"
 msgstr[1] ""
 "Die folgenden %d Anwendungen werden vorgeschlagen, werden aber nicht "
 "installiert:"
@@ -1213,7 +1220,8 @@ msgstr[1] "Die folgenden %d Produktaktualisierungen werden NICHT installiert:"
 msgid "The following application update will NOT be installed:"
 msgid_plural "The following %d application updates will NOT be installed:"
 msgstr[0] "Die folgende Anwendungsaktualisierung wird NICHT installiert:"
-msgstr[1] "Die folgenden %d Anwendungsaktualisierungen werden NICHT installiert:"
+msgstr[1] ""
+"Die folgenden %d Anwendungsaktualisierungen werden NICHT installiert:"
 
 #: src/Summary.cc:1504
 #, c-format, boost-format
@@ -1421,7 +1429,8 @@ msgstr ""
 #: src/Summary.cc:1824
 #, boost-format
 msgid "%1% is set, otherwise a system reboot would be required."
-msgstr "%1% wurde festgelegt, andernfalls wäre ein Systemneustart erforderlich."
+msgstr ""
+"%1% wurde festgelegt, andernfalls wäre ein Systemneustart erforderlich."
 
 #: src/Summary.cc:1826
 msgid "System reboot required."
@@ -1468,7 +1477,7 @@ msgstr "PackageKit wird noch ausgeführt (wahrscheinlich aktiv)."
 msgid "Try again?"
 msgstr "Erneut versuchen?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Unerwartete Ausnahme."
 
@@ -1499,12 +1508,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Die Option %s hat hier keine Auswirkung und wird daher ignoriert."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Andere Programmargumente (keine Optionen): "
 
@@ -2270,17 +2279,17 @@ msgid "Commands:"
 msgstr "Kommandos:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Ausführliche Installationsübersicht anzeigen."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Pakettyp (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2289,10 +2298,16 @@ msgstr ""
 "Aktualisierungen zu einer älteren als der neuesten Version sind auch "
 "akzeptabel."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr ""
 "Nur Patches in Erwägung ziehen, die das Paketmanagement selbst beeinflussen."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2368,14 +2383,15 @@ msgstr ""
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/help.cc:22
 msgid "zypper [--GLOBAL-OPTIONS] <COMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
-msgstr "zypper [--Globale-Optionen] <Kommando> [--Kommandooptionen] [Argumente]"
+msgstr ""
+"zypper [--Globale-Optionen] <Kommando> [--Kommandooptionen] [Argumente]"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/help.cc:25
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <Unterkommando> [--Kommandooptionen] [Argumente]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Zypper Hilfe drucken"
 
@@ -2603,22 +2619,22 @@ msgstr ""
 "offiziellen Update-Versionen zu ersetzen."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [OPTIONEN]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Verfügbare Patches listen."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Alle anwendbaren Patches auflisten."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Alle Patches auflisten, nicht nur die anwendbaren."
 
@@ -2675,36 +2691,40 @@ msgstr ""
 "verfügbaren Locales kann mit '%s' abgerufen werden."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [OPTIONEN] [LOCALE] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Angeforderte Locales (Sprachcodes) auflisten."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Angeforderte Locales und die entsprechenden Pakete auflisten."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Die entsprechenden Pakete anzeigen."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Alle verfügbaren Locales auflisten."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 "Positionsargumente werden ignoriert, da das Argument '--all' angegeben wurde."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "Die Locale(s), für die die Informationen ausgegeben werden sollen."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2712,15 +2732,15 @@ msgstr ""
 "Alle Locales mit dem Sprachcode 'en' abrufen, die über einen eigenen "
 "Ländercode verfügen, mit Ausnahme der Ausweichlösung 'en':"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr "Alle Locales mit Sprachcode 'en' mit oder ohne Ländercode abrufen:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "Locale abrufen, die dem Argument genau entspricht: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "Liste der Pakete abrufen, die für 'de' und 'en' verfügbar sind:"
 
@@ -2833,11 +2853,11 @@ msgstr[1] "%lu Sperren entfernt."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Name"
 
@@ -2847,8 +2867,8 @@ msgstr "Übereinstimmungen"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Typ"
@@ -2856,7 +2876,7 @@ msgstr "Typ"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Repository"
@@ -3149,8 +3169,8 @@ msgid ""
 "Don't require user interaction. Alias for the --non-interactive global "
 "option."
 msgstr ""
-"Keine Benutzerinteraktion erforderlich. Alias für die globale Option "
-"\"--non-interactive\"."
+"Keine Benutzerinteraktion erforderlich. Alias für die globale Option \"--non-"
+"interactive\"."
 
 #: src/commands/optionsets.cc:309
 msgid ""
@@ -3326,7 +3346,7 @@ msgid "Command"
 msgstr "Kommando"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Dienst"
 
@@ -3397,8 +3417,9 @@ msgid ""
 "match exactly."
 msgstr ""
 "Wenn keine Versionseinschränkung angegeben ist, werden Informationen über "
-"das beste verfügbare Paket angezeigt. Beachten Sie, dass sowohl die Versions-"
-" als auch die Veröffentlichungsnummer immer genau übereinstimmen müssen."
+"das beste verfügbare Paket angezeigt. Beachten Sie, dass sowohl die "
+"Versions- als auch die Veröffentlichungsnummer immer genau übereinstimmen "
+"müssen."
 
 #. translators: -s, --match-substrings
 #: src/commands/query/info.cc:65
@@ -3502,42 +3523,42 @@ msgid "Show detailed information for products."
 msgstr "Detaillierte Produktinformationen anzeigen."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [Optionen] [Repository] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Alle verfügbaren Pakete auflisten."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Alle verfügbaren Pakete in den angegebenen Repositorys auflisten."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 "Installierte Pakete anzeigen, die automatisch vom Resolver ausgewählt wurden."
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 "Installierte Pakete anzeigen, die vom Benutzer explizit ausgewählt wurden."
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 "Installierte Pakete, die von keinem Repository bereitgestellt werden, "
 "anzeigen."
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
@@ -3546,84 +3567,84 @@ msgstr ""
 "Aktualisierungskandidaten)."
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Vorgeschlagene Pakete anzeigen."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Empfohlene Pakete anzeigen."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Pakete anzeigen, die nicht benötigt werden."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Die Liste nach Paketname sortieren."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Die Liste nach Repository sortieren."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [Repository] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Alle verfügbaren Patches auflisten."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Alle verfügbaren Patches aus den festgelegten Repositorys auflisten."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [Optionen] [Repository] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Alle verfügbaren Schemata auflisten."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Alle verfügbaren Schemata aus den angegebenen Repositorys auflisten."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [Optionen] [Repository] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Alle verfügbaren Produkte auflisten."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Alle verfügbaren Produkte aus den angegebenen Repositorys auflisten."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Nur XML-Ausgabe: Wortwörtliche Weitergabe der gefundenen XML-Tags in einer "
 "Produktdatei."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "Option %1% hat ohne die globale Option %2% keinen Effekt."
@@ -3667,19 +3688,19 @@ msgstr ""
 "Der Repository-Typ wird stets automatisch erkannt. Diese Option wird "
 "ignoriert."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 "%s kann nicht zusammen mit %s verwendet werden. Die Einstellung %s wird "
 "verwendet."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
-"Wenn nur ein Argument verwendet wird, dann muss es sich um einen auf eine "
-".repo-Datei verweisenden URI handeln."
+"Wenn nur ein Argument verwendet wird, dann muss es sich um einen auf "
+"eine .repo-Datei verweisenden URI handeln."
 
 #: src/commands/repos/add.cc:130
 msgid "Specified type is not a valid repository type:"
@@ -3719,112 +3740,116 @@ msgstr "Rohmetadaten-Cache bereinigen."
 msgid "Clean both metadata and package caches."
 msgstr "Sowohl Metadaten-Cache als auch Paket-Cache bereinigen."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Aktiviert"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "GPG-Überprüfung"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Priorität"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Automatische Aktualisierung"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "An"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Aus"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Pakete beibehalten"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "GPG-Schlüssel-URI"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Pfad-Präfix"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "übergeordneter Dienst"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Schlüsselwörter"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Repo-Info-Pfad"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "MD-Cache-Pfad"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [Optionen] [Repository] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Auflistung aller definierten Repositorys."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 "Exportiert alle definierten Repositorys als eine einzelne lokale .repo-Datei."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Fehler beim Lesen von Repositorys:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "%s kann nicht zum Schreiben geöffnet werden."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Haben Sie eventuell keine Schreibberechtigung?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Repositorys wurden erfolgreich nach %s exportiert."
@@ -3832,20 +3857,20 @@ msgstr "Repositorys wurden erfolgreich nach %s exportiert."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Aktualisierung"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "Behalten"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Keine Repositorys definiert."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 "Mit dem Kommando 'zypper addrepo' können Sie ein oder mehrere Repositorys "
@@ -3955,7 +3980,7 @@ msgstr "Die globale Option '%s' hat hier keine Auswirkung."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Bei Verwendung von '%s' sind keine Argumente zulässig."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Angegebene Repositorys: "
 
@@ -3964,7 +3989,7 @@ msgstr "Angegebene Repositorys: "
 msgid "Refreshing repository '%s'."
 msgstr "Repository '%s' wird aktualisiert."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Inhalt des deaktivierten Repositorys '%s' wird durchsucht."
@@ -3974,7 +3999,7 @@ msgstr "Inhalt des deaktivierten Repositorys '%s' wird durchsucht."
 msgid "Skipping disabled repository '%s'"
 msgstr "Deaktiviertes Repository '%s' wird übersprungen"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Repository '%s' wird aufgrund des obigen Fehlers übersprungen."
@@ -4003,9 +4028,10 @@ msgstr ""
 
 #: src/commands/repos/refresh.cc:337
 msgid "Could not refresh the repositories because of errors."
-msgstr "Die Repositorys konnten aufgrund von Fehlern nicht aktualisiert werden."
+msgstr ""
+"Die Repositorys konnten aufgrund von Fehlern nicht aktualisiert werden."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 "Einige der Repositorys konnten aufgrund eines Fehlers nicht aktualisiert "
@@ -4064,14 +4090,14 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Repository '%s' wurde zu '%s' umbenannt."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 "Ein Repository namens '%s' ist bereits vorhanden. Verwenden Sie einen "
 "anderen Alias."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Fehler beim Bearbeiten des Repositorys:"
 
@@ -4372,7 +4398,8 @@ msgstr ""
 #. translators: --match-substrings
 #: src/commands/search/search.cc:105
 msgid "Search for a match to partial words (default)."
-msgstr "Suche nach Treffern, in denen die Suchzeichenfolge vorkommt (Standard)."
+msgstr ""
+"Suche nach Treffern, in denen die Suchzeichenfolge vorkommt (Standard)."
 
 #. translators: --match-words
 #: src/commands/search/search.cc:109
@@ -4541,27 +4568,27 @@ msgstr ""
 "Wie --details, mit zusätzlicher Angabe, wo die Übereinstimmung gefunden "
 "wurde (nützlich für Suchen mit Abhängigkeiten)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Das angegebene Repository '%s' ist deaktiviert."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Keine passenden Objekte gefunden."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 "Bei der Initialisierung oder Ausführung der Suchanfrage ist ein Problem "
 "aufgetreten"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "In der Meldung oben finden Sie einen entsprechenden Hinweis."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 "Das Problem kann möglicherweise durch Ausführen von 'zypper refresh' als "
@@ -4661,7 +4688,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Problem beim Abrufen der Repository-Indexdatei für Dienst '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Dienst '%s' wird aufgrund des obigen Fehlers übersprungen."
@@ -4682,24 +4709,28 @@ msgstr "Dienst '%s' wird entfernt:"
 msgid "Service '%s' has been removed."
 msgstr "Dienst '%s' wurde entfernt."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [Optionen]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Alle bestimmten Dienste auflisten."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Auflistung der definierten Dienste."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Keine Dienste definiert. Verwenden Sie das Kommando '%s', um mindestens "
 "einen Dienst hinzuzufügen."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5010,7 +5041,8 @@ msgstr "Abhängigkeitsauflösung erzwingen (selbst eine aggressive)."
 
 #: src/commands/solveroptionset.cc:63
 msgid "Do not force the solver to find a solution, let it ask."
-msgstr "Keine Abhängigkeitsauflösung erzwingen, Frage an den Benutzer zulassen."
+msgstr ""
+"Keine Abhängigkeitsauflösung erzwingen, Frage an den Benutzer zulassen."
 
 #: src/commands/solveroptionset.cc:64
 msgid "Set the solvers general attitude when resolving a job."
@@ -5087,7 +5119,8 @@ msgstr ""
 #. translators: -d, --build-deps-only
 #: src/commands/sourceinstall.cc:48
 msgid "Install only build dependencies of specified packages."
-msgstr "Installiert nur die Compilierungsabhängigkeiten der angegebenen Pakete."
+msgstr ""
+"Installiert nur die Compilierungsabhängigkeiten der angegebenen Pakete."
 
 #. translators: -D, --no-build-deps
 #: src/commands/sourceinstall.cc:52
@@ -5675,15 +5708,15 @@ msgstr "%s ist älter als %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Version"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arch"
 
@@ -5819,13 +5852,13 @@ msgstr "(leer)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Abhängigkeit"
 
@@ -5862,7 +5895,7 @@ msgid "Flavor"
 msgstr "Variante"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Ist Basis"
 
@@ -6130,57 +6163,57 @@ msgstr[1] "%1% Repositorys"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Es wird überprüft, ob die Metadaten für %s aktualisiert werden müssen"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Repository '%s' ist aktuell."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Die Aktualitätsüberprüfung von '%s' wurde verzögert."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Aktualisieren der Rohmetadaten erzwingen"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Metadaten von Repository '%s' abrufen"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Möchten Sie das Repository %s dauerhaft deaktivieren?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Fehler beim Deaktivieren des Repositorys '%s'."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Problem beim Abrufen der Dateien von '%s'."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "In der Fehlermeldung oben finden Sie einen entsprechenden Hinweis."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Keine URIs für '%s' definiert."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -6189,16 +6222,16 @@ msgstr ""
 "Fügen Sie eine oder mehrere Basis-URI(baseurl=URI)-Einträge zu %s für "
 "Repository '%s' hinzu."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Kein Alias für dieses Repository definiert."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Repository '%s' ist ungültig."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -6206,22 +6239,22 @@ msgstr ""
 "Überprüfen Sie, ob die für dieses Repository bestimmten URIs auf ein "
 "gültiges Repository verweisen."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Fehler beim Abrufen der Metadaten für '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Erstellen des Repository-Cache erzwingen"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Fehler beim Analysieren der Metadaten für '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6233,45 +6266,46 @@ msgstr ""
 "im Zweifel sind, erstellen Sie anhand der folgenden Anweisungen einen "
 "Fehlerbericht: http://de.opensuse.org/Zypper/Fehlersuche."
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Im lokalen Cache wurden keine Repository-Metadaten für '%s' gefunden."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Fehler bei der Erstellung des Cache:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 "Repository '%s' konnte anhand seines Alias, seiner Nummer oder URI nicht "
 "gefunden werden."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
-msgstr "Verwenden Sie '%s', um die Liste der definierten Repositorys abzurufen."
+msgstr ""
+"Verwenden Sie '%s', um die Liste der definierten Repositorys abzurufen."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Deaktiviertes Repository '%s' wird ignoriert"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "Die globale Option '%s 1' kann zur temporären Aktivierung von Repositorys "
 "verwendet werden."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Repository '%s' wird aufgrund der Option '%s' ignoriert."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Repository '%s' wird vorübergehend deaktiviert."
@@ -6279,7 +6313,7 @@ msgstr "Repository '%s' wird vorübergehend deaktiviert."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6288,7 +6322,7 @@ msgstr ""
 "Repository ‚%s‘ ist veraltet. Sie können 'zypper refresh' als root "
 "ausführen, um es zu aktualisieren."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6297,83 +6331,83 @@ msgstr ""
 "Der Metadaten-Cache muss für das Repository '%s' erstellt werden. Sie können "
 "dazu 'zypper refresh' als Root ausführen."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Repository '%s' bleibt weiterhin ungültig."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Ziel wird initialisiert"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Zielinitialisierung fehlgeschlagen:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Metadaten-Cache für '%s' wird bereinigt."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Rohmetadaten-Cache für '%s' wird bereinigt."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Rohmetadaten-Cache für %s '%s' wird beibehalten."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Pakete für '%s' werden bereinigt."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Repository '%s' kann aufgrund eines Fehlers nicht bereinigt werden."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Cache der installierten Pakete wird bereinigt."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 "Der Cache der installierten Pakete kann aufgrund eines Fehlers nicht "
 "bereinigt werden."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Die Repositorys konnten aufgrund von Fehlern nicht bereinigt werden."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Einige der Repositorys wurden aufgrund eines Fehlers nicht bereinigt."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Angegebene Repositorys wurden bereinigt."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Alle Repositorys wurden bereinigt."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Dies ist ein nicht beschreibbares Wechselmedium (CD/DVD). Automatische "
 "Aktualisierung wird deaktiviert."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Ungültiger Repository-Alias: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6381,25 +6415,25 @@ msgstr ""
 "Der Repository-Typ konnte nicht festgestellt werden. Überprüfen Sie, ob die "
 "definierten URIs (siehe unten) auf ein gültiges Repository verweisen:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Am angegebenen Speicherort wurde kein gültiges Repository gefunden:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Problem beim Übertragen der Repository-Daten von angegebenen URI:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Überprüfen Sie, ob auf den angegebenen URI zugegriffen werden kann."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Unbekanntes Problem beim Hinzufügen des Repositorys:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6409,144 +6443,144 @@ msgstr ""
 "deaktiviert. Die Integrität und Herkunft der Pakete kann nicht überprüft "
 "werden."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Repository '%s' erfolgreich hinzugefügt"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Daten werden von Medium '%s' gelesen"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Problem beim Lesen der Daten von Medium '%s'"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Überprüfen Sie, ob Ihr Installationsmedium gültig und lesbar ist."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 "Das Lesen von Daten von '%s'-Medien wird bis zur nächsten Aktualisierung "
 "verzögert."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Daten werden von Medium '%s' gelesen"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Problem beim Lesen der Daten von Medium '%s'"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Überprüfen Sie, ob Ihr Installationsmedium gültig und lesbar ist."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Problem beim Zugriff auf die Datei am angegebenen URI"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 "Überprüfen Sie, ob der URI gültig ist und auf ihn zugegriffen werden kann."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Problem beim Analysieren der Datei am angegebenen URI"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Ist es eine .repo-Datei?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 "Beim Versuch, die Datei am angegebenen URI zu lesen, ist ein Problem "
 "aufgetreten"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 "In der Datei wurde ein Repository ohne definierten Alias gefunden. Das "
 "Repository wird übersprungen."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 "Für Repository '%s' wurde kein URI definiert. Das Repository wird "
 "übersprungen."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Repository '%s' wurde entfernt."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Die Priorität von Repository '%s' wurde nicht verändert (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Repository '%s' wurde erfolgreich aktiviert."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Repository '%s' wurde erfolgreich deaktiviert."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Für Repository '%s' wurde die automatische Aktualisierung aktiviert."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Für Repository '%s' wurde die automatische Aktualisierung deaktiviert."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Für Repository '%s' wurde das Caching von RPM-Dateien aktiviert."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Für Repository '%s' wurde das Caching von RPM-Dateien deaktiviert."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Für Repository '%s' wurde die GPG-Prüfung aktiviert."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Für Repository '%s' wurde die GPG-Prüfung deaktiviert."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Die Priorität von Repository '%s' wurde auf %d festgelegt."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Name von Repository '%s' wurde auf '%s' festgelegt."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Für Repository '%s' müssen keine Änderungen vorgenommen werden."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Repository %s bleibt unverändert."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Repository-Daten werden geladen..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6554,49 +6588,49 @@ msgstr ""
 "Keine Repositorys definiert. Es werden nur die installierten auflösbaren "
 "Elemente verwendet. Keine Installation möglich."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Daten des Repositorys '%s' werden abgerufen..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 "Repository '%s' nicht im Cache gespeichert. Speichern im Cache wird "
 "ausgeführt..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Problem beim Laden der Daten von '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 "Repository '%s' konnte nicht aktualisiert werden. Der alte Cache wird "
 "verwendet."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 "Aufgrund eines Fehlers wurden die auflösbaren Elemente aus '%s' nicht "
 "geladen."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "Metadaten von Repository '%1%' seit %2% abgelaufen."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Versuchen Sie es vorher jedoch mit '%s' oder sogar mit '%s'."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6609,33 +6643,33 @@ msgstr ""
 "möglicherweise einen defekten Spiegel oder der Server hat die Unterstützung "
 "für das Repository eingestellt."
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Installierte Pakete werden gelesen..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Problem beim Lesen der installierten Pakete:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 "'%s' sieht wie eine RPM-Datei aus. Es wird versucht, sie herunterzuladen."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 "Problem mit der als '%s' angegebenen RPM-Datei. Die Datei wird übersprungen."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 "Problem beim Lesen des RPM-Headers von %s. Handelt es sich um eine RPM-Datei?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Einfacher Cache für RPM-Dateien"
 
@@ -6643,25 +6677,25 @@ msgstr "Einfacher Cache für RPM-Dateien"
 msgid "System Packages"
 msgstr "Systempakete"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Keine benötigten Patches gefunden."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Keine Schemata gefunden."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Keine Pakete gefunden."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Interner Name"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Keine Produkte gefunden."
 
@@ -6691,8 +6725,8 @@ msgstr "Detaillierte Informationen: "
 msgid "Choose the above solution using '1' or skip, retry or cancel"
 msgid_plural "Choose from above solutions by number or skip, retry or cancel"
 msgstr[0] ""
-"Wählen Sie die obige Lösung mittels '1' oder Sie (u)eberspringen, (w)"
-"iederholen oder brechen (a)b"
+"Wählen Sie die obige Lösung mittels '1' oder Sie (u)eberspringen, "
+"(w)iederholen oder brechen (a)b"
 msgstr[1] ""
 "Wählen Sie aus den obigen Lösungen mittels Nummer oder Sie (u)eberspringen, "
 "(w)iederholen oder brechen (a)b"
@@ -6703,7 +6737,8 @@ msgstr[1] ""
 msgid "Choose the above solution using '1' or cancel using 'c'"
 msgid_plural "Choose from above solutions by number or cancel"
 msgstr[0] "Wählen Sie die obige Lösung mittels '1' oder brechen Sie (a)b"
-msgstr[1] "Wählen Sie aus den obigen Lösungen mittels Nummer oder brechen Sie (a)b"
+msgstr[1] ""
+"Wählen Sie aus den obigen Lösungen mittels Nummer oder brechen Sie (a)b"
 
 #. translators: answers for dependency problem solution input prompt:
 #. "Choose from above solutions by number or skip, retry or cancel"
@@ -7071,7 +7106,7 @@ msgid "Updatestack"
 msgstr "Aktualisierungsstapel"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Patches"
 
@@ -7095,7 +7130,7 @@ msgid "Needed software management updates will be installed first:"
 msgstr ""
 "Benötigte Softwareverwaltungs-Aktualisierungen werden zuerst installiert:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Keine Aktualisierungen gefunden."
 
@@ -7104,48 +7139,48 @@ msgstr "Keine Aktualisierungen gefunden."
 msgid "The following updates are also available:"
 msgstr "Die folgenden Aktualisierungen sind außerdem verfügbar:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Paketaktualisierungen"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Muster-Aktualisierungen"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Produktaktualisierungen"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Aktuelle Version"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Verfügbare Version"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Keine übereinstimmenden Einträge gefunden."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Die folgenden Übereinstimmungen mit Eintragsnummern wurden gefunden:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 "Übereinstimmungen wurden in den Patch-Beschreibungen der folgenden Patches "
 "gefunden:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "Bereinigung für Bugzilla-Eintragsnummer %s wurde nicht gefunden oder ist "
 "nicht erforderlich."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
@@ -7153,7 +7188,7 @@ msgstr ""
 "erforderlich."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""
@@ -7353,7 +7388,8 @@ msgstr "Senden Sie einen Fehlerbericht zu diesem Problem."
 #. unless you translate the actual page :)
 #: src/utils/messages.cc:22
 msgid "See http://en.opensuse.org/Zypper/Troubleshooting for instructions."
-msgstr "Anweisungen finden Sie unter http://de.opensuse.org/Zypper/Fehlersuche."
+msgstr ""
+"Anweisungen finden Sie unter http://de.opensuse.org/Zypper/Fehlersuche."
 
 #: src/utils/messages.cc:38
 msgid "Too many arguments."

--- a/po/el.po
+++ b/po/el.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper.el\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Greek <https://l10n.opensuse.org/projects/zypper/master/el/>\n"
@@ -169,7 +169,8 @@ msgstr ""
 #. translators: --quiet, -q
 #: src/Config.cc:291
 msgid "Suppress normal output, print only error messages."
-msgstr "Απόκρυψη φυσιολογικών αποτελεσμάτων, εμφάνιση μόνο μηνυμάτων σφαλμάτων."
+msgstr ""
+"Απόκρυψη φυσιολογικών αποτελεσμάτων, εμφάνιση μόνο μηνυμάτων σφαλμάτων."
 
 #. translators: --verbose, -v
 #: src/Config.cc:299
@@ -1419,7 +1420,7 @@ msgstr "Το PackageKit εκτελείται ακόμα (πιθανόν είνα
 msgid "Try again?"
 msgstr "Δοκιμή ξανά;"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Μη αναμενόμενη εξαίρεση."
 
@@ -1446,17 +1447,17 @@ msgid ""
 "The link must point to your core products .prod file in /etc/products.d.\n"
 msgstr ""
 "Ο σύνδεσμος /etc/products.d/baseproduct ταλαντεύεται ή λείπει!\n"
-"Ο σύνδεσμος πρέπει να δείχνει στο αρχείο .prod των βασικών προϊόντων σας στο "
-"/etc/products.d.\n"
+"Ο σύνδεσμος πρέπει να δείχνει στο αρχείο .prod των βασικών προϊόντων σας "
+"στο /etc/products.d.\n"
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Η επιλογή %s δεν έχει κάποιο αποτέλεσμα εδώ, αγνόηση."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Παράμετροι προγράμματος που δεν είναι επιλογές: "
 
@@ -2195,17 +2196,17 @@ msgid "Commands:"
 msgstr "Εντολές:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Εμφάνιση της αναλυτικής περίληψης εγκατάστασης."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Τύπος πακέτου (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2213,8 +2214,14 @@ msgstr ""
 "Δοκιμάστε μια προσέγγιση 'best effort' για ενημέρωση. Επιτρέπονται επίσης "
 "ενημερώσεις σε πιο χαμηλή από την τρέχουσα έκδοση."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2287,7 +2294,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Εμφάνιση βοήθειας"
 
@@ -2480,22 +2487,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2548,49 +2555,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2692,11 +2703,11 @@ msgstr[1] "Αφαίρεση κλειδωμάτων %lu."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Όνομα"
 
@@ -2706,8 +2717,8 @@ msgstr ""
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Τύπος"
@@ -2715,7 +2726,7 @@ msgstr "Τύπος"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Αποθετήριο"
@@ -2871,24 +2882,21 @@ msgstr ""
 "                      ..$777777777777777777777777777777..$777777$7...\n"
 "                   .?77777777777777777777777777777777777777777777777$$+.\n"
 "               ..:$777777777777777777777777777777777777777777777777 ..I$$.\n"
-"             ..77777777777777777777777777777777777777777777777777..7$$I.7$.."
-"\n"
-"          . .$77777777777777777777777777777777777777777777777777..77...7.77."
-"\n"
-"        "
-"...$7777777777777777777777777777777777777777777777$77777.,7777$$.7$...\n"
-"        "
-".$7777777777777777777777777777777777777777777777777I77777.7777$.~77$..\n"
-"      "
-"..7777777777777777777777777777777777777777777777777777..777$.....77777..\n"
-"     ..77777777777777777777777777777777777777777777777777777$. "
-"..7777777777...\n"
-"     "
-".777777777777777777777777777777777777777777777777777777777$...........7..\n"
-"   "
-"..$777777777+~I7$7777777777777777777777777777777777777777777777$77:+7$777..\n"
-"   .$77777$.         .77777777777777777777777777777777777777777777777777$7.."
-"\n"
+"             ..77777777777777777777777777777777777777777777777777..7$"
+"$I.7$..\n"
+"          . ."
+"$77777777777777777777777777777777777777777777777777..77...7.77.\n"
+"        ...$7777777777777777777777777777777777777777777777$77777.,7777$"
+"$.7$...\n"
+"        ."
+"$7777777777777777777777777777777777777777777777777I77777.7777$.~77$..\n"
+"      ..7777777777777777777777777777777777777777777777777777..777$.....77777..\n"
+"     ..77777777777777777777777777777777777777777777777777777$. ..7777777777...\n"
+"     .777777777777777777777777777777777777777777777777777777777$...........7..\n"
+"   .."
+"$777777777+~I7$7777777777777777777777777777777777777777777777$77:+7$777..\n"
+"   .$77777$.         "
+".77777777777777777777777777777777777777777777777777$7..\n"
 "   77777$.  ...777.. ...77777777777777777777777777777$$777$77$777777$I.\n"
 "  .7777$....777777777~....77777777$77....777777777777= .. ...  . .  ..\n"
 " ..77777  .777777777777....7777777...   ... ?77777777..\n"
@@ -2898,23 +2906,22 @@ msgstr ""
 "   I777$7...7$7777.  7777.  ...77 .              ..777?.\n"
 "   .$77777........ .?7777      ...                   .$:\n"
 "     7777777.......$777$\n"
-"     .7$777777777777777.        ........  ....   . ..  ........  "
-"..............\n"
-"     ...77777777777777..       777$7$$7.  77..   .$7...?7$7$777  "
-".7$7$7$7$$.II.\n"
+"     .7$777777777777777.        ........  ....   . ..  ........  ..............\n"
+"     ...77777777777777..       777$7$$7.  77..   .$7...?7$7$777  .7$7$7$7$"
+"$.II.\n"
 "        ...77777777,...       $77777777. .77..   .77..77777777$  "
 ".777777777....\n"
-"            .......           77....... ..77..   .77..77.....    .77...... ."
-"\n"
+"            .......           77....... ..77..   .77..77.....    "
+".77...... .\n"
 ".7777..,7.77?...7777..7.?$$.  7$7$$$$7~...77..   .77..777$$$$7+...777$$$$?\n"
 "$....7.,7...7..7...,$ 7,...7...77777777$..77..   .77. .777777$77..7777777$\n"
 "7....7.,7   $..7777$7.$.  .7..       ,77..77.    .77.        .77 .77.\n"
-"$....$.,$...$..7......$.  .7...,,,,,,77$..777::::777...,,,,,,77$..77:,,,,,,."
-"\n"
-"I7777?.,$777$. 77777..7.  .7..$77777777.  .$77777$7...777777777  .77777777$"
-"7\n"
-".......,$...............  ..............  .....................  ..........."
-"\n"
+"$....$.,$...$..7......$.  "
+".7...,,,,,,77$..777::::777...,,,,,,77$..77:,,,,,,.\n"
+"I7777?.,$777$. 77777..7.  .7..$77777777.  .$77777$7...777777777  "
+".77777777$7\n"
+".......,"
+"$...............  ..............  .....................  ...........\n"
 "      .,7\n"
 "       ...\n"
 "                       ▓▓▓▓▒▒▒▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓\n"
@@ -3197,7 +3204,7 @@ msgid "Command"
 msgstr "Εντολή"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Υπηρεσία"
 
@@ -3367,120 +3374,120 @@ msgid "Show detailed information for products."
 msgstr "Εμφάνιση λεπτομερών πληροφοριών για τα προϊόντα."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Λίστα όλων των διαθέσιμων πακέτων."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Λίστα όλων των διαθέσιμων πακέτων στα ορισμένα αποθετήρια."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Εμφάνιση πακέτων που είναι προτεινόμενα."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Εμφάνιση πακέτων που είναι συνιστώμενα."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Εμφάνιση πακέτων που δεν χρειάζονται."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Ταξινόμηση της λίστας βάσει ονόματος πακέτου."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Ταξινόμηση λίστας ανά αποθετήριο."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Λίστα όλων των διαθέσιμων διορθώσεων."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Λίστα με όλες τις διαθέσιμες διορθώσεις στο καθορισμένο αποθετήριο."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Λίστα όλων των διαθέσιμων patterns."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Λίστα με όλα τα διαθέσιμα patterns στο καθορισμένο αποθετήριο."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Λίστα όλων των διαθέσιμων προϊόντων."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Λίστα με όλα τα διαθέσιμα προιόντα στο καθορισμένο αποθετήριο."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3519,14 +3526,14 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 "Το %s δεν μπορεί να χρησιμοποιηθεί μαζί με το %s. Χρησιμοποιώντας τις "
 "ρυθμίσεις του %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3572,112 +3579,116 @@ msgstr "Εκκαθάριση ακατέργαστης λανθάνουσας μ�
 msgid "Clean both metadata and package caches."
 msgstr "Εκκαθάριση λανθάνουσας μνήμης μεταδεδομένων και πακέτων."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Ψευδώνυμο"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Ενεργοποιημένο"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Έλεγχος GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Προτεραιότητα"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Αυτόματη ανανέωση"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Ενεργό"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Ανενεργό"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Διατήρηση Πακέτων"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI κλειδιού GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Πρόθεμα Διαδρομής"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Γονική υπηρεσία"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 #, fuzzy
 msgid "Repo Info Path"
 msgstr "Διαδρομή Πληροφοριών Αποθετηρίου"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Διαδρομή Λανθάνουσας Μνήμης MD"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Λίστα όλων των καθορισμένων αποθετηρίων."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "Εξαγωγή όλων των καθορισμένων αποθετηρίων σε απλό τοπικό αρχείο .repo."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Σφάλμα κατά την ανάγνωση των αποθετηρίων:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Αδυναμία ανοίγματος του '%s' για εγγραφή."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Μήπως δεν έχετε δικαιώματα εγγραφής;"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Τα αποθετήρια εξήχθησαν με επιτυχία στο %s."
@@ -3685,20 +3696,20 @@ msgstr "Τα αποθετήρια εξήχθησαν με επιτυχία στ�
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Ανανέωση"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Δεν ορίστηκαν αποθετήρια."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 "Χρησιμοποιήστε την εντολή 'zypper addrepo' για προσθήκη ενός ή περισσοτέρων "
@@ -3805,7 +3816,7 @@ msgstr "Η καθολική επιλογή '%s' δεν έχει αποτέλεσ
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Οι παράμετροι δεν επιτρέπονται εάν χρησιμοποιηθεί το '%s'."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Ορισμένα αποθετήρια: "
 
@@ -3814,7 +3825,7 @@ msgstr "Ορισμένα αποθετήρια: "
 msgid "Refreshing repository '%s'."
 msgstr "Απενεργοποίηση αποθετηρίου '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Σάρωση περιεχομένου του απενεργοποιημένου αποθετηρίου '%s'."
@@ -3824,7 +3835,7 @@ msgstr "Σάρωση περιεχομένου του απενεργοποιημ�
 msgid "Skipping disabled repository '%s'"
 msgstr "Παράβλεψη απενεργοποιημένου αποθετηρίου '%s'"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Παράβλεψη του αποθετηρίου '%s' λόγω του παραπάνω σφάλματος."
@@ -3854,7 +3865,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "Αδυναμία ανανέωσης αποθετηρίων λόγω σφαλμάτων."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Κάποια από τα αποθετήρια δεν ανανεώθηκαν λόγω ενός σφάλματος."
 
@@ -3910,14 +3921,14 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Το αποθετήριο '%s' μετονομάστηκε σε '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 "Το αποθετήριο με την ονομασία '%s' υπάρχει ήδη. Παρακαλώ χρησιμοποιήστε ένα "
 "άλλο ψευδώνυμο."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Σφάλμα κατά την τροποποίηση του αποθετηρίου:"
 
@@ -3944,7 +3955,8 @@ msgstr ""
 
 #: src/commands/repos/rename.cc:92
 msgid "Too few arguments. At least URI and alias are required."
-msgstr "Πολύ λίγες παράμετροι. Απαιτούνται τουλάχιστον το URI και το ψευδώνυμο."
+msgstr ""
+"Πολύ λίγες παράμετροι. Απαιτούνται τουλάχιστον το URI και το ψευδώνυμο."
 
 #: src/commands/repos/rename.cc:114
 #, c-format, boost-format
@@ -4350,30 +4362,31 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Το καθορισμένο αποθετήριο '%s' είναι απενεργοποιημένο."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "Δεν βρέθηκαν ζητήματα που να ταιριάζουν."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 "Προέκυψε πρόβλημα στην αρχικοποίηση ή την εκτέλεση του ερωτήματος της "
 "αναζήτησης"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Κοιτάξτε το παραπάνω μήνυμα για κάποια συμβουλή."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
-msgstr "Η εκτέλεση του 'zypper refresh' ως root μπορεί να επιλύσει το πρόβλημα."
+msgstr ""
+"Η εκτέλεση του 'zypper refresh' ως root μπορεί να επιλύσει το πρόβλημα."
 
 #. translators: -g, --category <CATEGORY>
 #: src/commands/selectpatchoptionset.cc:24
@@ -4463,7 +4476,7 @@ msgstr ""
 "υπηρεσία '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Παράβλεψη της υπηρεσίας '%s' λόγω του παραπάνω σφάλματος."
@@ -4482,24 +4495,28 @@ msgstr "Αφαίρεση της υπηρεσίας '%s':"
 msgid "Service '%s' has been removed."
 msgstr "Η υπηρεσία '%s' έχει αφαιρεθεί."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Λίστα όλων των ορισμένων υπηρεσιών."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Λίστα καθορισμένων υπηρεσιών."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Δεν έχουν οριστεί υπηρεσίες. Χρησιμοποιήστε την εντολή '%s' για να "
 "προσθέσετε μια ή περισσότερες υπηρεσίες."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5403,15 +5420,15 @@ msgstr "Το %s είναι παλαιότερο από το %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Έκδοση"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Αρχιτεκτονική"
 
@@ -5545,13 +5562,13 @@ msgstr "(άδειο)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "Κ"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Εξάρτηση"
 
@@ -5589,7 +5606,7 @@ msgid "Flavor"
 msgstr "Γεύση"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Είναι Βάση"
 
@@ -5855,75 +5872,75 @@ msgstr[1] "Αποθετήριο"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Έλεγχος για την ανάγκη ανανέωσης των μεταδεδομένων για %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Το αποθετήριο '%s' είναι ενημερωμένο."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Ο έλεγχος ενημέρωσης του '%s' καθυστέρησε."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Εξαναγκασμός ανανέωσης ακατέργαστων μεταδεδομένων"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Λήψη μεταδεδομένων αποθετηρίου '%s'"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Θέλετε να απενεργοποιήσετε μόνιμα το αποθετήριο %s;"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Σφάλμα απενεργοποίησης του αποθετηρίου '%s'."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Πρόβλημα κατά τη λήψη αρχείων από το %s."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Παρακαλώ δείτε το παραπάνω μήνυμα σφάλματος για κάποια υπόδειξη."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Δεν υπάρχουν ορισμένα URI για '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
-"Παρακαλώ προσθέστε ένα ή περισσότερα αναγνωριστικά URI (βασική τοποθεσία=URI)"
-" στο %s για το αποθετήριο '%s'."
+"Παρακαλώ προσθέστε ένα ή περισσότερα αναγνωριστικά URI (βασική "
+"τοποθεσία=URI) στο %s για το αποθετήριο '%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Δεν έχει οριστεί ψευδώνυμο για αυτό το αποθετήριο."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Το αποθετήριο '%s' δεν είναι έγκυρο."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -5931,22 +5948,22 @@ msgstr ""
 "Παρακαλώ ελέγξτε αν τα ορισμένα URI για αυτό το αποθετήριο οδηγούν σε ένα "
 "έγκυρο αποθετήριο."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Σφάλμα κατά τη λήψη των μεταδεδομένων για '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Εξαναγκασμός κατασκευής της λανθάνουσας μνήμης αποθετηρίου"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Σφάλμα ανάλυσης μεταδεδομένων για '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5958,47 +5975,47 @@ msgstr ""
 "υπάρχει αμφιβολία, παρακαλώ, υποβάλετε μια αναφορά σφάλματος ακολουθώντας "
 "τις οδηγίες στο http://en.opensuse.org/Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 "Τα μεταδεδομένα αποθετηρίου για το '%s' δεν βρέθηκαν στην τοπική λανθάνουσας "
 "μνήμη."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Σφάλμα κατά την κατασκευή της λανθάνουσας μνήμης:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 "Το αποθετήριο '%s' δεν βρέθηκε από το ψευδώνυμό του, τον αριθμό ή το URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 "Χρησιμοποιήστε το '%s' για να λάβετε τη λίστα με τα ορισμένα αποθετήρια."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Παράβλεψη απενεργοποιημένου αποθετηρίου '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, fuzzy, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "Χρησιμοποιήστε τις εντολές '%s' ή '%s' για να προσθέσετε ή να ενεργοποιήσετε "
 "αποθετήρια."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Παράβλεψη αποθετηρίου '%s' λόγω της '%s' επιλογής."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Προσωρινή ενεργοποίσηση αποθετηρίου '%s'."
@@ -6006,7 +6023,7 @@ msgstr "Προσωρινή ενεργοποίσηση αποθετηρίου '%s
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6015,7 +6032,7 @@ msgstr ""
 "Το αποθετήριο '%s' δεν είναι ενημερωμένο. Μπορείτε να εκτελέσετε 'zypper "
 "refresh' ως root για να το ενημερώσετε."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6024,85 +6041,85 @@ msgstr ""
 "Η λανθάνουσα μνήμη μεταδεδομένων πρέπει να κατασκευαστεί για το αποθετήριο "
 "'%s'. Για να το κάνετε αυτό, μπορείτε να εκτελέσετε 'zypper refresh' ως root."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Το αποθετήριο '%s' παραμένει απενεργοποιημένο."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Αρχικοποίηση Στόχου"
 
 # %s is either BOOTP or DHCP
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Αποτυχία αρχικοποίησης στόχου:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Εκκαθάριση μεταδεδομένων λανθάνουσας μνήμης για '%s'."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Εκκαθάριση ακατέργαστων μεταδεδομένων λανθάνουσας μνήμης για '%s'."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Διατήρηση ακατέργαστων μεταδεδομένων λανθάνουσας μνήμης για %s '%s'."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Εκκαθάριση πακέτων για '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Αδυναμία εκκαθάρισης αποθετηρίου '%s' λόγω ενός σφάλματος."
 
 #  progress stages
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Εκκαθάριση λανθάνουσας μνήμης εγκατεστημένων πακέτων."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 "Αδυναμία εκκαθάρισης λανθάνουσας μνήμης εγκατεστημένων πακέτων λόγω ενός "
 "σφάλματος."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Δεν ήταν δυνατή η εκκαθάριση των αποθετηρίων λόγω σφαλμάτων."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Κάποια από τα αποθετήρια δεν εκκαθαρίστηκαν λόγω ενός σφάλματος."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Τα ορισμένα αποθετήρια έχουν υποστεί εκκαθάριση."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Όλα τα αποθετήρια έχουν υποστεί εκκαθάριση."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Αυτό είναι ένα μεταβλητό μέσο (CD/DVD) μόνο-για-ανάγνωση, απενεργοποίηση της "
 "αυτόματης ανανέωσης."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Μη έγκυρο ψευδώνυμο αποθετηρίου: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6110,26 +6127,26 @@ msgstr ""
 "Αδυναμία ανίχνευσης του τύπου του αποθετηρίου. Παρακαλώ ελέγξτε αν τα "
 "ορισμένα URI (δείτε παρακάτω) οδηγούν σε ένα έγκυρο αποθετήριο:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 "Δεν ήταν δυνατή η εύρεση ενός έγκυρου αποθετηρίου στη δοσμένη τοποθεσία:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Πρόβλημα μεταφοράς δεδομένων αποθετηρίου από το καθορισμένο URI:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Παρακαλώ ελέγξτε αν το καθορισμένο URI είναι προσβάσιμο."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Άγνωστο πρόβλημα κατά την προσθήκη αποθετηρίου:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6138,142 +6155,142 @@ msgstr ""
 "Ο έλεγχος GPG είναι απενεργοποιημένος στη ρύθμιση παραμέτρων του αποθετηρίου "
 "'%1%'. Η ακεραιότητα και η προέλευση των πακέτων δεν μπορεί να επιβεβαιωθεί."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Το αποθετήριο '%s' προστέθηκε επιτυχώς"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Ανάγνωση δεδομένων από το μέσο '%s'"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Πρόβλημα ανάγνωσης δεδομένων από το μέσο '%s'"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-"Παρακαλώ ελέγξτε αν το μέσο της εγκατάστασής σας είναι έγκυρο και αναγνώσιμο."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 "Η ανάγνωση δεδομένων από το μέσο '%s' καθυστερείται μέχρι την επόμενη "
 "ανανέωση."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Ανάγνωση δεδομένων από το μέσο '%s'"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Πρόβλημα ανάγνωσης δεδομένων από το μέσο '%s'"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+"Παρακαλώ ελέγξτε αν το μέσο της εγκατάστασής σας είναι έγκυρο και αναγνώσιμο."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Πρόβλημα κατά την πρόσβαση του αρχείου στο καθορισμένο URI"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Παρακαλώ ελέγξτε αν το URI είναι έγκυρο και προσβάσιμο."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Πρόβλημα κατά την ανάλυση του αρχείου στο ορισμένο URI"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Είναι ένα αρχείο .repo;"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 "Εμφανίστηκε πρόβλημα κατά την προσπάθεια ανάγνωσης του αρχείου στο "
 "καθορισμένο URI"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Βρέθηκε αποθετήριο στο αρχείο χωρίς ορισμένο ψευδώνυμο, παράβλεψη."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Το αποθετήριο '%s' δεν έχει ορισμένο URI, παράβλεψη."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Το αποθετήριο '%s' έχει αφαιρεθεί."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Η προτεραιότητα του αποθετηρίου '%s' έχει μείνει αμετάβλητη (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Το αποθετήριο '%s' ενεργοποιήθηκε επιτυχώς."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Το αποθετήριο '%s' απενεργοποιήθηκε επιτυχώς."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Η αυτόματη ανανέωση έχει ενεργοποιηθεί για το αποθετήριο '%s'."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Η αυτόματη ανανέωση έχει απενεργοποιηθεί για το αποθετήριο '%s'."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 "Η τοπική αποθήκευση αρχείων RPM έχει ενεργοποιηθεί για το αποθετήριο '%s'."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 "Η τοπική αποθήκευση αρχείων RPM έχει απενεργοποιηθεί για το αποθετήριο '%s'."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Ο έλεγχος GPG έχει ενεργοποιηθεί για το αποθετήριο'%s'."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Ο έλεγχος GPG έχει απενεργοποιηθεί για το αποθετήριο '%s'."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Η προτεραιότητα του αποθετηρίου '%s' έχει οριστεί στο %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Η ονομασία του αποθετηρίου '%s' έχει οριστεί στο '%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Τίποτα προς αλλαγή στο αποθετήριο '%s'."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Το αποθετήριο %s μένει αμετάβλητο."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Φόρτωση δεδομένων αποθετηρίου..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6281,45 +6298,45 @@ msgstr ""
 "Δεν έχουν οριστεί αποθετήρια. Λειτουργία μόνο με τα εγκατεστημένα δεδομένα "
 "επιλύσεων. Τίποτα δεν μπορεί να εγκατασταθεί."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Λήψη δεδομένων αποθετηρίου '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Το αποθετήριο '%s' δεν είναι στην λανθάνουσα μνήμη. Αποθήκευση..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Πρόβλημα φόρτωσης δεδομένων από '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 "Το αποθετήριο '%s' δεν μπόρεσε να ενημερωθεί. Θα χρησιμοποιήσει την παλιά "
 "λανθάνουσα μνήμη."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Επιλύσεις από '%s' δεν φορτώνονται λόγω σφάλματος."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Δοκιμάστε '%s', ή καλύτερα '%s' πριν συνεχίσετε."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6328,30 +6345,30 @@ msgid ""
 msgstr ""
 
 #  progress stages
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Ανάγνωση εγκατεστημένων πακέτων..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Παρουσιάστηκε πρόβλημα κατά την ανάγνωση των εγκατεστημένων πακέτων:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "Το '%s' μοιάζει με αρχείο RPM. Θα γίνει προσπάθεια για λήψη."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Πρόβλημα με τον καθορισμό αρχείου RPM ως '%s', προσπέραση."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Πρόβλημα ανάγνωσης της επικεφαλίδας του RPM του %s. Είναι αρχείο RPM;"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Λανθάνουσα μνήμη απλών αρχείων RPM"
 
@@ -6359,25 +6376,25 @@ msgstr "Λανθάνουσα μνήμη απλών αρχείων RPM"
 msgid "System Packages"
 msgstr "Πακέτα Συστήματος"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Δε βρέθηκαν απαιτούμενες διορθώσεις."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Δεν βρέθηκαν patterns."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Δεν βρέθηκαν πακέτα."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Εσωτερικό Όνομα"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Δεν βρέθηκαν προϊόντα."
 
@@ -6783,7 +6800,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Διορθώσεις"
 
@@ -6808,7 +6825,7 @@ msgid "Needed software management updates will be installed first:"
 msgstr ""
 "Οι ακόλουθες ενημερώσεις διαχείρισης λογισμικού θα εγκατασταθούν πρώτες:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Δε βρέθηκαν ενημερώσεις."
 
@@ -6817,53 +6834,53 @@ msgstr "Δε βρέθηκαν ενημερώσεις."
 msgid "The following updates are also available:"
 msgstr "Οι ακόλουθες ενημερώσεις είναι επίσης διαθέσιμες:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Ενημερώσεις πακέτων"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Ενημερώσεις pattern"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Ενημερώσεις προϊόντος"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Τρέχουσα Έκδοση"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Διαθέσιμη Έκδοση"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Δεν βρέθηκαν ζητήματα που να ταιριάζουν."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Βρέθηκαν τα ακόλουθα ζητήματα σε αριθμούς:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 "Βρέθηκαν ταίρια στις περιγραφές των διορθώσεων στις ακόλουθες διορθώσεις:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "Διόρθωση στον bugzilla για το ζήτημα με νούμερο %s δεν βρέθηκε ή δε "
 "χρειάζεται."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "Διόρθωση για το ζήτημα CVE με νούμερο %s δεν βρέθηκε ή δε χρειάζεται."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: English (United Kingdom) <https://l10n.opensuse.org/projects/"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "Preparing installation..."
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Unexpected exception."
 
@@ -1403,12 +1403,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Non-option programme arguments: "
 
@@ -2128,24 +2128,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2215,7 +2221,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2401,22 +2407,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2467,49 +2473,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2613,11 +2623,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Name"
 
@@ -2628,8 +2638,8 @@ msgstr "Patches"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Type"
@@ -2637,7 +2647,7 @@ msgstr "Type"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Repository"
@@ -3072,7 +3082,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "ISDN service"
@@ -3237,120 +3247,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3390,12 +3400,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3439,116 +3449,120 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Enabled"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 #, fuzzy
 msgid "GPG Check"
 msgstr "DNS Check"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Autorefresh"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "On"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Off"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Keep Packages"
 msgstr "System area items"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 #, fuzzy
 msgid "Path Prefix"
 msgstr "Dial Prefix"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "Print Server"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Error reading repositories:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Cannot open file for writing."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 #, fuzzy
 msgid "Maybe you do not have write permissions?"
 msgstr "Can't open %s for writing. Maybe you don't have write permissions?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Repositories have been successfully exported to %s."
@@ -3556,21 +3570,21 @@ msgstr "Repositories have been successfully exported to %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Refresh"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "No repository found."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 #, fuzzy
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
@@ -3674,7 +3688,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 #, fuzzy
 msgid "Specified repositories: "
 msgstr "Specified repositories have been refreshed."
@@ -3684,7 +3698,7 @@ msgstr "Specified repositories have been refreshed."
 msgid "Refreshing repository '%s'."
 msgstr "Skipping disabled repository '%s'"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Skipping disabled repository '%s'"
@@ -3694,7 +3708,7 @@ msgstr "Skipping disabled repository '%s'"
 msgid "Skipping disabled repository '%s'"
 msgstr "Skipping disabled repository '%s'"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Skipping repository '%s' because of the above error."
@@ -3724,7 +3738,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "Could not refresh the repositories because of errors."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Some of the repositories have not been refreshed because of an error."
 
@@ -3777,12 +3791,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Repository %s renamed to %s"
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, fuzzy, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "Repository named '%s' already exists. Please, use another alias."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Error while modifying the repository:"
 
@@ -4216,27 +4230,27 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Autorefresh"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "No matches found"
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 #, fuzzy
 msgid "See the above message for a hint."
 msgstr "Please, see the above error message to for a hint."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4327,7 +4341,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Error reading repository description file for '%s'."
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, fuzzy, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Skipping repository '%s' because of the above error."
@@ -4347,24 +4361,28 @@ msgstr "Removing repository '%s'"
 msgid "Service '%s' has been removed."
 msgstr "Repository %s has been removed."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, fuzzy, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "No repositories defined. Use the 'zypper addrepo' command to add one or more "
 "repositories."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5257,15 +5275,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Version"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arch"
 
@@ -5402,13 +5420,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 #, fuzzy
 msgid "Dependency"
 msgstr "Dependencies"
@@ -5449,7 +5467,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5717,59 +5735,59 @@ msgstr[1] "Repository"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Checking whether to refresh metadata for %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Repository '%s' is up to date."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, fuzzy, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Repository %s has been removed."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Forcing raw metadata refresh"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Retrieving repository '%s' data..."
 
 # power-off message
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Do you want to halt the system now?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Skipping disabled repository '%s'"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, fuzzy, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Problem downloading files from '%s'."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 #, fuzzy
 msgid "Please see the above error message for a hint."
 msgstr "Please, see the above error message to for a hint."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, fuzzy, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "No URLs defined for '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, fuzzy, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -5778,17 +5796,17 @@ msgstr ""
 "Please, add one or more base URL (baseurl=URL) entries to %s for repository "
 "'%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 #, fuzzy
 msgid "No alias defined for this repository."
 msgstr "No alias defined this repository."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Repository '%s' is invalid."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 #, fuzzy
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
@@ -5797,22 +5815,22 @@ msgstr ""
 "Please, check if the URLs defined for this repository are pointing to a "
 "valid repository."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, fuzzy, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Error parsing metadata for '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Forcing building of repository cache"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Error parsing metadata for '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 #, fuzzy
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
@@ -5825,44 +5843,44 @@ msgstr ""
 "report by following instructions at http://en.opensuse.org/Zypper/"
 "Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Repository metadata for '%s' not found in local cache."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 #, fuzzy
 msgid "Error building the cache:"
 msgstr "Error building the cache database:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Repository '%s' not found by its alias or number."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, fuzzy, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Use 'zypper repos' to get the list of defined repositories."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Skipping disabled repository '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, fuzzy, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "Use 'zypper addrepo' or 'zypper modifyrepo' commands to add or enable "
 "repositories."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, fuzzy, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Disabling repository '%s' because of the above error."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Skipping disabled repository '%s'"
@@ -5870,7 +5888,7 @@ msgstr "Skipping disabled repository '%s'"
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -5879,7 +5897,7 @@ msgstr ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, fuzzy, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -5888,86 +5906,86 @@ msgstr ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Repository '%s' is invalid."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Initialising Target"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 #, fuzzy
 msgid "Target initialization failed:"
 msgstr "Initialisation failed"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, fuzzy, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Error parsing metadata for '%s':"
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, fuzzy, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Error parsing metadata for '%s':"
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, fuzzy, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Error parsing metadata for '%s':"
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, fuzzy, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Reading packages from %s"
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, fuzzy, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Disabling repository '%s' because of the above error."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 #, fuzzy
 msgid "Cleaning installed packages cache."
 msgstr "Reading installed packages"
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 #, fuzzy
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Disabling repository '%s' because of the above error."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 #, fuzzy
 msgid "Could not clean the repositories because of errors."
 msgstr "Could not refresh the repositories because of errors."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 #, fuzzy
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Some of the repositories have not been refreshed because of an error."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 #, fuzzy
 msgid "Specified repositories have been cleaned up."
 msgstr "Specified repositories have been refreshed."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 #, fuzzy
 msgid "All repositories have been cleaned up."
 msgstr "All repositories have been refreshed."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, fuzzy, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Skipping disabled repository '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 #, fuzzy
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
@@ -5976,169 +5994,169 @@ msgstr ""
 "Could not determine the type of the repository. Please, check if the defined "
 "URLs (see below) point to a valid repository:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Can't find a valid repository at given location:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 #, fuzzy
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Problem transferring repository data from specified URL:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 #, fuzzy
 msgid "Please check whether the specified URI is accessible."
 msgstr "Please, check whether the specified URL is accessible."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Unknown problem when adding repository:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Repository '%s' successfully added"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Reading data from '%s' media"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Problem reading data from '%s' media"
-
-#: src/repos.cc:1276
-#, fuzzy
-msgid "Please check if your installation media is valid and readable."
-msgstr "Please, check if your installation media is valid and readable."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, fuzzy, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Reading data from '%s' media"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Reading data from '%s' media"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Problem reading data from '%s' media"
+
+#: src/repos.cc:1274
+#, fuzzy
+msgid "Please check if your installation media is valid and readable."
+msgstr "Please, check if your installation media is valid and readable."
+
+#: src/repos.cc:1345
 #, fuzzy
 msgid "Problem accessing the file at the specified URI"
 msgstr "Problem transferring repository data from specified URL:"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 #, fuzzy
 msgid "Please check if the URI is valid and accessible."
 msgstr "Please, check whether the specified URL is accessible."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 #, fuzzy
 msgid "Problem parsing the file at the specified URI"
 msgstr "Problem transferring repository data from specified URL:"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 #, fuzzy
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Problem transferring repository data from specified URL:"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 #, fuzzy
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Repository '%s' not found."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Repository '%s' not found."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Repository %s has been removed."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Repository %s has been removed."
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Repository '%s' has been successfully enabled."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Repository '%s' has been successfully disabled."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, fuzzy, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Skipping disabled repository '%s'"
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Skipping disabled repository '%s'"
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Skipping disabled repository '%s'"
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Skipping disabled repository '%s'"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Skipping disabled repository '%s'"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Repository %s has been removed."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, fuzzy, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Repository %s has been removed."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, fuzzy, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Skipping disabled repository '%s'"
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Leaving repository %s unchanged."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 #, fuzzy
 msgid "Loading repository data..."
 msgstr "Retrieving repository '%s' data..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 #, fuzzy
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
@@ -6147,43 +6165,43 @@ msgstr ""
 "Warning: No repositories defined. Operating only with the installed "
 "resolvables. Nothing can be installed."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Retrieving repository '%s' data..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Repository '%s' not cached. Caching..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Problem loading data from '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "Repository metadata for '%s' not found in local cache."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Resolvables from '%s' not loaded because of error."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6191,32 +6209,32 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "Reading installed packages"
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "An error occurred while reading from the repository."
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6225,28 +6243,28 @@ msgstr ""
 msgid "System Packages"
 msgstr "System area items"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "No needed patches found."
 
-#: src/search.cc:342
+#: src/search.cc:344
 #, fuzzy
 msgid "No patterns found."
 msgstr "No updates found."
 
-#: src/search.cc:450
+#: src/search.cc:453
 #, fuzzy
 msgid "No packages found."
 msgstr "No updates found."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "Internal Error"
 
-#: src/search.cc:544
+#: src/search.cc:549
 #, fuzzy
 msgid "No products found."
 msgstr "No updates found."
@@ -6643,7 +6661,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Patches"
 
@@ -6667,7 +6685,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "The following packages will be installed:\n"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "No updates found."
 
@@ -6677,55 +6695,55 @@ msgstr "No updates found."
 msgid "The following updates are also available:"
 msgstr "New software updates are available."
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 #, fuzzy
 msgid "Pattern updates"
 msgstr "Battery Status"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr ""
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "Current Connection"
 
-#: src/update.cc:795
+#: src/update.cc:801
 #, fuzzy
 msgid "Available Version"
 msgstr "Available Memory"
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "No matches found"
 
-#: src/update.cc:978
+#: src/update.cc:986
 #, fuzzy
 msgid "The following matches in issue numbers have been found:"
 msgstr "The following packages will be updated:\n"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Esperanto <https://l10n.opensuse.org/projects/zypper/master/"
@@ -288,7 +288,8 @@ msgstr ""
 
 #: src/Config.cc:491
 msgid "Repositories disabled, using the database of installed packages only."
-msgstr "Deponejoj malebligitaj. Uzante nur la datumbazon de instalitaj pakaĵoj."
+msgstr ""
+"Deponejoj malebligitaj. Uzante nur la datumbazon de instalitaj pakaĵoj."
 
 #. translators: --disable-repositories
 #: src/Config.cc:495
@@ -1364,7 +1365,7 @@ msgstr ""
 msgid "Try again?"
 msgstr ""
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr ""
 
@@ -1392,12 +1393,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2077,24 +2078,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2164,7 +2171,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2345,22 +2352,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2411,49 +2418,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2554,11 +2565,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr ""
 
@@ -2568,8 +2579,8 @@ msgstr ""
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr ""
@@ -2577,7 +2588,7 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr ""
@@ -2991,7 +3002,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr ""
 
@@ -3151,120 +3162,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3303,12 +3314,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3350,111 +3361,115 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr ""
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr ""
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr ""
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr ""
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr ""
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr ""
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3462,20 +3477,20 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr ""
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr ""
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3576,7 +3591,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr ""
 
@@ -3585,7 +3600,7 @@ msgstr ""
 msgid "Refreshing repository '%s'."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr ""
@@ -3595,7 +3610,7 @@ msgstr ""
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3622,7 +3637,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3675,12 +3690,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr ""
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr ""
 
@@ -4106,25 +4121,25 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr ""
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr ""
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4214,7 +4229,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr ""
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4233,21 +4248,25 @@ msgstr ""
 msgid "Service '%s' has been removed."
 msgstr ""
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5117,15 +5136,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr ""
 
@@ -5259,13 +5278,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr ""
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -5302,7 +5321,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5556,94 +5575,94 @@ msgstr[1] ""
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr ""
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr ""
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr ""
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr ""
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr ""
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr ""
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr ""
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr ""
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr ""
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr ""
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5651,41 +5670,41 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr ""
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr ""
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr ""
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr ""
@@ -5693,294 +5712,294 @@ msgstr ""
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr ""
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr ""
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr ""
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr ""
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr ""
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr ""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr ""
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr ""
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr ""
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr ""
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr ""
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr ""
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr ""
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr ""
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr ""
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr ""
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -5988,30 +6007,30 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr ""
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr ""
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6019,25 +6038,25 @@ msgstr ""
 msgid "System Packages"
 msgstr ""
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr ""
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr ""
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr ""
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr ""
 
@@ -6408,7 +6427,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr ""
 
@@ -6431,7 +6450,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr ""
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr ""
 
@@ -6440,50 +6459,50 @@ msgstr ""
 msgid "The following updates are also available:"
 msgstr ""
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr ""
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr ""
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr ""
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr ""
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr ""
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -17,11 +17,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-08-03 17:59+0000\n"
 "Last-Translator: Antonio Simón <antonio@trans-mission.com>\n"
-"Language-Team: Spanish <https://l10n.opensuse.org/projects/zypper/master/es/>"
-"\n"
+"Language-Team: Spanish <https://l10n.opensuse.org/projects/zypper/master/es/"
+">\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -235,8 +235,8 @@ msgstr "Omitir paquetes desconocidos."
 msgid ""
 "Terse output for machine consumption. Implies --no-abbrev and --no-color."
 msgstr ""
-"Salida simplificada para procesamiento automático. Implica --no-abbrev y "
-"--no-color."
+"Salida simplificada para procesamiento automático. Implica --no-abbrev y --"
+"no-color."
 
 #. translators: --reposd-dir, -D <DIR>
 #: src/Config.cc:397
@@ -892,7 +892,8 @@ msgstr[1] "Se van a reinstalar las siguientes %d aplicaciones:"
 msgid "The following recommended package was automatically selected:"
 msgid_plural ""
 "The following %d recommended packages were automatically selected:"
-msgstr[0] "Se ha seleccionado automáticamente el siguiente paquete recomendado:"
+msgstr[0] ""
+"Se ha seleccionado automáticamente el siguiente paquete recomendado:"
 msgstr[1] ""
 "Se han seleccionado automáticamente los siguientes %d paquetes recomendados:"
 
@@ -919,7 +920,8 @@ msgstr[1] ""
 msgid "The following recommended product was automatically selected:"
 msgid_plural ""
 "The following %d recommended products were automatically selected:"
-msgstr[0] "Se ha seleccionado automáticamente el siguiente producto recomendado:"
+msgstr[0] ""
+"Se ha seleccionado automáticamente el siguiente producto recomendado:"
 msgstr[1] ""
 "Se han seleccionado automáticamente los siguientes %d productos recomendados:"
 
@@ -995,7 +997,8 @@ msgid "The following patch is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d patches are recommended, but will not be installed:"
 msgstr[0] "Se recomienda el siguiente parche, sin embargo no se instalará:"
-msgstr[1] "Se recomiendan los siguientes %d parches, los cuales no se instalarán:"
+msgstr[1] ""
+"Se recomiendan los siguientes %d parches, los cuales no se instalarán:"
 
 #: src/Summary.cc:1186
 #, c-format, boost-format
@@ -1003,7 +1006,8 @@ msgid "The following pattern is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d patterns are recommended, but will not be installed:"
 msgstr[0] "Se recomienda el siguiente patrón, sin embargo no se instalará:"
-msgstr[1] "Se recomiendan los siguientes %d patrones, los cuales no se instalarán:"
+msgstr[1] ""
+"Se recomiendan los siguientes %d patrones, los cuales no se instalarán:"
 
 #: src/Summary.cc:1190
 #, c-format, boost-format
@@ -1029,7 +1033,8 @@ msgid "The following package is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d packages are suggested, but will not be installed:"
 msgstr[0] "Se sugiere el siguiente paquete, sin embargo no se instalará:"
-msgstr[1] "Se sugieren los siguientes %d paquetes, los cuales no se instalarán:"
+msgstr[1] ""
+"Se sugieren los siguientes %d paquetes, los cuales no se instalarán:"
 
 #: src/Summary.cc:1233
 #, c-format, boost-format
@@ -1045,7 +1050,8 @@ msgid "The following pattern is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d patterns are suggested, but will not be installed:"
 msgstr[0] "Se sugiere el siguiente paquete, sin embargo no se instalará:"
-msgstr[1] "Se sugieren los siguientes %d paquetes, los cuales no se instalarán:"
+msgstr[1] ""
+"Se sugieren los siguientes %d paquetes, los cuales no se instalarán:"
 
 #: src/Summary.cc:1243
 #, c-format, boost-format
@@ -1053,7 +1059,8 @@ msgid "The following product is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d products are suggested, but will not be installed:"
 msgstr[0] "Se sugiere el siguiente producto, sin embargo no se instalará:"
-msgstr[1] "Se sugieren los siguientes %d productos, los cuales no se instalarán:"
+msgstr[1] ""
+"Se sugieren los siguientes %d productos, los cuales no se instalarán:"
 
 #: src/Summary.cc:1249
 #, c-format, boost-format
@@ -1223,7 +1230,8 @@ msgstr[1] "NO se instalarán las siguientes %d actualizaciones de aplicaciones:"
 msgid "The following item is locked and will not be changed by any action:"
 msgid_plural ""
 "The following %d items are locked and will not be changed by any action:"
-msgstr[0] "El elemento siguiente está bloqueado y no cambiará con ninguna acción:"
+msgstr[0] ""
+"El elemento siguiente está bloqueado y no cambiará con ninguna acción:"
 msgstr[1] ""
 "Los %d elementos siguientes están bloqueados y no cambiarán con ninguna "
 "acción:"
@@ -1471,7 +1479,7 @@ msgstr "PackageKit aún se encuentra en ejecución (probablemente ocupado)."
 msgid "Try again?"
 msgstr "¿Desea volver a intentarlo?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Excepción inesperada."
 
@@ -1502,12 +1510,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "La opción %s carece de efecto aquí. Se va a ignorar."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Argumentos de programa que no son opciones: "
 
@@ -1793,8 +1801,8 @@ msgid_plural "Received %1% new package signing keys from repository \"%2%\":"
 msgstr[0] ""
 "Se recibió la nueva clave de firma de paquete %1% del repositorio \"%2%\":"
 msgstr[1] ""
-"Se recibieron las nuevas claves de firma de paquete %1% del repositorio "
-"\"%2%\":"
+"Se recibieron las nuevas claves de firma de paquete %1% del repositorio \"%2%"
+"\":"
 
 #: src/callbacks/keyring.h:472
 msgid ""
@@ -1948,7 +1956,8 @@ msgstr "a/r/i/u/s"
 
 #: src/callbacks/media.cc:79
 msgid "Disable SSL certificate authority check and continue."
-msgstr "Inhabilitar comprobación de la autoridad certificadora SSL y continuar."
+msgstr ""
+"Inhabilitar comprobación de la autoridad certificadora SSL y continuar."
 
 #. translators: this is a prompt text
 #: src/callbacks/media.cc:82 src/callbacks/media.cc:174
@@ -2264,17 +2273,17 @@ msgid "Commands:"
 msgstr "Comandos:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Muestra el resumen de instalación detallado."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Tipo de paquete (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2282,11 +2291,17 @@ msgstr ""
 "Adopta un enfoque de esfuerzo mayor en la actualización. También se permiten "
 "actualizaciones a una versión inferior a la última."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr ""
 "Tenga en cuenta solo los parches que afectan a la gestión del paquete en sí "
 "misma."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2369,7 +2384,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <subcomando> [--opciones-de-comando] [argumentos]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Muestra la ayuda"
 
@@ -2577,8 +2592,8 @@ msgstr ""
 "con todas sus funciones que incluye el modificador para eliminar (-) "
 "aplicado a sus argumentos básicos. Es decir, \"removeptf foo\" es igual que "
 "\"install -- -foo\". Por eso el comando acepta las mismas opciones que el "
-"comando de instalación. Es la forma recomendada de eliminar una PTF ("
-"solución temporal de programa)."
+"comando de instalación. Es la forma recomendada de eliminar una PTF "
+"(solución temporal de programa)."
 
 #: src/commands/installremove.cc:317
 msgid ""
@@ -2596,22 +2611,22 @@ msgstr ""
 "actualizadas oficiales."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [opciones]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Muestra los parches disponibles."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Muestra todos los parches aplicables."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Muestra todos los parches, no solo los aplicables."
 
@@ -2670,39 +2685,43 @@ msgstr ""
 "llame a %s."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [OPCIONES] [REGIONAL] …"
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Muestra las configuraciones regionales pedidas (códigos de idioma)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 "Muestra las configuraciones regionales pedidas y sus paquetes "
 "correspondientes."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Muestra los paquetes correspondientes."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Muestra todas las configuraciones regionales disponibles."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
-"Ignora los argumentos de posición porque se ha proporcionado el argumento "
-"--all."
+"Ignora los argumentos de posición porque se ha proporcionado el argumento --"
+"all."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "Las configuraciones regionales cuya información se debe imprimir."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2710,18 +2729,18 @@ msgstr ""
 "Obtiene todas las configuraciones regionales con el codigo de idioma \"en\" "
 "que tienen su propio código de país, excluyendo el último recurso \"en\":"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 "Obtiene todas las configuraciones regionales con el código de idioma \"en\" "
 "con código de país o sin él:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 "Obtiene la configuración regional que coincide exactamente con el argumento: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 "Obtiene la lista de paquetes que están disponibles para \"de\" y \"en\":"
@@ -2841,11 +2860,11 @@ msgstr[1] "Eliminados %lu bloqueos."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Nombre"
 
@@ -2855,8 +2874,8 @@ msgstr "Coincidencias"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Tipo"
@@ -2864,7 +2883,7 @@ msgstr "Tipo"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Repositorio"
@@ -3332,7 +3351,7 @@ msgid "Command"
 msgstr "Comando"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Servicio"
 
@@ -3507,23 +3526,23 @@ msgid "Show detailed information for products."
 msgstr "Muestra información detallada de los productos."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [opciones] [repositorio]..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Enumera todos los paquetes disponibles."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 "Muestra todos los paquetes disponibles en los repositorios especificados."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
@@ -3531,20 +3550,20 @@ msgstr ""
 "automáticamente."
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 "Muestra los paquetes instalados que el usuario ha seleccionado expresamente."
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 "Muestra los paquetes instalados que no son proporcionados por ningún "
 "repositorio."
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
@@ -3553,86 +3572,86 @@ msgstr ""
 "candidato de actualización)."
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Muestra los paquetes sugeridos."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Muestra los paquetes recomendados."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Muestra los paquetes que no se necesitan."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Ordena la lista por nombre de paquete."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Ordena la lista por repositorio."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [REPOSITORIO] …"
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Enumera todos los parches disponibles."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Enumera los parches disponibles en los repositorios especificados."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [OPCIONES] [REPOSITORIO] …"
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Enumera todos los patrones disponibles."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 "Enumera todos los patrones disponibles en los repositorios especificados."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [OPCIONES] [REPOSITORIO] …"
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Enumera todos los productos disponibles."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 "Muestra todos los productos disponibles en los repositorios especificados."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Solo salida XML: remisión literal de las etiquetas XML encontradas en un "
 "archivo de producto."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "La opción %1% no tiene ningún efecto sin la opción global %2%."
@@ -3675,13 +3694,13 @@ msgstr ""
 "El tipo de repositorio se detecta siempre automáticamente. Esta opción se "
 "ignora."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 "No se puede usar %s con %s. Se va a utilizar el valor de configuración %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3727,111 +3746,115 @@ msgstr "Vacía el caché de metadatos en bruto."
 msgid "Clean both metadata and package caches."
 msgstr "Vacía tanto el caché de paquetes como el de metadatos."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Habilitado"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Comprobación GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Prioridad"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Actualización automática"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Activado"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Desactivado"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Conservar paquetes"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI de clave GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Prefijo de la vía"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Servicio padre"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Palabras clave"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Vía de información del repositorio"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Vía de caché MD"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [opciones] [repo]..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Enumera todos los repositorios definidos."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "Exporta todos los repositorios a un único archivo .repo local."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Error al leer los repositorios:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "No es posible abrir %s para la escritura."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "¿Es posible que no tenga permisos de escritura?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Se han exportado correctamente los repositorios a %s."
@@ -3839,20 +3862,20 @@ msgstr "Se han exportado correctamente los repositorios a %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Recargar"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "Mantener"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "No hay repositorios definidos."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr "Use el comando zypper addrepo para añadir uno o varios repositorios."
 
@@ -3960,7 +3983,7 @@ msgstr "La opción global '%s' no tiene efecto aquí."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "No se permiten argumentos cuando se utiliza '%s'."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Repositorios especificados: "
 
@@ -3969,7 +3992,7 @@ msgstr "Repositorios especificados: "
 msgid "Refreshing repository '%s'."
 msgstr "Se está actualizando el repositorio '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Se está explorando el contenido del repositorio inhabilitado '%s'."
@@ -3979,7 +4002,7 @@ msgstr "Se está explorando el contenido del repositorio inhabilitado '%s'."
 msgid "Skipping disabled repository '%s'"
 msgstr "Se va a omitir el repositorio inhabilitado '%s'"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Se va a omitir el repositorio '%s' debido al error anterior."
@@ -4007,7 +4030,7 @@ msgstr "Utilice los comandos '%s' o '%s' para añadir o habilitar repositorios."
 msgid "Could not refresh the repositories because of errors."
 msgstr "No es posible actualizar los repositorios debido a errores."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Algunos de los repositorios no se han actualizado debido a un error."
 
@@ -4062,12 +4085,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Se ha renombrado el repositorio '%s' a '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "Ya existe un repositorio con el nombre '%s'. Utilice otro alias."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Error al modificar el repositorio:"
 
@@ -4536,25 +4559,25 @@ msgstr ""
 "Como --details, con información adicional sobre los resultados de la "
 "búsqueda (útil para buscar en dependencias)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "El repositorio especificado (%s) está inhabilitado."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "No se encuentran elementos que coincidan."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Problema sucedido al inicializar o ejecutar la solicitud de búsqueda"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Consulte el mensaje anterior para una sugerencia."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 "Ejecutar 'zypper refresh' como usuario root puede solucionar el problema."
@@ -4652,7 +4675,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Problema al obtener el índice del repositorio para el servicio '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Se va a omitir el servicio '%s' debido al error anterior."
@@ -4671,24 +4694,28 @@ msgstr "Eliminando el servicio '%s':"
 msgid "Service '%s' has been removed."
 msgstr "Se ha eliminado el servicio '%s'."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [opciones]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Mostrar todos los servicios definidos."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Muestra los servicios definidos."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "No hay servicios definidos. Utilice el comando '%s' para añadir uno o más "
 "servicios."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5239,7 +5266,8 @@ msgstr "El intérprete Zypper no admite la ejecución de subcomandos."
 #: src/commands/subcommand.cc:640
 #, boost-format
 msgid "Subcommand %1% does not support zypper global options."
-msgstr "El subcomando %1% no es compatible con las opciones globales de zypper."
+msgstr ""
+"El subcomando %1% no es compatible con las opciones globales de zypper."
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/update.cc:22
@@ -5660,15 +5688,15 @@ msgstr "%s es más antiguo que %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Versión"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arquitectura"
 
@@ -5806,13 +5834,13 @@ msgstr "(vacío)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "E"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Dependencia"
 
@@ -5852,7 +5880,7 @@ msgid "Flavor"
 msgstr "Versión"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Es la base"
 
@@ -6117,57 +6145,57 @@ msgstr[1] "%1% repositorios"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Comprobando si es necesario actualizar los metadatos para %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "El repositorio '%s' está actualizado."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "La comprobación de actualización del repositorio '%s' se ha pospuesto."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Forzando actualización de metadatos en bruto"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Obteniendo los metadatos del repositorio '%s'"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "¿Desea inhabilitar el repositorio %s permanentemente?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Error al inhabilitar el repositorio '%s'."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Error al obtener los archivos de '%s'."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Consulte el mensaje de error anterior para obtener sugerencias."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "No hay ningún URI definido para '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -6176,16 +6204,16 @@ msgstr ""
 "Añada una o más entradas URI base (baseurl=URI) a %s para el repositorio "
 "'%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "No hay ningún alias definido para este repositorio."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "El repositorio '%s' no es válido."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -6193,22 +6221,22 @@ msgstr ""
 "Compruebe si los URI definidos para este repositorio apuntan a un "
 "repositorio válido."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Error al obtener los metadatos para '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Se está forzando la construcción del caché del repositorio"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Error al analizar los metadatos para '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6220,44 +6248,44 @@ msgstr ""
 "duda, abra un informe de errores siguiendo las instrucciones de http://"
 "en.opensuse.org/Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 "No se encuentran los metadatos del repositorio para '%s' en el caché local."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Error al generar el caché:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "No se ha encontrado el repositorio '%s' por su alias, número o URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Utilice '%s' para obtener la lista de los repositorios definidos."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Se va a ignorar el repositorio inhabilitado '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "La opción global '%s' se puede usar para habilitar temporalmente los "
 "repositorios."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Se va a ignorar el repositorio '%s' debido a la opción '%s'."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Se está habilitando temporalmente el repositorio '%s'."
@@ -6265,7 +6293,7 @@ msgstr "Se está habilitando temporalmente el repositorio '%s'."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6274,7 +6302,7 @@ msgstr ""
 "El repositorio '%s' no está actualizado. Puede ejecutar 'zypper refresh' "
 "como usuario root para actualizarlo."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6283,81 +6311,82 @@ msgstr ""
 "Es necesario construir el caché de metadatos para el repositorio '%s'. Puede "
 "ejecutar 'zypper refresh' como usuario root para hacerlo."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "El repositorio '%s' permanece inhabilitado."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Inicializando destino"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Error al inicializar el destino:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Borrando el caché de metadatos para '%s'."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Borrando el caché de metadatos en bruto para '%s'."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Conservando el caché de metadatos en bruto para %s '%s'."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Borrando paquetes de '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "No es posible borrar el repositorio '%s' debido a un error."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Borrando el caché de paquetes instalados."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
-msgstr "No es posible borrar el caché de paquetes instalados debido a un error."
+msgstr ""
+"No es posible borrar el caché de paquetes instalados debido a un error."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "No es posible borrar los repositorios debido a errores."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Algunos de los repositorios no se han borrado debido a un error."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Los repositorios especificados se han borrado."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Todos los repositorios se han borrado."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Soporte modificable de sólo lectura (CD/DVD), que desactiva la función de "
 "actualización automática."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Alias de repositorio no válido: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6365,25 +6394,26 @@ msgstr ""
 "No es posible determinar el tipo de repositorio. Compruebe si los URI "
 "definidos (ver más abajo) apuntan a un repositorio válido:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "No se encuentra un repositorio válido en la ubicación proporcionada:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
-msgstr "Problema al transferir datos del repositorio desde el URI especificado:"
+msgstr ""
+"Problema al transferir datos del repositorio desde el URI especificado:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Compruebe si es posible acceder al URI especificado."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Se ha producido un error desconocido al añadir el repositorio:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6392,143 +6422,143 @@ msgstr ""
 "La comprobación GPG está inhabilitada en la configuración del repositorio "
 "'%1%'. No es posible verificar la integridad ni el origen de los paquetes."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "El repositorio '%s' se ha añadido correctamente"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Leyendo datos desde el medio '%s'"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Problema al leer los datos desde el medio '%s'"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Compruebe si el medio de instalación es válido y se puede leer."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 "Se ha retrasado la lectura de datos de '%s' hasta la próxima actualización."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Leyendo datos desde el medio '%s'"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Problema al leer los datos desde el medio '%s'"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Compruebe si el medio de instalación es válido y se puede leer."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Problema al acceder al archivo en el URI especificado"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Compruebe si el URI es válido y se puede acceder a él."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Problema al analizar el archivo en el URI especificado"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "¿Se trata de un archivo .repo?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Problema al intentar leer el archivo en el URI especificado"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 "Se ha encontrado en el archivo un repositorio sin alias definido. Se va a "
 "omitir."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "El repositorio '%s' no tiene ningún URI definido. Se va a omitir."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Se ha eliminado el repositorio '%s'."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "La prioridad del repositorio '%s' se ha dejado sin cambios (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Se ha habilitado correctamente el repositorio '%s'."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Se ha inhabilitado correctamente el repositorio '%s'."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "La actualización automática se ha habilitado para el repositorio '%s'."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 "La actualización automática se ha inhabilitado para el repositorio '%s'."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 "Se ha habilitado el almacenamiento en caché de los archivos RPM para el "
 "repositorio '%s'."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 "Se ha inhabilitado el almacenamiento en caché de los archivos RPM para el "
 "repositorio '%s'."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Se ha habilitado la comprobación GPG para el repositorio '%s'."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Se ha inhabilitado la comprobación GPG para el repositorio '%s'."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "La prioridad del repositorio '%s' se ha definido como %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "El nombre del repositorio '%s' se ha definido como '%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "No hay cambios que realizar en el repositorio '%s'."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "El repositorio %s se va a mantener sin cambios."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Cargando datos del repositorio..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6536,45 +6566,45 @@ msgstr ""
 "No hay repositorios definidos. Se trabajará solo con las resoluciones "
 "instaladas. No se puede instalar nada."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Obteniendo los datos del repositorio '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Repositorio '%s' sin almacenar en caché. Almacenando en caché..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Problema al cargar los datos desde '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 "No es posible actualizar el repositorio '%s'. Se utilizará el caché "
 "existente."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "No se han cargado las resoluciones de '%s' debido a un error."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "Los metadatos del repositorio %1% caducaron el %2%."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Pruebe con '%s', o incluso con '%s', antes de hacerlo."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6582,36 +6612,36 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 "Los metadatos del repositorio han caducado. Compruebe si autorefresh está "
-"activado (zypper lr). Si no lo está, actualice manualmente el repositorio ("
-"zypper ref). Si esto no resuelve el problema, podría deberse a que usa una "
+"activado (zypper lr). Si no lo está, actualice manualmente el repositorio "
+"(zypper ref). Si esto no resuelve el problema, podría deberse a que usa una "
 "réplica rota o a que el servidor haya dejado de mantener el repositorio."
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Leyendo los paquetes instalados..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Se ha producido un problema al leer los paquetes instalados:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' parece un archivo RPM. Se intentará descargarlo."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Problema con el archivo RPM especificado como '%s'. Se va a omitir."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 "Problema al leer la cabecera RPM de %s. Compruebe que se trata de un archivo "
 "RPM."
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Caché de archivos RPM sencillo"
 
@@ -6619,25 +6649,25 @@ msgstr "Caché de archivos RPM sencillo"
 msgid "System Packages"
 msgstr "Paquetes del sistema"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "No se encuentran los parches necesarios."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "No se han encontrado patrones."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "No se encuentra ningún paquete."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Nombre interno"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "No se han encontrado productos."
 
@@ -7045,7 +7075,7 @@ msgid "Updatestack"
 msgstr "Pila de actualización"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Parches"
 
@@ -7069,7 +7099,7 @@ msgid "Needed software management updates will be installed first:"
 msgstr ""
 "Primero se instalarán las actualizaciones de gestión de software necesarias:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "No se ha encontrado ninguna actualización."
 
@@ -7078,49 +7108,49 @@ msgstr "No se ha encontrado ninguna actualización."
 msgid "The following updates are also available:"
 msgstr "Las siguientes actualizaciones también están disponibles:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Actualizaciones de paquetes"
 
 # menuentries/menuentry_security.ycp:37
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Actualizaciones de patrones"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Actualizaciones del producto"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Versión actual"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Versión disponible"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "No se encuentran problemas que coincidan."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Se han encontrado las siguientes coincidencias por número de problema:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 "Se han encontrado coincidencias en las descripciones de los siguientes "
 "parches:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "No se ha encontrado una solución para el problema de bugzilla número %s o "
 "puede que no sea necesaria."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
@@ -7128,7 +7158,7 @@ msgstr ""
 "que no sea necesaria."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""
@@ -7166,7 +7196,8 @@ msgstr "El archivo de configuración %1% no existe."
 #: src/utils/Augeas.cc:635
 #, boost-format
 msgid "%1%: Option '%2%' is defined multiple times. Using the last one."
-msgstr "%1%: la opción %2% se ha definido varias veces. Se va a usar la última."
+msgstr ""
+"%1%: la opción %2% se ha definido varias veces. Se va a usar la última."
 
 #: src/utils/Augeas.cc:656
 msgid "No config file is in use."
@@ -7651,8 +7682,8 @@ msgid ""
 "If nothing else works enter '#1' to select the 1st option, '#2' for the 2nd "
 "one, ..."
 msgstr ""
-"Si no funciona nada más, introduzca #1 para seleccionar la primera opción, #"
-"2 para la segunda, etc."
+"Si no funciona nada más, introduzca #1 para seleccionar la primera opción, "
+"#2 para la segunda, etc."
 
 #. TranslatorExplanation These are reasons for various failures.
 #: src/utils/prompt.h:95

--- a/po/et.po
+++ b/po/et.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper.et\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Estonian <https://l10n.opensuse.org/projects/zypper/master/et/"
@@ -1372,7 +1372,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "Paigaldamise ettevalmistamine..."
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Ootamatu erand."
 
@@ -1400,12 +1400,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -1425,8 +1425,8 @@ msgid ""
 "system compromise."
 msgstr ""
 "Andmete allkirjastamine võimaldab vastuvõtjal kontrollida, kas pärast "
-"andmete allkirjastamist muudatusi ei ole toimunud. Andmete vastuvõtmine ilma-"
-", vale- või tundmatu allkirjaga võib põhjustada süsteemi riknemise ja "
+"andmete allkirjastamist muudatusi ei ole toimunud. Andmete vastuvõtmine "
+"ilma-, vale- või tundmatu allkirjaga võib põhjustada süsteemi riknemise ja "
 "äärmuslikel juhtudel isegi süsteemi ohtu sattumise."
 
 #. translator: %1% is a file name
@@ -2151,24 +2151,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2238,7 +2244,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2424,22 +2430,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2490,49 +2496,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2636,11 +2646,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Nimi"
 
@@ -2651,8 +2661,8 @@ msgstr "Paigad"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Tüüp"
@@ -2660,7 +2670,7 @@ msgstr "Tüüp"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Hoidla"
@@ -3088,7 +3098,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "Server"
@@ -3253,120 +3263,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3408,12 +3418,12 @@ msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 "Tundmatu hoidla tüüp '%s'. Selle asemel kasutatakse tuvastatud tüüpi '%s'."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3455,115 +3465,119 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Lubatud"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 #, fuzzy
 msgid "GPG Check"
 msgstr "DNS kontroll"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 #, fuzzy
 msgid "Autorefresh"
 msgstr "Värskenda"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Sees"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Väljas"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Keep Packages"
 msgstr "Süsteemi ala elemendid"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "Printserver"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Viga hoidlate lugemisel:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Faili avamine kirjutamiseks nurjus."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, fuzzy, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Hoidla %s muutmine õnnestus."
@@ -3571,21 +3585,21 @@ msgstr "Hoidla %s muutmine õnnestus."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Värskenda"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "Värskenda"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 #, fuzzy
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
@@ -3689,7 +3703,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 #, fuzzy
 msgid "Specified repositories: "
 msgstr "Kõiki hoidlaid värskendati."
@@ -3699,7 +3713,7 @@ msgstr "Kõiki hoidlaid värskendati."
 msgid "Refreshing repository '%s'."
 msgstr "Hoidla '%s' lisamine."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Keelatud hoidla '%s' jäetakse vahele"
@@ -3709,7 +3723,7 @@ msgstr "Keelatud hoidla '%s' jäetakse vahele"
 msgid "Skipping disabled repository '%s'"
 msgstr "Keelatud hoidla '%s' jäetakse vahele"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Hoidla '%s' jäetakse ülaltoodud vea tõttu vahele."
@@ -3739,7 +3753,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "Hoidlate värskendamine nurjus tekkinud vigade tõttu."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 #, fuzzy
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Mõni hoidlatest jäi tekkinud vigade tõttu värskendamata."
@@ -3794,12 +3808,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Hoidla %s nimetati ümber hoidlaks %s"
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Viga hoidla muutmisel:"
 
@@ -4232,27 +4246,27 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Värskenda"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "Vasteid ei leitud"
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 #, fuzzy
 msgid "See the above message for a hint."
 msgstr "Kuvab seda teadet ja väljub."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4343,7 +4357,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Viga hoidla '%s' lugemisel:"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, fuzzy, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Hoidla '%s' jäetakse ülaltoodud vea tõttu vahele."
@@ -4362,24 +4376,28 @@ msgstr "Eemaldamine: %s-%s"
 msgid "Service '%s' has been removed."
 msgstr "Hoidla %s on eemaldatud."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, fuzzy, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Hoidlat pole määratud. Kasuta ühe või mitme hoidla lisamiseks käsku 'zypper "
 "addrepo'."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5271,15 +5289,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Versioon"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arh."
 
@@ -5416,13 +5434,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 #, fuzzy
 msgid "Dependency"
 msgstr "Sõltuvused"
@@ -5462,7 +5480,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5730,98 +5748,98 @@ msgstr[1] "Hoidla"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Hoidlat %s ei leitud."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, fuzzy, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Hoidla %s on eemaldatud."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 #, fuzzy
 msgid "Forcing raw metadata refresh"
 msgstr "aptrpm metaandmete parsimine nurjus: "
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Hoidla %s lugemine..."
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Soovid sa tõesti seda asukohta kasutada?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Hoidla '%s' lisamine."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, fuzzy, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Probleem andmete laadimisel asukohast '%s'"
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 #, fuzzy
 msgid "Please see the above error message for a hint."
 msgstr "Kuvab seda teadet ja väljub."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, fuzzy, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Viga hoidla muutmisel:"
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 #, fuzzy
 msgid "No alias defined for this repository."
 msgstr "Viga hoidla muutmisel:"
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Hoidlat %s ei leitud."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, fuzzy, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Viga hoidla '%s' lugemisel:"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 #, fuzzy
 msgid "Forcing building of repository cache"
 msgstr "Hoidla puhvri loomine..."
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, fuzzy, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Viga hoidla '%s' lugemisel:"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5829,44 +5847,44 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, fuzzy, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Hoidlat %s ei leitud."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 #, fuzzy
 msgid "Error building the cache:"
 msgstr "Viga sertifikaadi töötlemisel."
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Hoidlat %s ei leitud."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Keelatud hoidla '%s' jäetakse vahele"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, fuzzy, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "Hoidlat pole määratud. Kasuta ühe või mitme hoidla lisamiseks käsku 'zypper "
 "addrepo'."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, fuzzy, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Hoidla '%s' jäetakse ülaltoodud vea tõttu vahele."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Hoidla '%s' lisamine."
@@ -5874,266 +5892,266 @@ msgstr "Hoidla '%s' lisamine."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Hoidlat %s ei leitud."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Sihtmärgi lähtestamine"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 #, fuzzy
 msgid "Target initialization failed:"
 msgstr "Initsialiseerimine nurjus"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, fuzzy, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Viga hoidla '%s' lugemisel:"
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, fuzzy, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Viga hoidla '%s' lugemisel:"
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, fuzzy, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Viga hoidla '%s' lugemisel:"
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, fuzzy, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Hoidla '%s' jäetakse ülaltoodud vea tõttu vahele."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 #, fuzzy
 msgid "Cleaning installed packages cache."
 msgstr "Paigaldatud pakettide lugemine"
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 #, fuzzy
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Hoidla '%s' jäetakse ülaltoodud vea tõttu vahele."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 #, fuzzy
 msgid "Could not clean the repositories because of errors."
 msgstr "Hoidlate värskendamine nurjus tekkinud vigade tõttu."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 #, fuzzy
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Mõni hoidlatest jäi tekkinud vigade tõttu värskendamata."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 #, fuzzy
 msgid "Specified repositories have been cleaned up."
 msgstr "Kõiki hoidlaid värskendati."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 #, fuzzy
 msgid "All repositories have been cleaned up."
 msgstr "Kõiki hoidlaid värskendati."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, fuzzy, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Hoidla '%s' lisamine."
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 #, fuzzy
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Probleem hoidla andmete hankimisel antud URL-ilt."
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 #, fuzzy
 msgid "Unknown problem when adding repository:"
 msgstr "Probleem hoidla andmete parsimisel."
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Hoidla '%s' lisamine õnnestus:"
 
-#: src/repos.cc:1269
-#, fuzzy, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Probleem andmete laadimisel asukohast '%s'"
-
-#: src/repos.cc:1275
-#, fuzzy, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Probleem andmete laadimisel asukohast '%s'"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, fuzzy, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Probleem andmete laadimisel asukohast '%s'"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, fuzzy, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Probleem andmete laadimisel asukohast '%s'"
+
+#: src/repos.cc:1273
+#, fuzzy, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Probleem andmete laadimisel asukohast '%s'"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 #, fuzzy
 msgid "Problem accessing the file at the specified URI"
 msgstr "Probleem hoidla andmete hankimisel antud URL-ilt."
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 #, fuzzy
 msgid "Problem parsing the file at the specified URI"
 msgstr "Probleem hoidla andmete hankimisel antud URL-ilt."
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 #, fuzzy
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Probleem hoidla andmete hankimisel antud URL-ilt."
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 #, fuzzy
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Hoidlat %s ei leitud."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Hoidlat %s ei leitud."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Hoidla %s on eemaldatud."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Hoidla %s on eemaldatud."
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Hoidla %s muutmine õnnestus."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Hoidla %s muutmine õnnestus."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, fuzzy, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Keelatud hoidla '%s' jäetakse vahele"
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Keelatud hoidla '%s' jäetakse vahele"
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Keelatud hoidla '%s' jäetakse vahele"
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Keelatud hoidla '%s' jäetakse vahele"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Keelatud hoidla '%s' jäetakse vahele"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Hoidla %s on eemaldatud."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, fuzzy, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Hoidla %s on eemaldatud."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, fuzzy, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Hoidla '%s' lisamine."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Hoidla %s jäetakse muutmata."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 #, fuzzy
 msgid "Loading repository data..."
 msgstr "Hoidla %s lugemine..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 #, fuzzy
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
@@ -6142,43 +6160,43 @@ msgstr ""
 "Hoiatus: hoidlaid ei leitud. Kasutada saab ainult paigaldatud lahendajaid. "
 "Midagi ei saa paigaldada."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Hoidla %s lugemine..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Hoidla '%s' pole puhverdatud. Puhverdamine..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Probleem andmete laadimisel asukohast '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "Hoidlat %s ei leitud."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6186,32 +6204,32 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "Paigaldatud pakettide lugemine"
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Paigaldatud pakettide lugemine"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6220,28 +6238,28 @@ msgstr ""
 msgid "System Packages"
 msgstr "Süsteemi ala elemendid"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Ühtki vajalikku paika ei leitud."
 
-#: src/search.cc:342
+#: src/search.cc:344
 #, fuzzy
 msgid "No patterns found."
 msgstr "Ühtki uuendust ei leitud."
 
-#: src/search.cc:450
+#: src/search.cc:453
 #, fuzzy
 msgid "No packages found."
 msgstr "Ühtki uuendust ei leitud."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "Sisemine viga"
 
-#: src/search.cc:544
+#: src/search.cc:549
 #, fuzzy
 msgid "No products found."
 msgstr "Ühtki uuendust ei leitud."
@@ -6642,7 +6660,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Paigad"
 
@@ -6666,7 +6684,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "Paigaldatakse järgnevad paketid:\n"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Ühtki uuendust ei leitud."
 
@@ -6676,56 +6694,56 @@ msgstr "Ühtki uuendust ei leitud."
 msgid "The following updates are also available:"
 msgstr "Paigaldatakse järgnevad paketid:\n"
 
-#: src/update.cc:700
+#: src/update.cc:707
 #, fuzzy
 msgid "Package updates"
 msgstr "Uuenduste kontrollimine:"
 
-#: src/update.cc:704
+#: src/update.cc:711
 #, fuzzy
 msgid "Pattern updates"
 msgstr "Aku olek"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr ""
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "Praegune ühendus"
 
-#: src/update.cc:795
+#: src/update.cc:801
 #, fuzzy
 msgid "Available Version"
 msgstr "Saadaolevad uuendused"
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "Vasteid ei leitud"
 
-#: src/update.cc:978
+#: src/update.cc:986
 #, fuzzy
 msgid "The following matches in issue numbers have been found:"
 msgstr "Alla laaditakse järgnevad paketid:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1351,7 +1351,7 @@ msgstr ""
 msgid "Try again?"
 msgstr ""
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr ""
 
@@ -1379,12 +1379,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2064,24 +2064,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2151,7 +2157,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2332,22 +2338,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2398,49 +2404,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2541,11 +2551,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr ""
 
@@ -2555,8 +2565,8 @@ msgstr ""
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr ""
@@ -2564,7 +2574,7 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr ""
@@ -2978,7 +2988,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr ""
 
@@ -3138,120 +3148,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3290,12 +3300,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3337,111 +3347,115 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr ""
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr ""
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr ""
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr ""
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr ""
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr ""
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3449,20 +3463,20 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr ""
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr ""
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3563,7 +3577,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr ""
 
@@ -3572,7 +3586,7 @@ msgstr ""
 msgid "Refreshing repository '%s'."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr ""
@@ -3582,7 +3596,7 @@ msgstr ""
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3609,7 +3623,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3662,12 +3676,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr ""
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr ""
 
@@ -4093,25 +4107,25 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr ""
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr ""
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4201,7 +4215,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr ""
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4220,21 +4234,25 @@ msgstr ""
 msgid "Service '%s' has been removed."
 msgstr ""
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5104,15 +5122,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr ""
 
@@ -5246,13 +5264,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr ""
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -5289,7 +5307,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5543,94 +5561,94 @@ msgstr[1] ""
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr ""
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr ""
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr ""
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr ""
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr ""
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr ""
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr ""
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr ""
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr ""
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr ""
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5638,41 +5656,41 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr ""
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr ""
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr ""
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr ""
@@ -5680,294 +5698,294 @@ msgstr ""
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr ""
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr ""
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr ""
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr ""
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr ""
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr ""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr ""
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr ""
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr ""
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr ""
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr ""
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr ""
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr ""
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr ""
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr ""
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr ""
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -5975,30 +5993,30 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr ""
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr ""
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6006,25 +6024,25 @@ msgstr ""
 msgid "System Packages"
 msgstr ""
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr ""
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr ""
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr ""
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr ""
 
@@ -6395,7 +6413,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr ""
 
@@ -6418,7 +6436,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr ""
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr ""
 
@@ -6427,50 +6445,50 @@ msgstr ""
 msgid "The following updates are also available:"
 msgstr ""
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr ""
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr ""
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr ""
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr ""
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr ""
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -22,11 +22,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper.fi\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Finnish <https://l10n.opensuse.org/projects/zypper/master/fi/>"
-"\n"
+"Language-Team: Finnish <https://l10n.opensuse.org/projects/zypper/master/fi/"
+">\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -237,8 +237,8 @@ msgstr "Sivuuta tuntemattomat paketit."
 msgid ""
 "Terse output for machine consumption. Implies --no-abbrev and --no-color."
 msgstr ""
-"Niukka tuloste ohjelmalliseen käyttöön. Asettaa valitsimet --no-abbrev ja "
-"--no-color."
+"Niukka tuloste ohjelmalliseen käyttöön. Asettaa valitsimet --no-abbrev ja --"
+"no-color."
 
 #. translators: --reposd-dir, -D <DIR>
 #: src/Config.cc:397
@@ -304,8 +304,8 @@ msgid ""
 "Additionally use disabled repositories providing a specific keyword. Try '--"
 "plus-content debug' to enable repos indicating to provide debug packages."
 msgstr ""
-"Käytä myös käytöstä poistettuja avainsanan tarjoavia asennuslähteitä. "
-"”--plus-content debug” ottaa käyttöön myös vianpaikannusasennuslähteet."
+"Käytä myös käytöstä poistettuja avainsanan tarjoavia asennuslähteitä. ”--"
+"plus-content debug” ottaa käyttöön myös vianpaikannusasennuslähteet."
 
 #: src/Config.cc:491
 msgid "Repositories disabled, using the database of installed packages only."
@@ -891,7 +891,8 @@ msgid "The following recommended pattern was automatically selected:"
 msgid_plural ""
 "The following %d recommended patterns were automatically selected:"
 msgstr[0] "Seuraava suositeltu ohjelmistoryhmä valittiin automaattisesti:"
-msgstr[1] "Seuraavat %d suositeltua ohjelmistoryhmää valittiin automaattisesti:"
+msgstr[1] ""
+"Seuraavat %d suositeltua ohjelmistoryhmää valittiin automaattisesti:"
 
 #: src/Summary.cc:1089
 #, c-format, boost-format
@@ -907,7 +908,8 @@ msgid "The following recommended source package was automatically selected:"
 msgid_plural ""
 "The following %d recommended source packages were automatically selected:"
 msgstr[0] "Seuraava suositeltu lähdekoodipaketti valittiin automaattisesti:"
-msgstr[1] "Seuraavat %d suositeltua lähdekoodipakettia valittiin automaattisesti:"
+msgstr[1] ""
+"Seuraavat %d suositeltua lähdekoodipakettia valittiin automaattisesti:"
 
 #: src/Summary.cc:1100
 #, c-format, boost-format
@@ -993,7 +995,8 @@ msgid "The following application is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d applications are recommended, but will not be installed:"
 msgstr[0] "Seuraavaa ohjelmistoa suositellaan, mutta sitä ei asenneta:"
-msgstr[1] "Seuraavat %d ohjelmistoa ovat suositeltuja, mutta niitä ei asenneta:"
+msgstr[1] ""
+"Seuraavat %d ohjelmistoa ovat suositeltuja, mutta niitä ei asenneta:"
 
 #: src/Summary.cc:1228
 #, c-format, boost-format
@@ -1144,7 +1147,8 @@ msgid ""
 msgid_plural ""
 "The following %d packages were discontinued and have been superseded by a "
 "new packages with different names."
-msgstr[0] "Seuraava paketti on hylätty ja korvattu erinimisellä uudella paketilla."
+msgstr[0] ""
+"Seuraava paketti on hylätty ja korvattu erinimisellä uudella paketilla."
 msgstr[1] ""
 "Seuraavat %d pakettia on hylätty ja korvattu erinimisillä uusilla paketeilla."
 
@@ -1189,7 +1193,8 @@ msgid "The following item is locked and will not be changed by any action:"
 msgid_plural ""
 "The following %d items are locked and will not be changed by any action:"
 msgstr[0] "Seuraava kohde on lukittu, eikä sitä muuteta millään toimella:"
-msgstr[1] "Seuraavat %d kohteet on lukittu, eikä niitä muuteta millään toimella:"
+msgstr[1] ""
+"Seuraavat %d kohteet on lukittu, eikä niitä muuteta millään toimella:"
 
 #. always as plain name list
 #. translators: used as 'tag:' (i.e. followed by ':')
@@ -1212,7 +1217,8 @@ msgstr "Näet kaikki lukitut kohteet suorittamalla ”%1“."
 #, c-format, boost-format
 msgid "The following patch requires a system reboot:"
 msgid_plural "The following %d patches require a system reboot:"
-msgstr[0] "Seuraava korjauspäivitys vaatii käynnistämään järjestelmän uudelleen:"
+msgstr[0] ""
+"Seuraava korjauspäivitys vaatii käynnistämään järjestelmän uudelleen:"
 msgstr[1] ""
 "Seuraavat %d korjauspäivitystä vaativat käynnistämään järjestelmän uudelleen:"
 
@@ -1221,7 +1227,8 @@ msgstr[1] ""
 msgid "The following package requires a system reboot:"
 msgid_plural "The following %d packages require a system reboot:"
 msgstr[0] "Seuraava paketti vaatii käynnistämään järjestelmän uudelleen:"
-msgstr[1] "Seuraavat %d pakettia vaativat käynnistämään järjestelmän uudelleen:"
+msgstr[1] ""
+"Seuraavat %d pakettia vaativat käynnistämään järjestelmän uudelleen:"
 
 #: src/Summary.cc:1563
 msgid "Skipped needed patches which do not apply without conflict:"
@@ -1386,7 +1393,8 @@ msgstr ""
 #: src/Summary.cc:1824
 #, boost-format
 msgid "%1% is set, otherwise a system reboot would be required."
-msgstr "%1% on asetettu, muuten vaadittaisiin järjestelmän uudelleenkäynnistys."
+msgstr ""
+"%1% on asetettu, muuten vaadittaisiin järjestelmän uudelleenkäynnistys."
 
 #: src/Summary.cc:1826
 msgid "System reboot required."
@@ -1432,7 +1440,7 @@ msgstr "PackageKit on yhä toiminnassa (todennäköisesti kiireinen)."
 msgid "Try again?"
 msgstr "Yritetäänkö uudelleen?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Odottamaton poikkeus."
 
@@ -1463,12 +1471,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Valinta %s ei vaikuta täällä. Jätetään huomioimatta."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Pakolliset ohjelman parametrit: "
 
@@ -2224,25 +2232,31 @@ msgid "Commands:"
 msgstr "Valinnat:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Näyttää yksityiskohtaisen yhteenvedon asennuksesta."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Tyyppi (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr "Mahdollistaa pakettien päivittämisen myös vanhempaan versioon."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "Ota huomioon vain itse paketinhallintaan vaikuttavat korjaukset."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2318,7 +2332,7 @@ msgstr "zypper [--yleisvalinnat] <komento> [--komennon-valinnat] [parametrit]"
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <alikomento> [--komennon-valinnat] [parametrit]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Tulostaa ohjeen"
 
@@ -2514,8 +2528,8 @@ msgstr ""
 "poistamisen sijaan. Itse asiassa tämä on täysi asennuskomento, jossa "
 "raakaparametreihin sovelletaan poistomuunninta (-). ”removeptf foo” on näin "
 "sama kuin ”install -- -foo”, mistä syystä komento myös hyväksyy samat "
-"parametrit kuin asennuskomento. Tämä on suositeltu tapa poistaa PTF ("
-"ohjelman väliaikainen korjaus)."
+"parametrit kuin asennuskomento. Tämä on suositeltu tapa poistaa PTF "
+"(ohjelman väliaikainen korjaus)."
 
 #: src/commands/installremove.cc:317
 msgid ""
@@ -2532,22 +2546,22 @@ msgstr ""
 "virallisilla päivitysversioillaan."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [VALINNAT]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Luettelo saatavilla olevista korjauksista."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Luettele kaikki saatavilla olevat korjaukset."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Luettele kaikki korjaukset, ei voi saatavilla olevia."
 
@@ -2602,35 +2616,39 @@ msgstr ""
 "asetuksista komennolla \"%s”."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [VALINNAT] [MAA-ASETUS]…"
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Luettele pyydetyt maa-asetukset (kielikoodit)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Luettele pyydetyt maa-asetukset vastaavine paketteineen."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Näytä vastaavat paketit."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Luettelo kaikki saatavilla olevat maa-asetukset."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr "Ohitetaan sijaintiin perustuvat parametrit, koska --all on annettu."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "Maa-asetukset, joiden tiedot näytetään."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2638,15 +2656,15 @@ msgstr ""
 "Nouda kaikki kielikoodin ”en” maa-asetukset, joilla on oma maakoodi, paitsi "
 "oletusarvoa ”en”:"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr "Nouda kaikki kielikoodin ”en” maa-asetukset maakoodilla tai ilman:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "Nouda täsmälleen parametria vastaava maa-asetus: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 "Nouda ”de”- ja ”en”-kielikoodeille käytettävissä olevien pakettien luettelo:"
@@ -2757,11 +2775,11 @@ msgstr[1] "Poistettiin %lu lukkoa."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Nimi"
 
@@ -2771,8 +2789,8 @@ msgstr "Osumat"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Tyyppi"
@@ -2780,7 +2798,7 @@ msgstr "Tyyppi"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Asennuslähde"
@@ -3242,7 +3260,7 @@ msgid "Command"
 msgstr "Komento"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Palvelu"
 
@@ -3412,38 +3430,38 @@ msgid "Show detailed information for products."
 msgstr "Näyttää tuotteen yksityiskohtaiset tiedot."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [valinnat] [asennuslähde] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Näytää luettelon paketeista."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Tulostaa luettelon haluttujen asennuslähteiden paketeista."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr "Näytä ratkaisimen automaattisesti valitsemat asennetut paketit."
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr "Näytä käyttäjän eksplisiittisesti valitsemat asennetut paketit."
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr "Näytä asennetut paketit, joita mikään asennuslähde ei tarjoa."
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
@@ -3452,83 +3470,83 @@ msgstr ""
 "järjestelmäpaketit."
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Näyttää ehdotetut paketit."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Näyttää suositellut paketit."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Näyttää paketit joita ei enää tarvita."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Järjestä luettelo paketin nimen mukaan."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Järjestä luettelo asennuslähteen mukaan."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [asennuslähde] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Näytää luettelon korjauspäivityksistä."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Listaa saatavilla olevat korjauspäivitykset."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [valinnat] [asennuslähde] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Näytää luettelon ohjelmistoryhmistä."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Listaa asennuslähteen tarjoamat ohjelmistoryhmät."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [valinnat] [asennuslähde] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Näytää luettelon tuotteista."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Listaa tuotteet asennuslähteestä."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Vain XML-tuloste: välitä sellaisinaan tuotetiedostossa olevat XML-tunnisteet."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "Valinnalla %1% ei ole vaikutusta ilman yleisvalintaa %2%."
@@ -3570,12 +3588,12 @@ msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 "Asennuslähteen tyyppi tunnistetaan aina automaattisesti. Valitsin ohitetaan."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "Valintaa %s ei voida käyttää samanaikaisesti %s kanssa. Käytetään %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3620,16 +3638,16 @@ msgstr "Puhdistaa raakametatietojen välimuistin."
 msgid "Clean both metadata and package caches."
 msgstr "Puhdistaa sekä metatieto- että pakettivälimuistit."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
@@ -3637,95 +3655,99 @@ msgstr "URI"
 # kpowersave.cpp: tooltip
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Käytössä"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "GPG-tarkistus"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Tärkeysjärjestys"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Automaattinen päivitys"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Käytössä"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Pois käytöstä"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Pidä paketit"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "GPG-avaimen verkko-osoite"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Polun etuliite"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Kantapalvelu"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Hakusanat"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Asennuslähteen tietojen polku"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "MD-välimuistin sijainti"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [valinnat] [repo] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Listaa järjestelmän asennuslähteet."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "Tallenna kaikki asennuslähteet yksittäiseen .repo-tiedostoon."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Virhe luettaessa asennuslähteitä:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Tiedostoa %s ei voida avata kirjoitusta varten."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Ehkä sinulla ei ole kirjoitusoikeuksia?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Asennuslähteet on onnistuneesti viety tiedostoon %s."
@@ -3733,20 +3755,20 @@ msgstr "Asennuslähteet on onnistuneesti viety tiedostoon %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Päivitä"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Ei määritettyjä asennuslähteitä."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 "Käytä komentoa 'zypper addrepo' lisätäksesi yhden tai useampia "
@@ -3855,7 +3877,7 @@ msgstr "Valinnalla \"%s\" ei ole vaikutusta tässä."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Käytettäessä \"%s\" ei sallita parametreja."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Määritellyt asennuslähteet: "
 
@@ -3864,7 +3886,7 @@ msgstr "Määritellyt asennuslähteet: "
 msgid "Refreshing repository '%s'."
 msgstr "Virkistetään asennuslähdettä ”%s”."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Tarkastetaan käytöstä poistetun asennuslähteen '%s' sisältöä."
@@ -3874,7 +3896,7 @@ msgstr "Tarkastetaan käytöstä poistetun asennuslähteen '%s' sisältöä."
 msgid "Skipping disabled repository '%s'"
 msgstr "Ohitettiin käytöstä poistettu asennuslähde \"%s\""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Ohitettiin asennuslähde \"%s\" yllä olevien virheiden vuoksi."
@@ -3901,7 +3923,7 @@ msgstr "Lisää tai ota käyttöön asennuslähteitä komennoin \"%s\" tai \"%s\
 msgid "Could not refresh the repositories because of errors."
 msgstr "Asennuslähdettä ei voitu päivittää virheiden vuoksi."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Joitakin asennuslähteitä ei päivitetty virheiden vuoksi."
 
@@ -3960,12 +3982,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Asennuslähde \"%s\" nimeksi muutettiin \"%s\"."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "\"%s\" on jo käytössä: valitse toinen alias."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Virhe muokattaessa asennuslähdettä:"
 
@@ -4427,25 +4449,25 @@ msgstr ""
 "Kuten --details mutta kertoo myös, missä haku osui (hyödyllinen "
 "riippuvuuksista etsittäessä)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Määritetty asennuslähde \"%s\" on poistettu käytöstä."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Vastaavia kohteita ei löytynyt."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Virhe valmisteltaessa tai suoritettaessa hakua"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Tarkista yllä oleva virheviesti."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 "\"zypper refresh\" -komennon ajaminen pääkäyttäjänä saattaa korjata ongelman."
@@ -4542,7 +4564,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Virhe siirrettäessä palvelun \"%s\" tietoja:"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Ohitettiin palvelu \"%s\" yllä olevien virheiden vuoksi."
@@ -4561,24 +4583,28 @@ msgstr "Poistetaan palvelua \"%s\":"
 msgid "Service '%s' has been removed."
 msgstr "Palvelu \"%s\" poistettiin."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [valinnat]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Listaa palvelut."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Listaa järjestelmän palvelut."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Palveluita ei ole määritetty. Käytä \"%s\" -komentoa lisätäksesi vähintään "
 "yksi tai useampi palvelu."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4707,11 +4733,11 @@ msgid_plural ""
 "Repositories '%s' have been removed from disabled repositories of service "
 "'%s'"
 msgstr[0] ""
-"Poistettiin asennuslähde \"%s\" käytöstä poistetuista asennuslähteistä ("
-"palvelu \"%s\")"
+"Poistettiin asennuslähde \"%s\" käytöstä poistetuista asennuslähteistä "
+"(palvelu \"%s\")"
 msgstr[1] ""
-"Poistettiin asennuslähteet '%s' käytöstä poistetuista asennuslähteistä ("
-"palvelu '%s')"
+"Poistettiin asennuslähteet '%s' käytöstä poistetuista asennuslähteistä "
+"(palvelu '%s')"
 
 #: src/commands/services/modify.cc:285
 #, c-format, boost-format
@@ -5515,15 +5541,15 @@ msgstr "%s on vanhempi kuin %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Versio"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arkkitehtuuri"
 
@@ -5659,13 +5685,13 @@ msgstr "(tyhjä)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Riippuvuudet"
 
@@ -5702,7 +5728,7 @@ msgid "Flavor"
 msgstr "Tyyppi"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Kantapaketti"
 
@@ -5968,57 +5994,57 @@ msgstr[1] "%1% asennuslähdettä"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Tarkistetaan tarvitseeko %s metatietoja päivittää"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Asennuslähde \"%s\" on ajan tasalla."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Kohteen \"%s\" päivityksen tarkistusta on viivästetty."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Pakotetaan raakametatietojen päivitys"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Ladataan asennuslähteen \"%s\" tietoja"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Haluatko poistaa %s asennuslähteen pysyvästi?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Virhe poistettaessa asennuslähdettä '%s'."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Virhe ladattaessa tiedostoja kohteesta \"%s\"."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Tarkista yllä oleva viesti vihjeiden varalta."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Asennuslähteelle \"%s\" ei ole määritetty URI-osoitteita."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -6027,16 +6053,16 @@ msgstr ""
 "Aseta vähintään yksi osoite (baseurl=URI) tiedostoon %s asennuslähteelle "
 "\"%s\"."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Tälle asennuslähteelle ei ole määritetty aliasta."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Asennuslähde \"%s\" on virheellinen."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -6044,22 +6070,22 @@ msgstr ""
 "Tarkista että asennuslähteen URI-osoitteet osoittavat kelvolliseen "
 "asennuslähteeseen."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Virhe ladattaessa metatietoja asennuslähteestä '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Pakotetaan asennuslähteen välimuistin rakentaminen"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Virhe jäsennettäessä asennuslähteen \"%s\" metatietoja:"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6070,46 +6096,46 @@ msgstr ""
 "jäsentäjän ohjelmointivirheestä. Jos epäilet jälkimmäistä, tee virheraportti "
 "näiden ohjeiden mukaisesti: http://en.opensuse.org/Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 "Asennuslähteen \"%s\" metatietoja ei löytynyt paikallisesta välimuistista."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Virhe rakennettaessa välimuistia:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 "Asennuslähdettä \"%s\" ei löydetty aliaksen, järjestysnumeron tai URI-"
 "osoitteen perusteella."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Kirjoita \"%s\" saadaksesi lista määritetyistä asennuslähteistä."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Ohitetaan käytöstä poistettu asennuslähde \"%s\""
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "Yleisvalintaa ”%s” ei voi käyttää väliaikaisesti käytössä oleviin "
 "asennuslähteisiin."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Asennuslähde \"%s\" jätettiin huomioimatta parametrin \"%s\" vuoksi."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Otetaan väiliaikaisesti käyttöön asennuslähde '%s'."
@@ -6117,16 +6143,16 @@ msgstr "Otetaan väiliaikaisesti käyttöön asennuslähde '%s'."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
-"Asennuslähde \"%s\" ei ole ajan tasalla. Päivitä se suorittamalla "
-"\"zypper refresh\" -komento pääkäyttäjänä."
+"Asennuslähde \"%s\" ei ole ajan tasalla. Päivitä se suorittamalla \"zypper "
+"refresh\" -komento pääkäyttäjänä."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6135,81 +6161,81 @@ msgstr ""
 "Asennuslähteen \"%s\" välimuistitietokanta täytyy rakentaa uudelleen. Tämä "
 "onnistuu ajamalla \"zypper refresh\" -komento pääkäyttäjänä."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Asennuslähde '%s' pysyy poissa käytöstä."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Valmistellaan kohdetta"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Kohteen valmistelu epäonnistui:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Puhdistetaan asennuslähteen \"%s\" välimuistia."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Puhdistetaan asennuslähteen \"%s\" raakametatietojen välimuistia."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Säilytetään raakametatietojen välimuisti %s \"%s\"."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Puhdistettiin paketit \"%s\"."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Asennuslähdettä \"%s\" ei voitu puhdistaa virheen vuoksi."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Puhdistetaan asennettujen pakettien välimuistia."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Asennettujen pakettien välimuistia ei voi puhdistaa virheiden vuoksi."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Asennuslähteitä ei voitu puhdistaa virheiden vuoksi."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Joitakin asennuslähteitä ei ole päivitetty virheiden vuoksi."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Määritetyt asennuslähteet puhdistettiin."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Kaikki asennuslähteet puhdistettiin."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Tämä on vaihdettava vain luettavissa oleva asennusväline (CD/DVD). "
 "Automaattipäivitys poistetaan käytöstä."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Virheellinen asennuslähteen alias: \"%s\""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6217,26 +6243,26 @@ msgstr ""
 "Asennuslähteen tyyppiä ei voitu tunnistaa automaattisesti. Tarkista, "
 "osoittavatko alla olevat URI-osoitteet kelvollisiin asennuslähteisiin:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Annetusta sijainnista ei löydy asennuslähteitä:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 "Ongelma siirrettäessä asennuslähteen tietoja määritellystä URI-osoitteesta:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Tarkista, että URI-osoite on saatavissa."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Tunnistamaton ongelma lisättäessä asennuslähdettä:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6245,137 +6271,137 @@ msgstr ""
 "GPG-tarkistus on poistettu käytöstä asennuslähteen ”%1%” asetuksissa. "
 "Pakettien eheyttä ja alkuperää ei voi tarkistaa."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Asennuslähde \"%s\" lisättiin onnistuneesti"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Luetaan tietoja tietovälineeltä \"%s\""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Ongelma luettaessa tietovälinettä \"%s\""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Tarkista, että asennusmedia on oikeellinen ja luettavissa."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 "Tietojen lukemista '%s' medialta on viivytetty seuraavaa virkistykseen asti."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Luetaan tietoja tietovälineeltä \"%s\""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Ongelma luettaessa tietovälinettä \"%s\""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Tarkista, että asennusmedia on oikeellinen ja luettavissa."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Ongelma luettaessa tiedostoa määritellystä URI-osoitteesta"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Tarkista, että määritetty URI-osoite on oikein ja saatavilla."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Ongelma jäsennettäessä tiedostoa määritellystä URI-osoitteesta"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Onko se .repo-tiedosto?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 "Tapahtui virhe yritettäessä lukea tiedostoa määritetystä URI-osoitteesta"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Löydettiin asennuslähde ilman aliasta. Ohitetaan."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Asennuslähteellä \"%s\" ei ole URI-osoitetta. Ohitetaan."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Asennuslähde \"%s\" poistettiin."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Asennuslähteen \"%s\" tärkeysjärjestystä ei muutettu (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Asennuslähde \"%s\" otettiin käyttöön."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Asennuslähde \"%s\" poistettiin käytöstä."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Asennuslähteen \"%s\" automaattipäivitys otettiin käyttöön."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Asennuslähteen \"%s\" automaattipäivitys poistettiin käytöstä."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Asennuslähteen \"%s\" RPM-välimuisti otettiin käyttöön."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Asennuslähteen \"%s\" RPM-välimuisti poistettiin käytöstä."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Asennuslähteen \"%s\" GPG-tarkistus otettiin käyttöön."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Asennuslähteen \"%s\" GPG-tarkistus poistettiin käytöstä."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Asennuslähteen \"%s\" tärkeysjärjestykseksi asetettiin %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Asennuslähteen \"%s\" nimeksi asetettiin \"%s\"."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Ei muutoksia asennuslähteeseen \"%s\"."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Asennuslähteeseen %s ei tehty muutoksia."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Luetaan asennuslähteiden tietoja..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6383,44 +6409,44 @@ msgstr ""
 "Ei asennuslähdettä määritettynä. Käytetään ainoastaan asennettuja "
 "ratkaisimia. Mitään ei voida asentaa."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Luetaan asennuslähteen \"%s\" tietoja..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Asennuslähdettä \"%s\" ei löydy välimuistista. Ladataan..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Ongelma ladattaessa tietoja \"%s\""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 "Asennuslähteen \"%s\" päivitys ei onnistunut. Käytetään vanhaa välimuistia."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "\"%s\" ei voida käyttää virheiden vuoksi."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "Asennuslähteen ”%1%” metatiedot ovat vanhentuneet %2%."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Kokeile \"%s\" tai jopa \"%s\"."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6428,36 +6454,36 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 "Asennuslähteet metatiedot ovat vanhentuneet: tarkista, onko "
-"automaattivirkistys käytössä (zypper lr) tai virkistä lähde itse (zypper ref)"
-". Ellei ongelma ratkea, peilipalvelin voi olla virheellinen tai palvelin "
+"automaattivirkistys käytössä (zypper lr) tai virkistä lähde itse (zypper "
+"ref). Ellei ongelma ratkea, peilipalvelin voi olla virheellinen tai palvelin "
 "lakannut tukemasta asennuslähdettä."
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Luetaan asennettuja paketteja..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Tapahtui virhe luettaessa asennettuja paketteja:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "\"%s\" vaikuttaa RPM-tiedostolta: yritetään ladata se."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Virhe RPM-tiedostossa %s. Ohitetaan."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 "Virhe luettaessa RPM-paketin tunnistetietoa %s. Onko tämä varmasti RPM-"
 "tiedosto?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "RPM-tiedostojen välimuisti"
 
@@ -6465,25 +6491,25 @@ msgstr "RPM-tiedostojen välimuisti"
 msgid "System Packages"
 msgstr "Järjestelmän paketit"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Korjauspäivityksiä ei löytynyt."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Ohjelmistoryhmiä ei löytynyt."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Paketteja ei löytynyt."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Sisäinen nimi"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Tuotteita ei löytynyt."
 
@@ -6650,8 +6676,8 @@ msgid ""
 msgstr ""
 "Käynnissä on yhä ohjelmia, jotka käyttävät päivitysten poistamia tai "
 "muuttamia tiedostoja ja kirjastoja. Ne tulisi käynnistää uudelleen, jotta "
-"päivitykset tulevat voimaan. Saat näiden ohjelmien luettelon komennolla \""
-"%1%”."
+"päivitykset tulevat voimaan. Saat näiden ohjelmien luettelon komennolla "
+"\"%1%”."
 
 #: src/solve-commit.cc:657
 msgid "Update notifications were received from the following packages:"
@@ -6882,7 +6908,7 @@ msgid "Updatestack"
 msgstr "Päivityspino"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Korjauspäivitykset"
 
@@ -6905,7 +6931,7 @@ msgstr "Sisällytetyt luokat"
 msgid "Needed software management updates will be installed first:"
 msgstr "Tarvittavat ohjelmanhallintapäivitykset asennetaan ensin:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Ei päivitettävää."
 
@@ -6914,50 +6940,50 @@ msgstr "Ei päivitettävää."
 msgid "The following updates are also available:"
 msgstr "Seuraavat päivitykset ovat myös saatavilla:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Pakettipäivitykset"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Ohjelmistoryhmien päivitykset"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Tuotteen päivitykset"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Nykyinen versio"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Versiot saatavilla"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Ei vikoja."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Löydettiin viat:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "Löydettiin seuraavat paikkaukset kuvauksen perusteella:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr "Bugzilla-merkintää %s ei löydy tai se ei ole tarpeellinen."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "CVE-merkintää %s ei löydy tai se ei ole tarpeellinen."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "Korjausta %s-ongelmalle %s ei löytynyt tai sitä ei tarvita."

--- a/po/fr.po
+++ b/po/fr.po
@@ -13,11 +13,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper.fr\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-08-04 14:59+0000\n"
 "Last-Translator: Sophie Leroy <sophie@stoquart.com>\n"
-"Language-Team: French <https://l10n.opensuse.org/projects/zypper/master/fr/>"
-"\n"
+"Language-Team: French <https://l10n.opensuse.org/projects/zypper/master/fr/"
+">\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -828,7 +828,8 @@ msgstr[1] "Les %d paquets suivants vont être remis à une version inférieure 
 msgid "The following patch is going to be downgraded:"
 msgid_plural "The following %d patches are going to be downgraded:"
 msgstr[0] "Le correctif suivant va être remis à une version inférieure :"
-msgstr[1] "Les %d correctifs suivants vont être remis à une version inférieure :"
+msgstr[1] ""
+"Les %d correctifs suivants vont être remis à une version inférieure :"
 
 #: src/Summary.cc:876
 #, c-format, boost-format
@@ -928,7 +929,8 @@ msgstr[1] ""
 msgid "The following recommended source package was automatically selected:"
 msgid_plural ""
 "The following %d recommended source packages were automatically selected:"
-msgstr[0] "Le paquet source recommandé suivant a été sélectionné automatiquement :"
+msgstr[0] ""
+"Le paquet source recommandé suivant a été sélectionné automatiquement :"
 msgstr[1] ""
 "Les %d paquets source recommandés suivants ont été sélectionnés "
 "automatiquement :"
@@ -938,7 +940,8 @@ msgstr[1] ""
 msgid "The following recommended application was automatically selected:"
 msgid_plural ""
 "The following %d recommended applications were automatically selected:"
-msgstr[0] "L'application recommandée suivante a été automatiquement sélectionnée :"
+msgstr[0] ""
+"L'application recommandée suivante a été automatiquement sélectionnée :"
 msgstr[1] ""
 "Les %d applications recommandées suivantes ont été automatiquement "
 "sélectionnées :"
@@ -1020,7 +1023,8 @@ msgstr[1] ""
 msgid "The following application is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d applications are recommended, but will not be installed:"
-msgstr[0] "L'application suivante est recommandée, mais ne sera pas installée :"
+msgstr[0] ""
+"L'application suivante est recommandée, mais ne sera pas installée :"
 msgstr[1] ""
 "Les %d applications suivantes sont recommandées, mais ne seront pas "
 "installées :"
@@ -1031,7 +1035,8 @@ msgid "The following package is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d packages are suggested, but will not be installed:"
 msgstr[0] "Le paquet suivant est suggéré, mais ne sera pas installé :"
-msgstr[1] "Les %d paquets suivants sont suggérés, mais ne seront pas installés :"
+msgstr[1] ""
+"Les %d paquets suivants sont suggérés, mais ne seront pas installés :"
 
 #: src/Summary.cc:1233
 #, c-format, boost-format
@@ -1048,7 +1053,8 @@ msgid "The following pattern is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d patterns are suggested, but will not be installed:"
 msgstr[0] "Le schéma suivant est suggéré, mais ne sera pas installé :"
-msgstr[1] "Les %d schémas suivants sont suggérés, mais ne seront pas installés :"
+msgstr[1] ""
+"Les %d schémas suivants sont suggérés, mais ne seront pas installés :"
 
 #: src/Summary.cc:1243
 #, c-format, boost-format
@@ -1056,7 +1062,8 @@ msgid "The following product is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d products are suggested, but will not be installed:"
 msgstr[0] "Le produit suivant est suggéré, mais ne sera pas installé :"
-msgstr[1] "Les %d produits suivants sont suggérés, mais ne seront pas installés :"
+msgstr[1] ""
+"Les %d produits suivants sont suggérés, mais ne seront pas installés :"
 
 #: src/Summary.cc:1249
 #, c-format, boost-format
@@ -1143,14 +1150,16 @@ msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Le paquet suivant n'est pas supporté par son fournisseur :"
-msgstr[1] "Les %d paquets suivants ne sont pas supportés par leur fournisseur :"
+msgstr[1] ""
+"Les %d paquets suivants ne sont pas supportés par leur fournisseur :"
 
 #: src/Summary.cc:1382
 #, c-format, boost-format
 msgid "The following package is not supported by its vendor:"
 msgid_plural "The following %d packages are not supported by their vendor:"
 msgstr[0] "Le paquet suivant n'est pas supporté par son fournisseur :"
-msgstr[1] "Les %d paquets suivants ne sont pas supportés par leur fournisseur :"
+msgstr[1] ""
+"Les %d paquets suivants ne sont pas supportés par leur fournisseur :"
 
 #: src/Summary.cc:1400
 #, c-format, boost-format
@@ -1210,21 +1219,24 @@ msgstr[1] "Les %d mises à jour de paquets suivantes ne seront PAS installées 
 msgid "The following product update will NOT be installed:"
 msgid_plural "The following %d product updates will NOT be installed:"
 msgstr[0] "La mise à jour de produit suivante ne sera PAS installée :"
-msgstr[1] "Les %d mises à jour de produits suivantes ne seront PAS installées :"
+msgstr[1] ""
+"Les %d mises à jour de produits suivantes ne seront PAS installées :"
 
 #: src/Summary.cc:1471
 #, c-format, boost-format
 msgid "The following application update will NOT be installed:"
 msgid_plural "The following %d application updates will NOT be installed:"
 msgstr[0] "La mise à jour d'application suivante ne sera PAS installée :"
-msgstr[1] "Les %d mises à jour d'applications suivantes ne seront PAS installées :"
+msgstr[1] ""
+"Les %d mises à jour d'applications suivantes ne seront PAS installées :"
 
 #: src/Summary.cc:1504
 #, c-format, boost-format
 msgid "The following item is locked and will not be changed by any action:"
 msgid_plural ""
 "The following %d items are locked and will not be changed by any action:"
-msgstr[0] "L'élément suivant est verrouillé et ne sera modifié par aucune action :"
+msgstr[0] ""
+"L'élément suivant est verrouillé et ne sera modifié par aucune action :"
 msgstr[1] ""
 "Les %d éléments suivants sont verrouillés et ne seront modifiés par aucune "
 "action :"
@@ -1475,7 +1487,7 @@ msgstr "PackageKit est toujours en cours d'exécution (probablement occupé)."
 msgid "Try again?"
 msgstr "Essayer à nouveau ?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Exception inattendue."
 
@@ -1506,12 +1518,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "L'option %s n'a aucun effet ici, ignorée."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Arguments de programme non optionnels : "
 
@@ -1799,11 +1811,11 @@ msgstr ""
 msgid "Received %1% new package signing key from repository \"%2%\":"
 msgid_plural "Received %1% new package signing keys from repository \"%2%\":"
 msgstr[0] ""
-"Réception de %1% nouvelle clé de signature de paquets provenant du dépôt « "
-"%2% » :"
+"Réception de %1% nouvelle clé de signature de paquets provenant du dépôt "
+"« %2% » :"
 msgstr[1] ""
-"Réception de %1% nouvelles clés de signature de paquets provenant du dépôt « "
-"%2% » :"
+"Réception de %1% nouvelles clés de signature de paquets provenant du dépôt "
+"« %2% » :"
 
 #: src/callbacks/keyring.h:472
 msgid ""
@@ -2284,17 +2296,17 @@ msgid "Commands:"
 msgstr "Commandes :"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Afficher le résumé détaillé de l'installation."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Type de paquet (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2303,11 +2315,17 @@ msgstr ""
 "vers une version inférieure plutôt que vers la toute dernière version sont "
 "aussi possibles."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr ""
 "Considérer seulement les correctifs qui affectent la gestion des paquets "
 "elle-même."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2389,7 +2407,7 @@ msgstr "zypper [--global-options] <commande> [--command-options] [arguments]"
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <sous-commande> [--command-options] [arguments]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Affiche l'aide"
 
@@ -2529,8 +2547,8 @@ msgid ""
 "<=, =, >=, >."
 msgstr ""
 "Installer les paquets d'après les fonctions spécifiées ou les fichiers RPM "
-"d'après l'emplacement spécifié. Une fonction s'écrit NOM[.ARCH][OP<VERSION>]"
-", où OP est l'un des opérateurs suivants : <, <=, =, >=, >."
+"d'après l'emplacement spécifié. Une fonction s'écrit NOM[.ARCH]"
+"[OP<VERSION>], où OP est l'un des opérateurs suivants : <, <=, =, >=, >."
 
 #. translators: --from <ALIAS|#|URI>
 #: src/commands/installremove.cc:195 src/commands/utils/download.cc:170
@@ -2618,22 +2636,22 @@ msgstr ""
 "jour officielle."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [OPTIONS]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Lister les correctifs disponibles."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Lister tous les correctifs applicables."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Lister tous les correctifs, pas seulement ceux applicables."
 
@@ -2690,36 +2708,40 @@ msgstr ""
 "appelant '%s'."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [OPTIONS] [LOCALISATION] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Lister les localisations demandées (codes de langues)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Lister les localisations demandées et les paquets correspondants."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Afficher les paquets correspondants."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Lister toutes les localisations disponibles."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 "Les arguments positionnels sont ignorés, car l'argument --all a été spécifié."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "Les localisations dont les informations doivent être affichées."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2727,18 +2749,18 @@ msgstr ""
 "Obtenir tous les paramètres régionaux avec le code de langue 'en' qui ont "
 "leur propre code de pays, excepté le 'en' de base :"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 "Obtenir tous les paramètres régionaux avec le code de langue 'en' avec ou "
 "sans code de pays :"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 "Obtenir les paramètres régionaux correspondant exactement à l'argument : "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "Obtenir la liste des paquets disponibles pour 'de' et 'en' :"
 
@@ -2852,11 +2874,11 @@ msgstr[1] "%lu verrouillages supprimés."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Nom"
 
@@ -2867,8 +2889,8 @@ msgstr "Correspondances"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Type"
@@ -2876,7 +2898,7 @@ msgstr "Type"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Dépôt"
@@ -3102,7 +3124,8 @@ msgstr "Ne travailler qu'avec le dépôt spécifié."
 #: src/commands/optionsets.cc:87
 #, c-format, boost-format
 msgid "Option '--%s' overrides a previously set download mode."
-msgstr "L'option « --%s » annule un mode de téléchargement précédemment défini."
+msgstr ""
+"L'option « --%s » annule un mode de téléchargement précédemment défini."
 
 #: src/commands/optionsets.cc:116
 #, c-format, boost-format
@@ -3164,14 +3187,15 @@ msgid ""
 "Don't require user interaction. Alias for the --non-interactive global "
 "option."
 msgstr ""
-"Se passer de l'interaction avec l'utilisateur. Alias de l'option globale "
-"--non-interactive."
+"Se passer de l'interaction avec l'utilisateur. Alias de l'option globale --"
+"non-interactive."
 
 #: src/commands/optionsets.cc:309
 msgid ""
 "Whether applicable optional patches should be treated as needed or be "
 "excluded."
-msgstr "Si les correctifs optionnels applicables doivent être inclus ou exclus."
+msgstr ""
+"Si les correctifs optionnels applicables doivent être inclus ou exclus."
 
 #: src/commands/optionsets.cc:312
 msgid "The default is to exclude optional patches."
@@ -3311,7 +3335,8 @@ msgstr "Échec de la vérification :"
 #. Here: Table output
 #: src/commands/ps.cc:127 src/solve-commit.cc:623
 msgid "Checking for running processes using deleted libraries..."
-msgstr "Contrôle des processus actifs utilisant des bibliothèques supprimées..."
+msgstr ""
+"Contrôle des processus actifs utilisant des bibliothèques supprimées..."
 
 # TLABEL linuxrc_2002_03_29_0036__42
 #. process ID
@@ -3340,7 +3365,7 @@ msgid "Command"
 msgstr "Commande"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Service"
 
@@ -3516,22 +3541,22 @@ msgid "Show detailed information for products."
 msgstr "Affiche des informations détaillées sur des produits."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [OPTIONS] [dépôt] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Liste tous les paquets disponibles."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Lister tous les paquets disponibles dans les dépôts spécifiés."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
@@ -3539,19 +3564,19 @@ msgstr ""
 "le résolveur."
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 "Afficher les paquets installés qui ont été sélectionnés explicitement par "
 "l'utilisateur."
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr "Affiche les paquets installés qui ne sont fournis par aucun dépôt."
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
@@ -3560,84 +3585,84 @@ msgstr ""
 "la mise à jour)."
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Afficher les paquets suggérés."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Afficher les paquets recommandés."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Afficher les paquets non nécessaires."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Trier la liste par nom de paquet."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Trier la liste par dépôt."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [dépôt] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Liste tous les correctifs disponibles."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Liste tous les correctifs disponibles dans les dépôts spécifiés."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [OPTIONS] [dépôt] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Liste tous les modèles disponibles."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Lister tous les modèles disponibles dans les dépôts spécifiés."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [OPTIONS] [dépôt] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Liste tous les produits disponibles."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Lister tous les produits disponibles dans les dépôts spécifiés."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Sortie XML uniquement : Transférer directement les tags XML trouvés dans un "
 "fichier produit."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "L'option %1% n'a pas d'effet sans l'option globale %2%."
@@ -3678,13 +3703,13 @@ msgstr "Ne pas vérifier l'URI, vérifier plus tard lors du rafraîchissement."
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr "Le type de dépôt est toujours auto-détecté. Cette option est ignorée."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 "Impossible d'utiliser %s en même temps que %s. Le paramètre %s est utilisé."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3729,112 +3754,116 @@ msgstr "Vide le cache des métadonnées brutes."
 msgid "Clean both metadata and package caches."
 msgstr "Vide le cache des métadonnées et des paquets."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Activé"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Vérification GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Priorité"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Rafraichissement automatique"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Activé"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Désactivé"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Conserver les paquets"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI de la clé GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Préfixe du chemin"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Service parent"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Mots-clés"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Chemin des informations du dépôt"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Chemin du cache MD"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [OPTIONS] [DÉPÔT] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Lister tous les dépôts définis."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "Exporter tous les dépôts définis dans un fichier .repo local unique."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Erreur lors de la lecture des dépôts :"
 
 # TLABEL kinternet_2002_02_20_2255__39
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Impossible d'ouvrir le fichier %s en écriture."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Peut-être ne possédez-vous pas les autorisations d'écriture ?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Les dépôts ont correctement été exportés vers %s."
@@ -3842,20 +3871,20 @@ msgstr "Les dépôts ont correctement été exportés vers %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Rafraichir"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "Conserver"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Aucun dépôt défini."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 "Utilisez la commande 'zypper addrepo' pour ajouter un ou plusieurs dépôts."
@@ -3966,7 +3995,7 @@ msgstr "L'option globale '%s' n'a aucun effet ici."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Les arguments ne sont pas autorisés si '%s' est utilisé."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Dépôts spécifiés : "
 
@@ -3975,7 +4004,7 @@ msgstr "Dépôts spécifiés : "
 msgid "Refreshing repository '%s'."
 msgstr "Rafraîchissement du dépôt '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Analyse du contenu du dépôt désactivé '%s'."
@@ -3985,7 +4014,7 @@ msgstr "Analyse du contenu du dépôt désactivé '%s'."
 msgid "Skipping disabled repository '%s'"
 msgstr "Dépôt désactivé '%s' ignoré"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Dépôt '%s' ignoré en raison de l'erreur susmentionnée."
@@ -4006,13 +4035,14 @@ msgstr "Il n'y a pas de dépôts activés définis."
 #: src/commands/repos/refresh.cc:331
 #, c-format, boost-format
 msgid "Use '%s' or '%s' commands to add or enable repositories."
-msgstr "Utilisez les commandes '%s' ou '%s' pour ajouter ou activer des dépôts."
+msgstr ""
+"Utilisez les commandes '%s' ou '%s' pour ajouter ou activer des dépôts."
 
 #: src/commands/repos/refresh.cc:337
 msgid "Could not refresh the repositories because of errors."
 msgstr "Impossible de rafraichir les dépôts à cause d'erreurs."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Plusieurs dépôts n'ont pas été rafraichis à cause d'une erreur."
 
@@ -4068,12 +4098,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Le dépôt '%s' a été renommé en '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "Un dépôt nommé '%s' existe déjà. Veuillez utiliser un autre alias."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Erreur lors de la modification du dépôt :"
 
@@ -4543,27 +4573,27 @@ msgstr ""
 "Comme --details, mais avec des informations supplémentaires lorsque la "
 "recherche correspond (utile pour la recherche dans les dépendances)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Le dépôt '%s' spécifié est désactivé."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Aucun élément correspondant n'a été trouvé."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 "Problème rencontré lors de l'initialisation ou de l'exécution de la requête "
 "de recherche"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Voir le message ci-dessus pour une indication."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "Lancer 'zypper refresh' en tant que root peut résoudre le problème."
 
@@ -4641,7 +4671,8 @@ msgstr "Ajoute un service d'index de dépôts au système."
 
 #: src/commands/services/add.cc:140
 msgid "The type of service is always autodetected. This option is ignored."
-msgstr "Le type de service est toujours auto-détecté. Cette option est ignorée."
+msgstr ""
+"Le type de service est toujours auto-détecté. Cette option est ignorée."
 
 #: src/commands/services/common.cc:37
 msgid "Error reading services:"
@@ -4659,7 +4690,7 @@ msgstr ""
 "Problème de récupération du fichier d'index du dépôt pour le service '%s' :"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Service '%s' ignoré à cause de l'erreur susmentionnée."
@@ -4678,24 +4709,28 @@ msgstr "Suppression du service '%s' :"
 msgid "Service '%s' has been removed."
 msgstr "Le service '%s' a été supprimé."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [OPTIONS]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Liste tous les services définis."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Lister les services définis."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Pas de services définis. Utilisez la commande '%s' pour ajouter un ou "
 "plusieurs services."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4801,7 +4836,8 @@ msgid "Repository '%s' has been added to disabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been added to disabled repositories of service '%s'"
 msgstr[0] "Le dépôt '%s' a été ajouté aux dépôts désactivés du service '%s'"
-msgstr[1] "Les dépôts '%s' ont été ajoutés aux dépôts désactivés du service '%s'"
+msgstr[1] ""
+"Les dépôts '%s' ont été ajoutés aux dépôts désactivés du service '%s'"
 
 #: src/commands/services/modify.cc:269
 #, c-format, boost-format
@@ -4810,7 +4846,8 @@ msgid ""
 msgid_plural ""
 "Repositories '%s' have been removed from enabled repositories of service '%s'"
 msgstr[0] "Le dépôt '%s' a été supprimé des dépôts activés du service '%s'"
-msgstr[1] "Les dépôts '%s' ont été supprimés des dépôts activés du service '%s'"
+msgstr[1] ""
+"Les dépôts '%s' ont été supprimés des dépôts activés du service '%s'"
 
 #: src/commands/services/modify.cc:276
 #, c-format, boost-format
@@ -4820,7 +4857,8 @@ msgid_plural ""
 "Repositories '%s' have been removed from disabled repositories of service "
 "'%s'"
 msgstr[0] "Le dépôt '%s' a été supprimé des dépôts désactivés du service '%s'"
-msgstr[1] "Les dépôts '%s' ont été supprimés des dépôts désactivés du service '%s'"
+msgstr[1] ""
+"Les dépôts '%s' ont été supprimés des dépôts désactivés du service '%s'"
 
 #: src/commands/services/modify.cc:285
 #, c-format, boost-format
@@ -5652,15 +5690,15 @@ msgstr "%s est plus ancien que %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Version"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Architecture"
 
@@ -5800,14 +5838,14 @@ msgstr "(vide)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 # TLABEL packages_2002_03_14_2340__36
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Dépendance"
 
@@ -5844,7 +5882,7 @@ msgid "Flavor"
 msgstr "Saveur"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "De base"
 
@@ -6105,59 +6143,59 @@ msgstr[1] "%1% dépôts"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Vérification du rafraîchissement des métadonnées pour %s"
 
 # TLABEL linuxrc_2002_03_29_0036__117
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Le dépôt '%s' est à jour."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "La vérification de l'état du dépôt '%s' a été reportée."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Forçage de la mise à jour des métadonnées brutes"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Récupération des métadonnées du dépôt '%s'"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Voulez-vous désactiver le dépôt %s de façon permanente ?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Erreur lors de la désactivation du dépôt '%s'."
 
 # TLABEL restore_2002_08_07_0216__60
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Problème de récupération de fichiers depuis '%s'."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Veuillez consulter le message d'erreur ci-dessus pour une indication."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Aucune URI définie pour '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -6165,17 +6203,17 @@ msgid ""
 msgstr ""
 "Veuillez ajouter une ou plusieurs URI (baseurl=URI) à %s pour le dépôt '%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Aucun alias défini pour ce dépôt."
 
 # TLABEL linuxrc_2002_03_29_0036__117
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Le dépôt '%s' est invalide."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -6183,22 +6221,22 @@ msgstr ""
 "Veuillez vérifier que l'URI définie pour ce dépôt pointe bien sur un dépôt "
 "valide."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Erreur lors de la récupération des métadonnées pour '%s' :"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Force la construction du cache pour le dépôt"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Erreur lors de l'analyse des métadonnées pour '%s' :"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6211,45 +6249,45 @@ msgstr ""
 "disponibles à l'adresse http://fr.opensuse.org/Zypper/Dépannage"
 
 # TLABEL linuxrc_2002_03_29_0036__117
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 "Les métadonnées du dépôt pour '%s' n'ont pas été trouvées dans le cache "
 "local."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Erreur lors de la reconstruction du cache :"
 
 # TLABEL linuxrc_2002_03_29_0036__117
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 "Le dépôt '%s' n'a pas été trouvé en fonction de son alias, numéro ou URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Utilisez '%s' pour obtenir la liste des dépôts définis."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Dépôt désactivé '%s' ignoré"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr "L'option globale '%s' permet d'activer temporairement des dépôts."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Ignore le dépôt '%s' à cause de l'option '%s'."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Activation temporaire du dépôt '%s'."
@@ -6257,7 +6295,7 @@ msgstr "Activation temporaire du dépôt '%s'."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6266,7 +6304,7 @@ msgstr ""
 "Le dépôt '%s' n'est pas à jour. Vous pouvez lancer 'zypper refresh' en tant "
 "que root pour le mettre à jour."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6275,83 +6313,83 @@ msgstr ""
 "Le cache de métadonnées a besoin d'être construit pour le dépôt '%s'. Vous "
 "pouvez lancer 'zypper refresh' en tant que root pour le faire."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Le dépôt '%s' reste désactivé."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Initialisation de la cible"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Échec de l'initialisation de la cible :"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Nettoyage du cache des métadonnées pour '%s'."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Nettoyage du cache des métadonnées brutes pour '%s'."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Conservation du cache des métadonnées brutes pour %s '%s'."
 
 # TLABEL restore_2002_08_07_0216__60
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Nettoyage des paquets pour '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Impossible de nettoyer le dépôt '%s' à cause d'une erreur."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Nettoyage du cache des paquets installés."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 "Impossible de nettoyer le cache des paquets installés à cause d'une erreur."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Impossible de nettoyer les dépôts à cause d'erreurs."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Certains dépôts n'ont pas été nettoyés à cause d'une erreur."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Les dépôts spécifiés ont été nettoyés."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Tous les dépôts ont été nettoyés."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Ceci est un support amovible en lecture seule (CD/DVD), désactivation du "
 "rafraîchissement automatique."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Alias de dépôt invalide : '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6359,25 +6397,26 @@ msgstr ""
 "Impossible de déterminer le type de dépôt. Veuillez vérifier si les URI "
 "définis (voir ci-après) pointent vers un dépôt valide :"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Impossible de trouver un dépôt valide à l'endroit indiqué :"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
-msgstr "Problème lors du transfert des données du dépôt depuis l'URI spécifié :"
+msgstr ""
+"Problème lors du transfert des données du dépôt depuis l'URI spécifié :"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Veuillez vérifier si l'URI spécifié est accessible."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Problème inconnu lors de l'ajout du dépôt :"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6386,141 +6425,141 @@ msgstr ""
 "La vérification GPG est désactivée dans la configuration du dépôt '%1%'. "
 "L'intégrité et l'origine des paquets ne peuvent pas être assurées."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Le dépôt '%s' a été ajouté avec succès"
 
-# TLABEL restore_2002_08_07_0216__60
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Lecture des données depuis le support '%s'"
-
-# TLABEL restore_2002_08_07_0216__60
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Problème de lecture des données depuis le support %s"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-"Vérifiez si votre support d'installation est valide et accessible en lecture."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 "La lecture des données depuis le support '%s' est reportée jusqu'au prochain "
 "rafraîchissement."
 
-#: src/repos.cc:1352
+# TLABEL restore_2002_08_07_0216__60
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Lecture des données depuis le support '%s'"
+
+# TLABEL restore_2002_08_07_0216__60
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Problème de lecture des données depuis le support %s"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+"Vérifiez si votre support d'installation est valide et accessible en lecture."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Problème d'accès au fichier à l'URI spécifié"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Veuillez vérifier que l'URI est valide et accessible."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Problème d'analyse du fichier à l'URI spécifié"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Est-ce un fichier .repo ?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Problème rencontré à la lecture du fichier à l'URI spécifié"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Un dépôt sans alias défini a été trouvé dans le fichier, ignoré."
 
 # TLABEL linuxrc_2002_03_29_0036__117
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Le dépôt '%s' n'a pas d'URI défini. Il va être ignoré."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Le dépôt '%s' a été supprimé."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "La priorité du dépôt '%s' a été laissée inchangée (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Le dépôt '%s' a été activé avec succès."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Le dépôt '%s' a été désactivé avec succès."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Le rafraichissement automatique a été activé pour le dépôt '%s'."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Le rafraichissement automatique a été désactivé pour le dépôt '%s'."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "La mise en cache des fichiers RPM a été activée pour le dépôt '%s'."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "La mise en cache des fichiers RPM a été désactivée pour le dépôt '%s'."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "La vérification GPG a été activée pour le dépôt '%s'."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "La vérification GPG a été désactivée pour le dépôt '%s'."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "La priorité du dépôt '%s' a été réglée à %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Le nom du dépôt '%s' a été défini à '%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Rien à changer pour le dépôt '%s'."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Le dépôt %s est laissé inchangé."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Chargement des données du dépôt..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6528,45 +6567,46 @@ msgstr ""
 "Pas de dépôt défini. Ne fonctionne qu'avec les résolvables installés. Rien "
 "ne peut être installé."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Récupération de données du dépôt '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Le dépôt '%s' n'a pas été mis en cache. Mise en cache..."
 
 # TLABEL restore_2002_08_07_0216__60
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Problème lors du chargement des données depuis '%s'"
 
 # TLABEL linuxrc_2002_03_29_0036__117
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
-msgstr "Le dépôt '%s' n'a pas pu être rafraichi. Utilisation de l'ancien cache."
+msgstr ""
+"Le dépôt '%s' n'a pas pu être rafraichi. Utilisation de l'ancien cache."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Les éléments de '%s' n'ont pas pu être chargés en raison d'une erreur."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "Les métadonnées du dépôt '%1%' sont expirées depuis le %2%."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Essayez '%s', ou même '%s' avant de faire ceci."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6574,36 +6614,36 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 "Métadonnées du dépôt expirées : vérifiez si l'option 'autorefresh' est "
-"activée (zypper lr), sinon, rafraîchissez manuellement le dépôt (zypper ref)"
-". Si cela ne résout pas le problème, il se peut que vous utilisez un miroir "
-"interrompu ou que le serveur a cessé de prendre en charge le dépôt."
+"activée (zypper lr), sinon, rafraîchissez manuellement le dépôt (zypper "
+"ref). Si cela ne résout pas le problème, il se peut que vous utilisez un "
+"miroir interrompu ou que le serveur a cessé de prendre en charge le dépôt."
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Lecture des paquets installés..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Un problème est survenu lors de la lecture des paquets installés :"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' semble être un fichier RPM. Essaiera de le télécharger."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Problème avec le fichier RPM spécifié '%s'. Il va être ignoré."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 "Problème lors de la lecture de l'en-tête RPM de %s. Est-ce bien un fichier "
 "RPM ?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Cache local des fichiers RPM"
 
@@ -6611,25 +6651,25 @@ msgstr "Cache local des fichiers RPM"
 msgid "System Packages"
 msgstr "Paquets système"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Aucun correctif nécessaire trouvé."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Aucun modèle trouvé."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Aucun paquet trouvé."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Nom interne"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Aucun produit trouvé."
 
@@ -7044,7 +7084,7 @@ msgid "Updatestack"
 msgstr "Pile de mise à jour"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Correctifs"
 
@@ -7069,7 +7109,7 @@ msgstr ""
 "Les mises à jour de gestion des logiciels requises seront installées en "
 "premier :"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Aucune mise à jour trouvée."
 
@@ -7078,53 +7118,53 @@ msgstr "Aucune mise à jour trouvée."
 msgid "The following updates are also available:"
 msgstr "Les mises à jour suivantes sont également disponibles :"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Mises à jour de paquets"
 
 # TLABEL security_2002_08_07_0216__32
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Mises à jour de modèles"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Mises à jour de produits"
 
 # TLABEL kinternet_2002_02_20_2255__11
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Version actuelle"
 
 # TLABEL nis_server_2002_01_04_0147__65
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Version disponible"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Aucun problème correspondant n'a été trouvé."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
-"Les correspondances suivantes dans les numéros de problèmes ont été trouvées "
-":"
+"Les correspondances suivantes dans les numéros de problèmes ont été "
+"trouvées :"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 "Des correspondances dans les descriptions des correctifs suivants ont été "
 "trouvées :"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "Le correctif pour le problème Bugzilla numéro %s n'a pas été trouvé ou n'est "
 "pas nécessaire."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
@@ -7132,7 +7172,7 @@ msgstr ""
 "nécessaire."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper.gl\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Galician <https://l10n.opensuse.org/projects/zypper/master/gl/"
@@ -239,7 +239,8 @@ msgstr ""
 #. translators: --cache-dir, -C <DIR>
 #: src/Config.cc:412
 msgid "Use alternative directory for all caches."
-msgstr "Utilizar directorio alternativo de base de datos de caché de metadatos."
+msgstr ""
+"Utilizar directorio alternativo de base de datos de caché de metadatos."
 
 #. translators: --raw-cache-dir <DIR>
 #: src/Config.cc:425
@@ -1392,7 +1393,7 @@ msgstr "PackageKit está en execución (probablemente ocupado)."
 msgid "Try again?"
 msgstr "Tentar de novo?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Excepción non agardada."
 
@@ -1420,12 +1421,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "A opción %s non ten efecto aquí, ignorándoa."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Argumentos do programa sen opcións: "
 
@@ -2123,17 +2124,17 @@ msgid "Commands:"
 msgstr "Ordes:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Tipo de resolución (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2141,8 +2142,14 @@ msgstr ""
 "Realizar 'o mellor esforzo' para actualizar. Acéptanse tamén actualizacións "
 "a unha versión anterior á última."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2216,7 +2223,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Mostra a axuda"
 
@@ -2405,22 +2412,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2473,49 +2480,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2617,11 +2628,11 @@ msgstr[1] "Bloqueos %lu eliminados."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Nome"
 
@@ -2631,8 +2642,8 @@ msgstr ""
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Tipo"
@@ -2640,7 +2651,7 @@ msgstr "Tipo"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Repositorio"
@@ -3060,7 +3071,7 @@ msgid "Command"
 msgstr "Orde"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Servizo"
 
@@ -3224,120 +3235,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Listar todos os paquetes dispoñibles."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches"
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Listar todos os parches dispoñibles."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Lista os parches dispoñibles no repositorio especificado"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [opcións] [repositorio] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Listar todos os patróns dispoñibles."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Lista todos os patróns dispoñibles nos repositorios especificados."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [opcións] [repositorio] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Listar todos os produtos dispoñibles."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Lista todos os produtos dispoñibles nos repositorios especificados."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3376,12 +3387,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "Non se pode usar %s xunta con %s. Usando a opción %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3425,111 +3436,115 @@ msgstr "Limpar a caché de metadatos en bruto."
 msgid "Clean both metadata and package caches."
 msgstr "Limpar tanto a caché de paquetes como a de metadatos."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Activado"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Comprobación GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Prioridade"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Actualizar automaticamente"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Conectado"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Desconectado"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Manter paquetes"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI da chave GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Prefixo de ruta"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Servizo principal"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Ruta da caché MD"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Enumera todos os repositorios definidos."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Erro ó ler os repositorios:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Non se puido abrir %s para escribir."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Podería ser que non tivese permisos de escritura?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Os repositorios exportáronse con éxito a %s."
@@ -3537,20 +3552,20 @@ msgstr "Os repositorios exportáronse con éxito a %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Actualizar"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr ""
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3654,7 +3669,7 @@ msgstr "A opción global '%s' non ten efecto aquí."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Non se permiten argumentos cando se emprega '%s'."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Repositorios especificados: "
 
@@ -3663,7 +3678,7 @@ msgstr "Repositorios especificados: "
 msgid "Refreshing repository '%s'."
 msgstr "Desactivando o repositorio '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr ""
@@ -3673,7 +3688,7 @@ msgstr ""
 msgid "Skipping disabled repository '%s'"
 msgstr "Saltando o repositorio desactivado '%s'"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Saltando o repositorio '%s' por mor do erro de enriba."
@@ -3701,7 +3716,7 @@ msgstr "Use os comandos '%s' ou '%s' para engadir ou activar repositorios."
 msgid "Could not refresh the repositories because of errors."
 msgstr "Non se puideron actualizar os repositorios por mor dos erros."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Non se actualizou algún dos repositorios por mor dun erro."
 
@@ -3756,12 +3771,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "O repositorio '%s' foi renomeado a '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "Xa existe un repositorio chamado '%s'. Use outro alias."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Erro mentres se modificaba o repositorio:"
 
@@ -4193,26 +4208,26 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "O repositorio especificado '%s' está desactivado."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "Non se atoparon problemas de coincidencias."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Ocorreu un problema ó inicializar ou executar a consulta de busca"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Mire a mensaxe de enriba para obter unha suxestión."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "Executar 'zypper refresh' coma root debería resolver o problema."
 
@@ -4299,10 +4314,11 @@ msgstr "Actualizando servizo '%s'."
 #: src/commands/services/common.cc:136 src/commands/services/common.cc:146
 #, c-format, boost-format
 msgid "Problem retrieving the repository index file for service '%s':"
-msgstr "Houbo un problema ao obter o índice do repositorio para o servizo '%s':"
+msgstr ""
+"Houbo un problema ao obter o índice do repositorio para o servizo '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Saltando o servizo '%s' debido ao erro anterior."
@@ -4321,24 +4337,28 @@ msgstr "Eliminando o servizo '%s':"
 msgid "Service '%s' has been removed."
 msgstr "Eliminouse o servizo '%s'."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Lista os servicios definidos."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Non hai definido ningún servizo. Use o comando '%s' para engadir un ou máis "
 "servizos."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4433,7 +4453,8 @@ msgstr "O nome do servizo '%s' foi definido coma '%s'."
 msgid "Repository '%s' has been added to enabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been added to enabled repositories of service '%s'"
-msgstr[0] "Engadíuse o repositorio '%s' aos repositorios activados do servizo '%s'"
+msgstr[0] ""
+"Engadíuse o repositorio '%s' aos repositorios activados do servizo '%s'"
 msgstr[1] ""
 "Engadíronse os repositorios '%s' aos repositorios activados do servizo '%s'"
 
@@ -5223,15 +5244,15 @@ msgstr "%s é máis antigo ca %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Versión"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arq"
 
@@ -5365,13 +5386,13 @@ msgstr "(baleiro)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "E"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Dependencia"
 
@@ -5409,7 +5430,7 @@ msgid "Flavor"
 msgstr "Versión"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "É base"
 
@@ -5671,57 +5692,57 @@ msgstr[1] "Repositorio"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Comprobar cando actualizar os metadatos de %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "O repositorio '%s' está actualizado."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Retrasouse a comprobación de actualización de '%s'."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Forzando actualización de metadatos en bruto"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Obtendo os metadatos do repositorio '%s'"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr ""
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr ""
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Problema ao obter os ficheiros desde '%s'."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Mire a mensaxe de enriba para obter unha suxestión."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Non se definiron URIs para '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -5730,16 +5751,16 @@ msgstr ""
 "Engada un ou máis entradas URI base (baseurl=URI) a %s para o repositorio "
 "'%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Non se definiu ningún alias para este repositorio."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "O repositorio '%s' é incorrecto."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -5747,22 +5768,22 @@ msgstr ""
 "Verifique se os URIs definidos para este repositorio apuntan a un "
 "repositorio correcto."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Houbo un erro ao descargar os metadatos de '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Forzar a construción da caché do repositorio"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Erro ó analizar os metadatos de '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5774,42 +5795,42 @@ msgstr ""
 "favor, cubra un informe de erro seguindo as instrucións de http://"
 "en.opensuse.org/Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Non se atoparon os metadatos do repositorio '%s' na caché local."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Erro ao construír a caché:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 "Non se atopou o repositorio '%s' polo seu alias, o seu número nin o seu URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Use '%s' para obter a lista dos repositorios definidos."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Ignorando o repositorio desactivado '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, fuzzy, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr "Use os comandos '%s' ou '%s' para engadir ou activar repositorios."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Ignorando repositorio '%s' debido á opción '%s'."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr ""
@@ -5817,7 +5838,7 @@ msgstr ""
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -5826,7 +5847,7 @@ msgstr ""
 "O repositorio '%s' está desactualizado. Pode executar 'zypper refresh' coma "
 "root para actualizalo."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -5835,81 +5856,81 @@ msgstr ""
 "Precísase construir a caché de metadatos do repositorio '%s'. Pode executar "
 "'zypper refresh' coma root para facelo."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr ""
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Iniciando o obxectivo"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Fallou o inicio do obxectivo:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Limpando a caché de metadatos de '%s'."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Limpando a caché de metadatos en bruto para '%s'."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Mantendo a caché de metadatos en bruto para %s '%s'."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Limpando os paquetes de '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Non se puido limpar o repositorio '%s' por mor dun erro."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Limpando a caché de paquetes instalados."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Non se puido limpar a caché dos paquetes instalados por mor dun erro."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Non se puideron limpar os repositorios por mor de varios erros."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Non se puido limpar algún dos repositorios por mor dun erro."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Limpáronse os repositorios especificados."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Limpáronse todos os repositorios."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Este é un soporte substituíble de só lectura (CD/DVD), desactivando a "
 "actualización automática."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Alias incorrecto de repositorio: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -5917,205 +5938,206 @@ msgstr ""
 "Non se puido determinar o tipo do repositorio. Verifique se os URIs "
 "definidos (mire embaixo) apuntan a un repositorio correcto:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 "Non se puido atopar un repositorio correcto na localización proporcionada:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 "Problema óao transferir os datos do repositorio dende o URI especificado:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Verifique se o URI especificado é accesible."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Problema descoñecido ao engadir o repositorio:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Engadiuse con éxito o repositorio '%s'"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Lendo datos do soporte '%s'"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Problema óao ler datos do soporte '%s'"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Verifique se o soporte de instalación é correcto e lexible."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Lendo datos do soporte '%s'"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Problema óao ler datos do soporte '%s'"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Verifique se o soporte de instalación é correcto e lexible."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Problema ao acceder ao ficheiro do URI especificado"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Verifique se o URI é correcto e accesible."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Problema ao analizar o ficheiro no URI especificado"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "É un ficheiro .repo?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 "Atopouse un problema mentres se intentaba ler o ficheiro no URI especificado"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Atopouse un repositorio sen alias no ficheiro, saltando."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "O repositorio '%s' non ten definidio un URI, saltándoo."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Eliminouse o repositorio '%s'."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "A prioridade do repositorio '%s' deixouse sen cambios (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Activouse correctamente o repositorio '%s'."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Desactivouse correctamente o repositorio '%s'."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Activouse a actualización automatica do repositorio '%s'."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Desactivouse a actualización automatica do repositorio '%s'."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Activouse a caché de ficheiros RPM do repositorio '%s'."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Desactivouse a caché de ficheiros RPM do repositorio '%s'."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Activouse a comprobación GPG do repositorio '%s'."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Desactivouse a comprobación GPG do repositorio '%s'."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "A prioridade do repositorio '%s' estableceuse a %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "O nome do repositorio '%s' foi definido coma '%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Non hai nada que cambiar no repositorio '%s'."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Deixando sen cambios o repositorio %s."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Obtendo os datos do repositorio..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Obtendo datos do repositorio '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "O repositorio '%s' non está na caché. Poñendo na caché..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Problema ao cargar datos de '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
-msgstr "O repositorio '%s' non se pode actualizar. Empregando unha caché vella."
+msgstr ""
+"O repositorio '%s' non se pode actualizar. Empregando unha caché vella."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Non foron cargados os elementos de '%s' debido a un erro."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Probe '%s', ou incluso '%s' antes de facer iso."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6123,30 +6145,30 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Lendo os paquetes instalados..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr ""
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' parece un ficheiro RPM. Hase intentar descargalo."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Problema co ficheiro RPM especificado coma '%s', saltándoo."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Problema ó ler a cabeceira RPM de %s. É un ficheiro RPM?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Caché de ficheiros RPM"
 
@@ -6154,25 +6176,25 @@ msgstr "Caché de ficheiros RPM"
 msgid "System Packages"
 msgstr "Paquetes do sistema"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Non se atoparon parches necesarios."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Non se atoparon patróns."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Non se atoparon paquetes."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Nome interno"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Non se atoparon produtos."
 
@@ -6569,7 +6591,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Parches"
 
@@ -6594,7 +6616,7 @@ msgid "Needed software management updates will be installed first:"
 msgstr ""
 "Primeiro hanse instalar as seguintes actualizacións do xestor de software:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Non se atoparon actualizacións."
 
@@ -6603,46 +6625,46 @@ msgstr "Non se atoparon actualizacións."
 msgid "The following updates are also available:"
 msgstr "Tamén hai dispoñibles as seguintes actualizacións:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Actualizacións de paquetes"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Actualizacións de patróns"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Actualizacións de produtos"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Versión actual"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Versión dispoñible"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Non se atoparon problemas de coincidencias."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Atopáronse as seguintes coincidencias nos números de problema:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "Atopáronse coincidencias nos seguintes parches:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "Non se atopou ou non é necesario unha corrección para o informe Bugzilla "
 "número %s."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
@@ -6650,7 +6672,7 @@ msgstr ""
 "necesaria."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/gu.po
+++ b/po/gu.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nis\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Gujarati <https://l10n.opensuse.org/projects/zypper/master/gu/"
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "સ્થાપનની તૈયારી થઇ રહી છે..."
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "અનઅપેક્ષિત અપવાદ."
 
@@ -1396,12 +1396,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2119,24 +2119,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2206,7 +2212,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2392,22 +2398,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2458,49 +2464,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2604,11 +2614,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr " નામ "
 
@@ -2619,8 +2629,8 @@ msgstr "મળતા આવતાઓ"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr " પ્રકાર "
@@ -2628,7 +2638,7 @@ msgstr " પ્રકાર "
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr ""
@@ -3054,7 +3064,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "સર્વર"
@@ -3218,120 +3228,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3370,12 +3380,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3417,119 +3427,123 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr " સક્ષમ કરેલ "
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 #, fuzzy
 msgid "GPG Check"
 msgstr " DNS તપાસ"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 #, fuzzy
 msgid "Autorefresh"
 msgstr "સ્વયં તાજુ કરો"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 #, fuzzy
 msgid "On"
 msgstr "ના"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Keep Packages"
 msgstr "સિસ્ટમ વિસ્તારની વસ્તુઓ"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 #, fuzzy
 msgid "Path Prefix"
 msgstr "ડાયલ પ્રિફિક્સ "
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "સર્વર"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 #, fuzzy
 msgid "Error reading repositories:"
 msgstr "એરર એડિટીંગ ફોટો"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "લખવા માટે ફાઇલ ખોલી શકાતી નથી."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 #, fuzzy
 msgid "Maybe you do not have write permissions?"
 msgstr "પ્રમાણભૂત કરવા તમારી પાસે પરવાનગી નથી."
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3537,21 +3551,21 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "ફરીથી તાજુ કરો"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "સ્વયં તાજુ કરો"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3652,7 +3666,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 #, fuzzy
 msgid "Specified repositories: "
 msgstr "એરર એડિટીંગ ફોટો"
@@ -3662,7 +3676,7 @@ msgstr "એરર એડિટીંગ ફોટો"
 msgid "Refreshing repository '%s'."
 msgstr "સાધનો ઉમેરાય છે"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "સાધનો ઉમેરાય છે"
@@ -3672,7 +3686,7 @@ msgstr "સાધનો ઉમેરાય છે"
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3702,7 +3716,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "પસંદ કરેલ એન્ટ્રી દૂર કરી શકાઈ નહીં."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 #, fuzzy
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "પસંદ કરેલ એન્ટ્રી દૂર કરી શકાઈ નહીં."
@@ -3756,12 +3770,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, fuzzy, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "આ નામનું પ્લેલિસ્ટ તો છે જ. મહેરબાની કરીને કોઈ બીજું નામ આપો."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 #, fuzzy
 msgid "Error while modifying the repository:"
 msgstr "રિક્વેસ્ટ પાર્સ કરવામાં ભૂલ."
@@ -4194,27 +4208,27 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "સ્વયં તાજુ કરો"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "કોઇ પરિણામ મળ્યા નથી."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 #, fuzzy
 msgid "See the above message for a hint."
 msgstr "કૃપા કરીને ભૂલ સુધારો અને ફરીથી પ્રયત્ન કરો."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4305,7 +4319,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "એરર એડિટીંગ ફોટો"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, fuzzy, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "પસંદ કરેલ એન્ટ્રી દૂર કરી શકાઈ નહીં."
@@ -4325,21 +4339,25 @@ msgstr "%s દૂર કરવામાં નિષ્ફળ"
 msgid "Service '%s' has been removed."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5231,15 +5249,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr " આવૃત્તિ "
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr " આર્ક "
 
@@ -5377,13 +5395,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr " S "
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -5421,7 +5439,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5688,97 +5706,97 @@ msgstr[1] "સેવા ચાલુ નથી."
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, fuzzy, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "સાધનો ઉમેરાય છે"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "શું તમારે હમણા સિસ્ટમ શોભાવવા  માગો છે?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "સાધનો ઉમેરાય છે"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, fuzzy, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "%s માંથી પ્રોડક્ટ વંચાઇ રહી છે"
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 #, fuzzy
 msgid "Please see the above error message for a hint."
 msgstr "કૃપા કરીને ભૂલ સુધારો અને ફરીથી પ્રયત્ન કરો."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, fuzzy, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "%s: બે સબડોમેઈન ડિફાઈન થયેલ છે '%s' ને માટે.\n"
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 #, fuzzy
 msgid "No alias defined for this repository."
 msgstr "રિક્વેસ્ટ પાર્સ કરવામાં ભૂલ."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, fuzzy, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "એરર એડિટીંગ ફોટો"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 #, fuzzy
 msgid "Forcing building of repository cache"
 msgstr "CD મેટાડેટા શોધાય છે..."
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, fuzzy, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "એરર એડિટીંગ ફોટો"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5786,42 +5804,42 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, fuzzy, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 #, fuzzy
 msgid "Error building the cache:"
 msgstr "iPod ડેટાબેઝ બનાવવામાં ભૂલ થઈ છે"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "સાધનો ઉમેરાય છે"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, fuzzy, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "પસંદ કરેલ એન્ટ્રી દૂર કરી શકાઈ નહીં."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "સાધનો ઉમેરાય છે"
@@ -5829,310 +5847,310 @@ msgstr "સાધનો ઉમેરાય છે"
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "લક્ષ્યનો પ્રારંભ થઈ રહ્યા છે"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 #, fuzzy
 msgid "Target initialization failed:"
 msgstr "ઈનીશીયલાઈઝેશન નિષ્ફળ ગયું"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, fuzzy, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "એરર એડિટીંગ ફોટો"
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, fuzzy, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "એરર એડિટીંગ ફોટો"
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, fuzzy, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "એરર એડિટીંગ ફોટો"
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, fuzzy, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "%s માંથી પેકેજીસ વંચાઇ રહ્યા છે"
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, fuzzy, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "પસંદ કરેલ એન્ટ્રી દૂર કરી શકાઈ નહીં."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 #, fuzzy
 msgid "Cleaning installed packages cache."
 msgstr "પેકેજીસનું સ્થાપન દૂર કરવાનો આદેશ"
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 #, fuzzy
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "પસંદ કરેલ એન્ટ્રી દૂર કરી શકાઈ નહીં."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 #, fuzzy
 msgid "Could not clean the repositories because of errors."
 msgstr "પસંદ કરેલ એન્ટ્રી દૂર કરી શકાઈ નહીં."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 #, fuzzy
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "પસંદ કરેલ એન્ટ્રી દૂર કરી શકાઈ નહીં."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 #, fuzzy
 msgid "Specified repositories have been cleaned up."
 msgstr "એરર એડિટીંગ ફોટો"
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 #, fuzzy
 msgid "All repositories have been cleaned up."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, fuzzy, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "સાધનો ઉમેરાય છે"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 #, fuzzy
 msgid "Problem transferring repository data from specified URI:"
 msgstr "CD મેટાડેટા શોધાય છે..."
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 #, fuzzy
 msgid "Please check whether the specified URI is accessible."
 msgstr "સ્ક્રિપ્ટ ફાઈલ પ્રાપ્ત થાય તેમ નથી"
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 #, fuzzy
 msgid "Unknown problem when adding repository:"
 msgstr "CD મેટાડેટા શોધાય છે..."
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, fuzzy, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "%s માંથી પ્રોડક્ટ વંચાઇ રહી છે"
-
-#: src/repos.cc:1275
-#, fuzzy, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "%s માંથી પ્રોડક્ટ વંચાઇ રહી છે"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, fuzzy, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "%s માંથી પ્રોડક્ટ વંચાઇ રહી છે"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, fuzzy, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "%s માંથી પ્રોડક્ટ વંચાઇ રહી છે"
+
+#: src/repos.cc:1273
+#, fuzzy, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "%s માંથી પ્રોડક્ટ વંચાઇ રહી છે"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 #, fuzzy
 msgid "Problem accessing the file at the specified URI"
 msgstr "CD મેટાડેટા શોધાય છે..."
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 #, fuzzy
 msgid "Please check if the URI is valid and accessible."
 msgstr "સ્ક્રિપ્ટ ફાઈલ પ્રાપ્ત થાય તેમ નથી"
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 #, fuzzy
 msgid "Problem parsing the file at the specified URI"
 msgstr "CD મેટાડેટા શોધાય છે..."
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 #, fuzzy
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "CD મેટાડેટા શોધાય છે..."
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 #, fuzzy
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "સેવા ચાલુ નથી."
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "સાધનો ઉમેરાય છે"
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "સાધનો ઉમેરાય છે"
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "સાધનો ઉમેરાય છે"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "સાધનો ઉમેરાય છે"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, fuzzy, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, fuzzy, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "સાધનો ઉમેરાય છે"
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, fuzzy, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "સાધનો ઉમેરાય છે"
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 #, fuzzy
 msgid "Loading repository data..."
 msgstr "સાધનો ઉમેરાય છે"
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "સાધનો ઉમેરાય છે"
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, fuzzy, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "%s માંથી પ્રોડક્ટ વંચાઇ રહી છે"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "સેવા ચાલુ નથી."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6140,32 +6158,32 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "પેકેજીસનું સ્થાપન દૂર કરવાનો આદેશ"
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "સ્થાપન સ્ત્રોતમાંથી વાંચતી વખતે ભૂલ થઇ."
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6174,28 +6192,28 @@ msgstr ""
 msgid "System Packages"
 msgstr "સિસ્ટમ વિસ્તારની વસ્તુઓ"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 #, fuzzy
 msgid "No patterns found."
 msgstr "કોઇ પરિણામ મળ્યા નથી."
 
-#: src/search.cc:450
+#: src/search.cc:453
 #, fuzzy
 msgid "No packages found."
 msgstr "કોઇ પરિણામ મળ્યા નથી."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "આંતરિક ભૂલ"
 
-#: src/search.cc:544
+#: src/search.cc:549
 #, fuzzy
 msgid "No products found."
 msgstr "કોઇ પરિણામ મળ્યા નથી."
@@ -6584,7 +6602,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 #, fuzzy
 msgid "Patches"
 msgstr "મળતા આવતાઓ"
@@ -6609,7 +6627,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "આ પેકેજીસની સ્થાપના કરવી જરુરી છે."
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 #, fuzzy
 msgid "No updates found."
 msgstr "કોઇ પરિણામ મળ્યા નથી."
@@ -6620,56 +6638,56 @@ msgstr "કોઇ પરિણામ મળ્યા નથી."
 msgid "The following updates are also available:"
 msgstr "નીચે પ્રમાણેના સ્ત્રોતો સુધાર્યા છે"
 
-#: src/update.cc:700
+#: src/update.cc:707
 #, fuzzy
 msgid "Package updates"
 msgstr "પેકેજરનું નામ : %1"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr ""
 
-#: src/update.cc:706
+#: src/update.cc:713
 #, fuzzy
 msgid "Product updates"
 msgstr "પ્રોડક્ટનું પુનરાવર્તન"
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "અત્યારનું જોડાણ"
 
-#: src/update.cc:795
+#: src/update.cc:801
 #, fuzzy
 msgid "Available Version"
 msgstr "ઉપલબ્ધ મેમરી"
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "કોઇ પરિણામ મળ્યા નથી."
 
-#: src/update.cc:978
+#: src/update.cc:986
 #, fuzzy
 msgid "The following matches in issue numbers have been found:"
 msgstr " નીચેના vpnc VPN જોડાણ બનાવાશે:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -8,11 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Hebrew <https://l10n.opensuse.org/projects/zypper/master/he/>"
-"\n"
+"Language-Team: Hebrew <https://l10n.opensuse.org/projects/zypper/master/he/"
+">\n"
 "Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1384,7 +1384,7 @@ msgstr ""
 msgid "Try again?"
 msgstr ""
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr ""
 
@@ -1412,12 +1412,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2116,24 +2116,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2203,7 +2209,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2386,22 +2392,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2452,49 +2458,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2597,11 +2607,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "שם"
 
@@ -2612,8 +2622,8 @@ msgstr ""
 #  Column header
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "סוג"
@@ -2621,7 +2631,7 @@ msgstr "סוג"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr ""
@@ -3043,7 +3053,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "שרת"
@@ -3204,120 +3214,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3356,12 +3366,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3403,113 +3413,117 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr ""
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr ""
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 #, fuzzy
 msgid "On"
 msgstr "עומן"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr ""
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "שרת"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr ""
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Can't run %s.  Exiting."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3517,20 +3531,20 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr ""
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr ""
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3631,7 +3645,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr ""
 
@@ -3640,7 +3654,7 @@ msgstr ""
 msgid "Refreshing repository '%s'."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr ""
@@ -3650,7 +3664,7 @@ msgstr ""
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3677,7 +3691,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3730,12 +3744,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr ""
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr ""
 
@@ -4161,25 +4175,25 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr ""
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr ""
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4269,7 +4283,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr ""
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4288,21 +4302,25 @@ msgstr ""
 msgid "Service '%s' has been removed."
 msgstr ""
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5187,15 +5205,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "גרסה"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr ""
 
@@ -5338,13 +5356,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr ""
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5642,94 +5660,94 @@ msgstr[1] "גרסה"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr ""
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr ""
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr ""
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr ""
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr ""
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr ""
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr ""
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr ""
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr ""
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr ""
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5737,41 +5755,41 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr ""
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr ""
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr ""
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr ""
@@ -5779,294 +5797,294 @@ msgstr ""
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr ""
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr ""
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr ""
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr ""
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr ""
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr ""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr ""
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr ""
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr ""
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr ""
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr ""
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr ""
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr ""
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr ""
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr ""
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr ""
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6074,30 +6092,30 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr ""
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr ""
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6105,27 +6123,27 @@ msgstr ""
 msgid "System Packages"
 msgstr ""
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr ""
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr ""
 
 #  table header texts
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "שם"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr ""
 
@@ -6496,7 +6514,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr ""
 
@@ -6519,7 +6537,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr ""
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr ""
 
@@ -6528,51 +6546,51 @@ msgstr ""
 msgid "The following updates are also available:"
 msgstr ""
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr ""
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr ""
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "גרסה"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr ""
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr ""
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper.hi\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Hindi <https://l10n.opensuse.org/projects/zypper/master/hi/>\n"
@@ -1369,7 +1369,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "इंस्टालेशन की तैयारी कर रहा है..."
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr ""
 
@@ -1397,12 +1397,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2120,24 +2120,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2207,7 +2213,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2393,22 +2399,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2459,49 +2465,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2605,11 +2615,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "नाम"
 
@@ -2620,8 +2630,8 @@ msgstr "पैच"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "प्रकार"
@@ -2629,7 +2639,7 @@ msgstr "प्रकार"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "भंडार"
@@ -3058,7 +3068,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "सेवक"
@@ -3222,120 +3232,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3375,12 +3385,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3422,118 +3432,122 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "एलियास"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "समर्थ हैं"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 #, fuzzy
 msgid "GPG Check"
 msgstr "DNS जांच"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 #, fuzzy
 msgid "Autorefresh"
 msgstr "स्वत: रीफ्रेश"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 #, fuzzy
 msgid "On"
 msgstr "n"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "बंद"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Keep Packages"
 msgstr "सिस्टम क्षेत्र के मद"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 #, fuzzy
 msgid "Path Prefix"
 msgstr "डायल प्रत्यय"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "सेवक"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 #, fuzzy
 msgid "Error reading repositories:"
 msgstr "संसाधन जोड़ रहा"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "लेखन के लिए फाइल नहीं खोल सकता है।"
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3541,21 +3555,21 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "रीफ्रेश"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "स्वत: रीफ्रेश"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3656,7 +3670,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 #, fuzzy
 msgid "Specified repositories: "
 msgstr "संसाधन जोड़ रहा"
@@ -3666,7 +3680,7 @@ msgstr "संसाधन जोड़ रहा"
 msgid "Refreshing repository '%s'."
 msgstr "संसाधन जोड़ रहा"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "संसाधन जोड़ रहा"
@@ -3676,7 +3690,7 @@ msgstr "संसाधन जोड़ रहा"
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3706,7 +3720,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "चयनित प्रविष्टि को नहीं हटा सका।"
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 #, fuzzy
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "चयनित प्रविष्टि को नहीं हटा सका।"
@@ -3760,12 +3774,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 #, fuzzy
 msgid "Error while modifying the repository:"
 msgstr "अनुरोध को पार्जिंग करते समय त्रुटि।"
@@ -4198,26 +4212,26 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "स्वत: रीफ्रेश"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "अद्यतन पता नहीं"
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4308,7 +4322,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "संसाधन जोड़ रहा"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, fuzzy, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "चयनित प्रविष्टि को नहीं हटा सका।"
@@ -4328,21 +4342,25 @@ msgstr "हटा रहा है"
 msgid "Service '%s' has been removed."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5234,15 +5252,15 @@ msgstr "%s को %s की आवश्यकता है"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "वरजन"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "आर्क"
 
@@ -5379,13 +5397,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 #, fuzzy
 msgid "Dependency"
 msgstr "निर्भरताऐ"
@@ -5424,7 +5442,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5686,96 +5704,96 @@ msgstr[1] "भंडार"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, fuzzy, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "संसाधन जोड़ रहा"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "क्या अब आप सिस्टम को रोकना चाहते हैं?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "संसाधन जोड़ रहा"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, fuzzy, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "%s से उत्पाद को पढ़ रहा है"
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, fuzzy, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "अनुरोध को पार्जिंग करते समय त्रुटि।"
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 #, fuzzy
 msgid "No alias defined for this repository."
 msgstr "अनुरोध को पार्जिंग करते समय त्रुटि।"
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, fuzzy, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "%s से उत्पाद को पढ़ रहा है"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 #, fuzzy
 msgid "Forcing building of repository cache"
 msgstr "संसाधन डेटाबेस सृजित कर रहा"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, fuzzy, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "%s से उत्पाद को पढ़ रहा है"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5783,42 +5801,42 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, fuzzy, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 #, fuzzy
 msgid "Error building the cache:"
 msgstr "प्रमाण पत्र को पार्जिंग करते समय त्रुटि।"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "संसाधन जोड़ रहा"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, fuzzy, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "चयनित प्रविष्टि को नहीं हटा सका।"
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "संसाधन जोड़ रहा"
@@ -5826,308 +5844,308 @@ msgstr "संसाधन जोड़ रहा"
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "इनीशियलाईजिंग..."
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 #, fuzzy
 msgid "Target initialization failed:"
 msgstr " शुरूआत शुरू "
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, fuzzy, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "%s से उत्पाद को पढ़ रहा है"
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, fuzzy, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "%s से उत्पाद को पढ़ रहा है"
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, fuzzy, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "%s से उत्पाद को पढ़ रहा है"
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, fuzzy, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "%s से पैकेजों को पढ़ रहा है"
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, fuzzy, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "चयनित प्रविष्टि को नहीं हटा सका।"
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 #, fuzzy
 msgid "Cleaning installed packages cache."
 msgstr "पैकेजस इसंटाल करो"
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 #, fuzzy
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "चयनित प्रविष्टि को नहीं हटा सका।"
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 #, fuzzy
 msgid "Could not clean the repositories because of errors."
 msgstr "चयनित प्रविष्टि को नहीं हटा सका।"
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 #, fuzzy
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "चयनित प्रविष्टि को नहीं हटा सका।"
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 #, fuzzy
 msgid "Specified repositories have been cleaned up."
 msgstr "संसाधन जोड़ रहा"
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 #, fuzzy
 msgid "All repositories have been cleaned up."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, fuzzy, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "संसाधन जोड़ रहा"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 #, fuzzy
 msgid "Please check whether the specified URI is accessible."
 msgstr "स्क्रिप्ट फाइल एक्सेस योग्य नहीं है"
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 #, fuzzy
 msgid "Unknown problem when adding repository:"
 msgstr "संसाधन जोड़ रहा"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, fuzzy, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "%s से उत्पाद को पढ़ रहा है"
-
-#: src/repos.cc:1275
-#, fuzzy, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "%s से उत्पाद को पढ़ रहा है"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, fuzzy, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "%s से उत्पाद को पढ़ रहा है"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, fuzzy, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "%s से उत्पाद को पढ़ रहा है"
+
+#: src/repos.cc:1273
+#, fuzzy, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "%s से उत्पाद को पढ़ रहा है"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 #, fuzzy
 msgid "Problem accessing the file at the specified URI"
 msgstr "%s से उत्पाद को पढ़ रहा है"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 #, fuzzy
 msgid "Please check if the URI is valid and accessible."
 msgstr "स्क्रिप्ट फाइल एक्सेस योग्य नहीं है"
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 #, fuzzy
 msgid "Problem parsing the file at the specified URI"
 msgstr "%s से उत्पाद को पढ़ रहा है"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 #, fuzzy
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "संसाधन जोड़ रहा"
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "संसाधन जोड़ रहा"
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "संसाधन जोड़ रहा"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "संसाधन जोड़ रहा"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, fuzzy, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, fuzzy, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "संसाधन जोड़ रहा"
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, fuzzy, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "संसाधन जोड़ रहा"
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 #, fuzzy
 msgid "Loading repository data..."
 msgstr "संसाधन जोड़ रहा"
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "संसाधन जोड़ रहा"
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, fuzzy, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "%s से उत्पाद को पढ़ रहा है"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "निर्दिष्ट स्कीम AC नहीं मिली."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6135,32 +6153,32 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "पैकेजस इसंटाल करो"
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "पैकेजस इसंटाल करो"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6169,28 +6187,28 @@ msgstr ""
 msgid "System Packages"
 msgstr "सिस्टम क्षेत्र के मद"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 #, fuzzy
 msgid "No patterns found."
 msgstr "अद्यतन पता नहीं"
 
-#: src/search.cc:450
+#: src/search.cc:453
 #, fuzzy
 msgid "No packages found."
 msgstr "अद्यतन पता नहीं"
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "आंतरिक त्रुटि"
 
-#: src/search.cc:544
+#: src/search.cc:549
 #, fuzzy
 msgid "No products found."
 msgstr "अद्यतन पता नहीं"
@@ -6575,7 +6593,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 #, fuzzy
 msgid "Patches"
 msgstr "पैच"
@@ -6600,7 +6618,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "निम्नांकित vpnc VPN संबंधन बनायी जाएगी:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "अद्यतन पता नहीं"
 
@@ -6610,57 +6628,57 @@ msgstr "अद्यतन पता नहीं"
 msgid "The following updates are also available:"
 msgstr "निम्नलिखित संसाधन संशोधित है"
 
-#: src/update.cc:700
+#: src/update.cc:707
 #, fuzzy
 msgid "Package updates"
 msgstr "पैकेज"
 
-#: src/update.cc:704
+#: src/update.cc:711
 #, fuzzy
 msgid "Pattern updates"
 msgstr "स्थिती"
 
-#: src/update.cc:706
+#: src/update.cc:713
 #, fuzzy
 msgid "Product updates"
 msgstr "उत्पाद पुनरीक्षण"
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "वर्तमान कनेक्शन"
 
-#: src/update.cc:795
+#: src/update.cc:801
 #, fuzzy
 msgid "Available Version"
 msgstr "उपलब्ध स्थान"
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "अद्यतन पता नहीं"
 
-#: src/update.cc:978
+#: src/update.cc:986
 #, fuzzy
 msgid "The following matches in issue numbers have been found:"
 msgstr "निम्नांकित vpnc VPN संबंधन बनायी जाएगी:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Croatian <https://l10n.opensuse.org/projects/zypper/master/hr/"
@@ -1444,7 +1444,7 @@ msgstr ""
 msgid "Try again?"
 msgstr ""
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Neočekivana iznimka."
 
@@ -1472,12 +1472,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Izbor %s ovdje nema učinka, ignoriram."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2178,24 +2178,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2265,7 +2271,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2447,22 +2453,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2513,49 +2519,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2659,11 +2669,11 @@ msgstr[2] "Uklonjeni paketi"
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Ime"
 
@@ -2674,8 +2684,8 @@ msgstr "Zakrpe"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Vrsta"
@@ -2683,7 +2693,7 @@ msgstr "Vrsta"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Repozitorij"
@@ -3103,7 +3113,7 @@ msgid "Command"
 msgstr "Naredba"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Servis"
 
@@ -3264,120 +3274,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3417,12 +3427,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3464,113 +3474,117 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Omogućeno"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "DNS provjera"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Prioritet"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Automatski osvježi"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 #, fuzzy
 msgid "On"
 msgstr "Oman"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Off"
 msgstr "Ured"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Zadrži pakete"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Roditeljski servis"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Greška kod učitavanja repozitorija:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Ne mogu otvoriti %s za čitanje."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3578,21 +3592,21 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Osvježi"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "Nije pronađen niti jedan repozotorij."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3693,7 +3707,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Navedeni repozitoriji: "
 
@@ -3702,7 +3716,7 @@ msgstr "Navedeni repozitoriji: "
 msgid "Refreshing repository '%s'."
 msgstr "Onemogućujem repozitorij '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Preskačem onemogućeni direktorij '%s'"
@@ -3712,7 +3726,7 @@ msgstr "Preskačem onemogućeni direktorij '%s'"
 msgid "Skipping disabled repository '%s'"
 msgstr "Preskačem onemogućeni direktorij '%s'"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3740,7 +3754,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "Ne mogu osvježiti repozitorije zbog grešaka."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Neki repozitoriji nisu osvježeni zbog greške."
 
@@ -3793,12 +3807,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr ""
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr ""
 
@@ -4230,26 +4244,26 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Navedeni repozitoriji: "
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "Niti jedan paket nije pronađen."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4339,7 +4353,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr ""
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4358,21 +4372,25 @@ msgstr "Uklanjam servis '%s':"
 msgid "Service '%s' has been removed."
 msgstr "Servis '%s' je uklonjen."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5257,15 +5275,15 @@ msgstr "%s je starije nego %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Verzija"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arhitektura"
 
@@ -5402,13 +5420,13 @@ msgstr "(prazno)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Ovisnosti"
 
@@ -5446,7 +5464,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5706,94 +5724,94 @@ msgstr[2] "Repozitorij"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Repozitorij '%s' je ažuran."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr ""
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr ""
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Da li zaista želite koristiti ovu putanju?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Onemogućujem repozitorij '%s'."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr ""
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Niti jedan URI nije definiran za '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Niti jedan alias nije definiran za ovaj repozitorij."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Repozitorij '%s' je neispravan."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr ""
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5801,41 +5819,41 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr ""
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Preskačem onemogućeni direktorij '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr ""
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Onemogućujem repozitorij '%s'."
@@ -5843,296 +5861,296 @@ msgstr "Onemogućujem repozitorij '%s'."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Repozitorij '%s' je neispravan."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Inicijaliziram metu"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Inicijalizacija mete nije uspjela:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr ""
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Čistim pakete za '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Ne mogu očistiti repozitorij '%s' zbog greške."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr ""
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Neki repozitoriji nisu očišćeni zbog greške."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Navedeni repozitoriji su očišćeni."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Svi repozitoriji su očišćeni."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, fuzzy, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Onemogućujem repozitorij '%s'."
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr ""
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Repozitorij '%s' je uspješno dodan"
 
-#: src/repos.cc:1269
+#: src/repos.cc:1262
+#, fuzzy, c-format, boost-format
+msgid "Reading data from '%s' media is delayed until next refresh."
+msgstr "Čitam podatke s '%s' medija"
+
+#: src/repos.cc:1267
 #, c-format, boost-format
 msgid "Reading data from '%s' media"
 msgstr "Čitam podatke s '%s' medija"
 
-#: src/repos.cc:1275
+#: src/repos.cc:1273
 #, c-format, boost-format
 msgid "Problem reading data from '%s' media"
 msgstr "Problem kod učitavanja podataka s '%s' medija"
 
-#: src/repos.cc:1276
+#: src/repos.cc:1274
 msgid "Please check if your installation media is valid and readable."
 msgstr ""
 "Molimo vas da provjerite da li je instalacijski medij ispravan i može li se "
 "s njega čitati."
 
-#: src/repos.cc:1283
-#, fuzzy, c-format, boost-format
-msgid "Reading data from '%s' media is delayed until next refresh."
-msgstr "Čitam podatke s '%s' medija"
-
-#: src/repos.cc:1352
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr ""
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr ""
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr ""
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr ""
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Preskačem onemogućeni direktorij '%s'"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Preskačem onemogućeni direktorij '%s'"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr ""
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr ""
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr ""
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Učitavam podatke repozitorija..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Dohvaćam podatke repozitorija '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Dogodio se problem prilikom učitavanja podataka s '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6140,31 +6158,31 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Učitavam instalirane pakete..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Dogodila se greška prilikom čitanja instaliranih paketa:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6172,25 +6190,25 @@ msgstr ""
 msgid "System Packages"
 msgstr "Sistemski paketi"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Niti jedan uzorak nije pronađen."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Niti jedan paket nije pronađen."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Interno ime"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Niti jedan proizvod nije pronađen."
 
@@ -6572,7 +6590,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Zakrpe"
 
@@ -6596,7 +6614,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "Slijedeći paketi će biti skinuti:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Niti jedna zakrpa nije pronađena."
 
@@ -6605,51 +6623,51 @@ msgstr "Niti jedna zakrpa nije pronađena."
 msgid "The following updates are also available:"
 msgstr ""
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Dogradnje paketa"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Dogradnje uzoraka"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Dogradnje proizvoda"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "trenutna verzija"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Dostupna verzija"
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "Niti jedan paket nije pronađen."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper.hu\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Hungarian <https://l10n.opensuse.org/projects/zypper/master/"
@@ -918,7 +918,8 @@ msgid "The following recommended source package was automatically selected:"
 msgid_plural ""
 "The following %d recommended source packages were automatically selected:"
 msgstr[0] "A következő javasolt forráscsomag lett automatikusan kiválasztva:"
-msgstr[1] "A következő %d javasolt forráscsomag lett automatikusan kiválasztva:"
+msgstr[1] ""
+"A következő %d javasolt forráscsomag lett automatikusan kiválasztva:"
 
 #: src/Summary.cc:1100
 #, c-format, boost-format
@@ -1155,7 +1156,8 @@ msgid ""
 msgid_plural ""
 "The following %d packages were discontinued and have been superseded by a "
 "new packages with different names."
-msgstr[0] "A következő csomag megszűnt, és egy új, más nevű csomag váltotta fel."
+msgstr[0] ""
+"A következő csomag megszűnt, és egy új, más nevű csomag váltotta fel."
 msgstr[1] ""
 "A következő %d csomag megszűnt, és egy új, különböző nevű csomagok váltották "
 "fel őket."
@@ -1446,7 +1448,7 @@ msgstr "A PAckageKit még fut (valószínűleg művelet hajt végre)."
 msgid "Try again?"
 msgstr "Megpróbálja újra?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Váratlan kivétel."
 
@@ -1478,12 +1480,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Az %s kapcsolónak itt nincs szerepe, ezért figyelmen kívül marad."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Nem kapcsoló jellegű paraméterek: "
 
@@ -1598,7 +1600,8 @@ msgstr "A(z) %s aláírás nélküli fájl elfogadása."
 #: src/callbacks/keyring.h:156
 #, c-format, boost-format
 msgid "Accepting an unsigned file '%s' from repository '%s'."
-msgstr "A(z) %s aláírás nélküli fájl elfogadása a(z) '%s' telepítési forrásból."
+msgstr ""
+"A(z) %s aláírás nélküli fájl elfogadása a(z) '%s' telepítési forrásból."
 
 #. translator: %1% is a file name
 #: src/callbacks/keyring.h:166
@@ -2224,17 +2227,17 @@ msgid "Commands:"
 msgstr "Parancsok:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "A részletes telepítési összefoglaló megjelenítése."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "A feloldható típusa (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2242,11 +2245,17 @@ msgstr ""
 "A 'best effort' felhasználása a frissítéshez, amely elfogadja a legfrissebb "
 "verziónál régebbiek telepítését is."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr ""
 "Csak olyan javításokat célszerű választania, amelyek magára a "
 "csomagkezelésre vonatkoznak."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2325,7 +2334,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <alparancs> [--parancsbeállítások] [argumentumok]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Segítség megjelenítése"
 
@@ -2536,22 +2545,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [kapcsolók]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Minden alkalmazható csomag listázása."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Minden javítás felsorolása (nem csak az alkalmazható javításoké)."
 
@@ -2608,37 +2617,41 @@ msgstr ""
 "elérhető kódok listája a(z) '%s' hívásával kérhető le."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [kapcsolók] [területi beállítás] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "A kért területi beállítások (nyelvi kódok) felsorolása."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "A kért területi beállítások és a megfelelő csomagok felsorolása."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "A megfelelő csomagok megjelenítése."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Az összes elérhető területi beállítás listázása."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 "A pozícióra vonatkozó argumentumok kihagyása, mivel meg lett adva az --all "
 "argumentum."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "A területi beállítások, amelyek adatait ki kell nyomtatni."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2646,17 +2659,17 @@ msgstr ""
 "Az 'en' nyelvi kóddal rendelkező összes olyan területi beállítás lekérése, "
 "amelyhez saját országkód tartozik, a tartalék 'en' kivételével:"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 "Az 'en' nyelvi kóddal rendelkező összes területi beállítás lekérése, "
 "országkóddal vagy országkód nélkül:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "Az argumentumnak pontosan megfelelő területi beállítás lekérése: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "A 'de' és az 'en' kódhoz elérhető csomagok listájának lekérése:"
 
@@ -2763,11 +2776,11 @@ msgstr[1] "%lu zárolás eltávolítva."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Név"
 
@@ -2777,8 +2790,8 @@ msgstr "Megfelelések"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Típus"
@@ -2786,7 +2799,7 @@ msgstr "Típus"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Telepítési forrás"
@@ -3058,8 +3071,8 @@ msgid ""
 "download-as-needed disables the fileconflict check."
 msgstr ""
 "A csomagok telepítése akkor is, ha lecserélik más, már telepített csomagok "
-"fájljait. Az alapértelmezés a fájlütközések hibaként történő kezelése. A "
-"--download-as-needed kapcsoló kikapcsolja a fájlütközések ellenőrzését."
+"fájljait. Az alapértelmezés a fájlütközések hibaként történő kezelése. A --"
+"download-as-needed kapcsoló kikapcsolja a fájlütközések ellenőrzését."
 
 #. translators: -y, --no-confirm
 #: src/commands/optionsets.cc:291
@@ -3242,7 +3255,7 @@ msgid "Command"
 msgstr "Parancs"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Szolgáltatás"
 
@@ -3412,121 +3425,121 @@ msgid "Show detailed information for products."
 msgstr "Termékek részletes információinak megjelenítése."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [kapcsolók] [telepítési forrás] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Elérhető csomagok listázása."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "A megadott telepítési forrásokban elérhető összes csomag listázása."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "A javasolt csomagok megjelenítése."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Az ajánlott csomagok megjelenítése."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "A nem szükséges csomagok megjelenítése."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "A lista rendezése a csomagok neve szerint."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "A lista rendezése telepítési forrás szerint."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [telepítési forrás] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Elérhető javítások listázása."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Elérhető frissítések listázása a megadott telepítési forrásból."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [kapcsolók] [telepítési forrás] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Elérhető minták listázása."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Az adott telepítési forrásokban elérhető összes minta listázása."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [kapcsolók] [telepítési forrás] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Elérhető termékek listázása."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Az adott telepítési forrásokban elérhető összes termék listázása."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Csak XML-kimenet: A termékfájlban talált XML-címkék szó szerinti továbbítása."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "A(z) %1% kapcsolónak nincs hatása a(z) %2% globális kapcsoló nélkül."
@@ -3570,12 +3583,12 @@ msgstr ""
 "A telepítési forrás típusának felismerése mindig automatikusan történik. Ez "
 "a kapcsoló figyelmen kívül lesz hagyva."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "A %s nem használható együtt a %s -el. A %s beállításainak használata."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3621,113 +3634,117 @@ msgstr "Raw metaadat-gyorsítótár törlése."
 msgid "Clean both metadata and package caches."
 msgstr "metaadat és a csomag-gyorsítótár törlése."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Álnév"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Bekapcsolva"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "GPG-ellenőrzés"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Prioritás"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Automatikus frissítés"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Be"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Kikapcsolva"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Csomagok megőrzése"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "GPG-kulcs URI"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Elérési út prefixum"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Szűlő szolgáltatás"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Kulcsszavak"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Telepítési forrás adatainak elérési útvonala"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "MD gyorsítótár elérési útja"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [kapcsolók] [telepítési forrás] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Az összes definiált telepítési forrás listázása."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 "Az összes definiált telepítési forrás exportálása egyetlen helyi .repo "
 "fájlként."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Hiba a telepítési forrás olvasásakor:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "A %s fájl nem nyitható meg írásra."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Ellenőrizze, hogy van-e írásjoga."
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "A(z) %s telepítési forrás exportálása sikeres."
@@ -3735,20 +3752,20 @@ msgstr "A(z) %s telepítési forrás exportálása sikeres."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Frissítés"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Nincs megadott telepítési forrás."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 "A 'zypper addrepo' parancs használatával adjon meg egy vagy több telepítési "
@@ -3856,7 +3873,7 @@ msgstr "Az '%s' kapcsolónak itt nincs szerepe, ezért figyelmen kívül marad."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "A(z) '%s' használata esetén a kapcsolók használata nem megengedett."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Megadott telepítési forrás: "
 
@@ -3865,7 +3882,7 @@ msgstr "Megadott telepítési forrás: "
 msgid "Refreshing repository '%s'."
 msgstr "A(z) '%s' telepítési forrás frissítése."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "A letiltott '%s' telepítési forrás tartalmának vizsgálata."
@@ -3875,7 +3892,7 @@ msgstr "A letiltott '%s' telepítési forrás tartalmának vizsgálata."
 msgid "Skipping disabled repository '%s'"
 msgstr "A letiltott '%s' telepítési forrás kihagyása"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "A jelzett hiba miatt a(z) %s telepítési forrás kihagyása."
@@ -3906,7 +3923,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "A jelzett hiba miatt a telepítési forrás frissítése sikertelen."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Hiba miatt néhány telepítési forrás nem került frissítésre."
 
@@ -3965,13 +3982,13 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "A(z) '%s' telepítési forrás átnevezése megtörtént. Az új neve '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 "Ilyen nevű ('%s') telepítési forrás már létezik. Adjon egy másik álnevet."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Hiba a telepítési forrás módosítása közben:"
 
@@ -3992,7 +4009,8 @@ msgstr "Megadott forrás átnevezése."
 #. translators: command description
 #: src/commands/repos/rename.cc:67
 msgid "Assign new alias to the repository specified by alias, number or URI."
-msgstr "Új álnév társítása az álnév, sorszám vagy URI által megadott forráshoz."
+msgstr ""
+"Új álnév társítása az álnév, sorszám vagy URI által megadott forráshoz."
 
 #: src/commands/repos/rename.cc:92
 msgid "Too few arguments. At least URI and alias are required."
@@ -4426,25 +4444,25 @@ msgstr ""
 "A --details beállításhoz hasonlóan, további információkkal, ha találat "
 "lelhető fel (függőségekben való kereséshez hasznos)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "A megadott '%s' telepítési forrás le van tiltva."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Nem találhatók megfelelő elemek."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Probléma történt a keresés előkészítése vagy végrehajtásakor"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Tekintse meg a fent található hibaüzenetet."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 "A 'zypper refresh' root felhasználóként való futtatása megoldhatja a "
@@ -4538,7 +4556,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "A(z) '%s' szolgáltatás jegyzékének lekérdezése sikertelen:"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "A jelzett hiba miatt a(z) %s szolgáltatás kihagyása."
@@ -4557,24 +4575,28 @@ msgstr "A(z) '%s' szolgáltatás eltávolítása:"
 msgid "Service '%s' has been removed."
 msgstr "A(z) '%s' szolgáltatás eltávolítása megtörtént."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [kapcsolók]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Összes szolgáltatás listázása."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "A definiált szolgáltatások felsorolása."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Nincs megadva szolgáltatás. Használja a '%s' parancsot egy vagy több "
 "szolgáltatás hozzáadásához."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5078,7 +5100,8 @@ msgstr "A Zypper elérhető alparancsai a következőben: '%1%'"
 #. translators: headline of an enumeration
 #: src/commands/subcommand.cc:475
 msgid "Zypper subcommands available from elsewhere on your $PATH"
-msgstr "A Zypper elérhető alparancsai más, a $PATH változóban megadott helyeken"
+msgstr ""
+"A Zypper elérhető alparancsai más, a $PATH változóban megadott helyeken"
 
 #: src/commands/subcommand.cc:480
 msgid ""
@@ -5376,7 +5399,8 @@ msgstr "Szükséges telepítési források letöltése..."
 #: src/commands/utils/source-download.cc:428
 #, c-format, boost-format
 msgid "Source package '%s' is not provided by any repository."
-msgstr "A(z) '%s' forráscsomag nem található egyetlen telepítési forrásban sem."
+msgstr ""
+"A(z) '%s' forráscsomag nem található egyetlen telepítési forrásban sem."
 
 #: src/commands/utils/source-download.cc:446
 #: src/commands/utils/source-download.cc:460
@@ -5515,15 +5539,15 @@ msgstr "%s régebbi, mint %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Verzió"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Architektúra"
 
@@ -5660,14 +5684,14 @@ msgstr "(üres)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 # clients/inst_sw_single.ycp:705
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Függőség"
 
@@ -5704,7 +5728,7 @@ msgid "Flavor"
 msgstr "Ízesítés"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Alap"
 
@@ -5970,57 +5994,57 @@ msgstr[1] "Telepítési forrás"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "A(z) %s frissített metaadatainak keresése"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "A(z) %s telepítési forrás naprakész."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "A(z) '%s' telepítési forrás állapotellenőrzése késleltetve."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Nyers metaadatok frissítésének kikényszerítése"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "A(z) %s telepítési forrás adatainak beolvasása"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Végleg letiltja a(z) %s telepítési forrást?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Hiba történt a(z) '%s' telepítési forrás letiltásakor."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Hiba történt a fájlok letöltésekor a következő helyről: '%s'."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Tekintse meg a fent található hibaüzenetet javaslatért."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Nincs megadva URI a következőhöz: '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -6029,38 +6053,38 @@ msgstr ""
 "Adjon meg egy vagy több URI-t (baseurl=URI) a(z) %s útvonalhoz a következő "
 "telepítési forráshoz: '%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Ehhez a telepítési forráshoz nincs álnév megadva."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "A(z) %s telepítési forrás nem érvényes."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 "Ellenőrizze, hogy a telepítési forráshoz megadott URI megfelelő helyre mutat."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Hiba történt a(z) '%s' metaadatainak feldolgozása közben:"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Telepítési forrás gyorsítótárának felépítésének kikényszerítése"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Hiba történt a(z) '%s' metaadatainak feldolgozása közben:"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6071,46 +6095,47 @@ msgstr ""
 "metaadat-feldolgozó kódban. Amennyiben úgy gondolja jelentse be a hibát a "
 "http://hu.opensuse.org/Zypper oldalon leírtaknak megfelelően"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 "A(z) %s telepítési forrás metaadata nem található a helyi gyorsítótárban."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Hiba történt a gyorsítótár adatbázisának felépítése közben:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 "A(z) '%s' telepítési forrás nem található az álneve száma vagy az URI "
 "alapján."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
-msgstr "A beállított telepítési források listájához használja a '%s' parancsot."
+msgstr ""
+"A beállított telepítési források listájához használja a '%s' parancsot."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "A letiltott '%s' telepítési forrás kihagyása"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "A telepítési források ideiglenes engedélyezéséhez használhatja a globális "
 "'%s' opciót."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "A(z) %s telepítési forrás figyelmen kívül hagyása '%s' kapcsoló miatt."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "A(z) '%s' telepítési forrás ideiglenes engedélyezése."
@@ -6118,7 +6143,7 @@ msgstr "A(z) '%s' telepítési forrás ideiglenes engedélyezése."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6127,7 +6152,7 @@ msgstr ""
 "A(z) '%s' telepítési forrás nem naprakész, frissítéséhez rendszergazdaként "
 "futtathatja a  'zypper refresh' parancsot."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6136,81 +6161,81 @@ msgstr ""
 "A gyorsítótár adatbázisát a(z) '%s' telepítési forráshoz újra kell építeni. "
 "Ennek érdekében rendszergazdaként futtathatja a 'zypper refresh' parancsot."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "A(z) '%s' telepítési forrás letiltva marad."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Cél inicializálása"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "A cél inicializálása meghiúsult:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "A '%s' telepítési forrás metaadatainak kiürítése."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "A '%s' telepítési forrás nyers metaadatainak kiürítése."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "A(z) %s '%s' nyers metaadat gyorsítótárban tartása."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "A '%s' telepítési forrás csomagjainak kiürítése."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "A(z) %s telepítési forrás frissítése során hiba történt."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Telepített csomagok törlése a gyorsítótárból."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Hiba miatt nem sikerült a telepített csomagok gyorsítótárának törlése."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "A jelzett hibák miatt a telepítési források frissítése sikertelen."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Hiba miatt néhány telepítési forrás nem került frissítésre."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "A megadott telepítési források frissítése megtörtént."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Az összes telepítési forrás frissítése megtörtént."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Ez egy csak olvasható, cserélhető adathordozó (CD/DVD), ezért az automatikus "
 "frissítés letiltásra kerül."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Érvénytelen telepítési forrás álnév: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6218,26 +6243,26 @@ msgstr ""
 "A telepítési forrás típusa nem deríthető ki. Ellenőrizze, hogy az URI "
 "valóban egy érvényes telepítési forrásra mutat:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "A megadott helyen nem található érvényes telepítési forrás:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 "A telepítési forrás adatainak lekérdezése a megadott URI-ról sikertelen:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Ellenőrizze, hogy a megadott URI valóban elérhető."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Ismeretlen hiba történt a telepítés forrás hozzáadásakor:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6246,143 +6271,144 @@ msgstr ""
 "A GPG-ellenőrzés le van tiltva a(z) '%1%' telepítési forrásban. A csomagok "
 "sértetlensége és eredete nem ellenőrizhető."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "A(z) '%s' telepítési forrás hozzáadása sikeres"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Az adatok betöltése a következő a(z) '%s' adathordozóról"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Az adatok betöltése  a(z) '%s' adathordozóról sikertelen"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-"Ellenőrizze, hogy a telepítési adathordozó valóban érvényes és olvasható."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 "Az adatok „%s” adathordozóról történő olvasása nem működik a következő "
 "frissítésig."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Az adatok betöltése a következő a(z) '%s' adathordozóról"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Az adatok betöltése  a(z) '%s' adathordozóról sikertelen"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+"Ellenőrizze, hogy a telepítési adathordozó valóban érvényes és olvasható."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "A fájl adatainak lekérdezése a megadott URI-ról sikertelen"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Ellenőrizze, hogy a megadott URI érvényes és valóban elérhető."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "A fájl feldolgozása a megadott URI-ról sikertelen"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Ez egy .repo fájl?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Hiba történt a megadott URI-n található fájl beolvasása közben"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 "A fájlban egy álnévvel nem rendelkező telepítési forrás lett megadva, amely "
 "így kihagyásra kerül."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
-msgstr "A(z) %s telepítési forráshoz nincs megadva URI, ezért kihagyásra kerül."
+msgstr ""
+"A(z) %s telepítési forráshoz nincs megadva URI, ezért kihagyásra kerül."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "A(z) '%s' telepítési forrás eltávolítása megtörtént."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "A(z) '%s' telepítési forrás prioritása változatlan maradt (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "A(z) %s telepítési forrás engedélyezése sikeres."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "A(z) %s telepítési forrás letiltása sikeres."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "A(z) '%s' telepítési forrás automatikus frissítése engedélyezve."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "A(z) '%s' telepítési forrás automatikus frissítése letiltva."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 "Az RPM-fájlok gyorsítótárazása a(z) '%s' telepítési forráshoz engedélyezve "
 "lett."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 "Az RPM-fájlok gyorsítótárazása a(z) '%s' telepítési forráshoz kikapcsolva."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Az GPG-ellenőrzés engedélyezve van a(z) '%s' telepítési forráshoz."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Az GPG-ellenőrzés le van tiltva a(z) '%s' telepítési forráshoz."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "A(z) '%s' telepítési forrás %d prioritásának beállítása megtörtént."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "A(z) '%s' telepítési forrás neve átállítva erre:'%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "A(z) '%s' telepítési forrásban nincs módosítás."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "A(z) %s telepítési forrás változatlan maradt."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Telepítési forrás adatainak beolvasása..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6390,46 +6416,46 @@ msgstr ""
 "Nincs megadva letöltési forrás. A művelet csak a telepített feloldandókkal "
 "történik. Egyetlen csomag sem telepíthető."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "A(z) %s telepítési forrás adatainak beolvasása..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 "A(z) '%s' telepítési forrás nincs a gyorsítótárban. Beolvasás folyamatban..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Az adatok betöltése sikertelen a következő helyről: '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 "A(z) '%s' telepítési forrás frissítése nem sikerült. A korábbi gyorsítótár "
 "kerül felhasználásra."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Hiba történt, így \"%s\" feloldhatói nem tölthetők be."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Próbálja ki ezt: '%s', vagy ezt: '%s', mielőtt tovább lép."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6437,32 +6463,33 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Telepített csomagok beolvasása..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Probléma adódott a telepített csomagok olvasása közben:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "A '%s' egy RPM-fájlnak tűnik. Letöltés megkísérlése."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 "Probléma van az RPM-fájl '%s' típusként történő megadásával, ezért figyelmen "
 "kívül marad."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
-msgstr "Hiba történt a(z) %s RPM-fejléc beolvasása közben. Ez valóban RPM-fájl?"
+msgstr ""
+"Hiba történt a(z) %s RPM-fejléc beolvasása közben. Ez valóban RPM-fájl?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "RPM-fájlok gyorsítótára"
 
@@ -6470,25 +6497,25 @@ msgstr "RPM-fájlok gyorsítótára"
 msgid "System Packages"
 msgstr "Rendszercsomagok"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Nem találhatók frissítések."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Nem találhatók minták."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Nem találhatók csomagok."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Belső név"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Nem találhatók termékek."
 
@@ -6842,8 +6869,10 @@ msgstr "Minden telepített csomag függősége rendben."
 #, boost-format
 msgid "Considering %1% out of %2% applicable patches:"
 msgid_plural "Considering %1% out of %2% applicable patches:"
-msgstr[0] "Döntéshozatal a(z) %1%. javításról a(z) %2% alkalmazható javítás közül:"
-msgstr[1] "Döntéshozatal a(z) %1%. javításról a(z) %2% alkalmazható javítás közül:"
+msgstr[0] ""
+"Döntéshozatal a(z) %1%. javításról a(z) %2% alkalmazható javítás közül:"
+msgstr[1] ""
+"Döntéshozatal a(z) %1%. javításról a(z) %2% alkalmazható javítás közül:"
 
 #. translator: stats table header
 #: src/update.cc:340
@@ -6874,7 +6903,8 @@ msgstr[1] "%d javítás nem kötelező"
 #: src/update.cc:362
 #, boost-format
 msgid "use '%1%' to include optional patches"
-msgstr "a nem kötelező javítások belefoglalásához használja a következőt: '%1%'"
+msgstr ""
+"a nem kötelező javítások belefoglalásához használja a következőt: '%1%'"
 
 #. translator: stats summary
 #: src/update.cc:371
@@ -6900,7 +6930,7 @@ msgid "Updatestack"
 msgstr "Frissítési köteg"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Javítások"
 
@@ -6923,7 +6953,7 @@ msgstr "Benne foglalt kategóriák"
 msgid "Needed software management updates will be installed first:"
 msgstr "Először az alábbi szoftverkezelő frissítések települnek:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Nem találhatók frissítések."
 
@@ -6932,52 +6962,52 @@ msgstr "Nem találhatók frissítések."
 msgid "The following updates are also available:"
 msgstr "A következő frissítések is elérhetők:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Csomagfrissítések"
 
 # modules/inst_config_x11.ycp:216
 # /usr/lib/YaST2/clients/inst_config_x11.ycp:865
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Minták frissítései"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Termék frissítések"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Jelenlegi verzió"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Elérhető verzió"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Nem található ehhez illeszkedő hibabejelentés."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "A következő illeszkedő hibabejelentés-számok találhatók:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "A következő javításokban található egyezés a frissítés leírásában:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr "Nem található hibajavítás a megadott bugzillabejegyzéshez: %s."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "Nem található hibajavítás a megadott CVE-bejegyzéshez: %s."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:47+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Indonesian <https://l10n.opensuse.org/projects/zypper/master/"
@@ -854,7 +854,8 @@ msgstr[0] ""
 msgid "The following recommended pattern was automatically selected:"
 msgid_plural ""
 "The following %d recommended patterns were automatically selected:"
-msgstr[0] "%d Pola yang direkomendasikan berikut ini akan dipilih secara otomatis:"
+msgstr[0] ""
+"%d Pola yang direkomendasikan berikut ini akan dipilih secara otomatis:"
 
 #: src/Summary.cc:1089
 #, c-format, boost-format
@@ -922,7 +923,8 @@ msgstr[0] ""
 msgid "The following patch is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d patches are recommended, but will not be installed:"
-msgstr[0] "%d Tambalan berikut ini direkomendasikan, tetapi tidak akan dipasang:"
+msgstr[0] ""
+"%d Tambalan berikut ini direkomendasikan, tetapi tidak akan dipasang:"
 
 #: src/Summary.cc:1186
 #, c-format, boost-format
@@ -943,7 +945,8 @@ msgstr[0] "%d Produk berikut ini direkomendasikan, tetapi tidak akan dipasang:"
 msgid "The following application is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d applications are recommended, but will not be installed:"
-msgstr[0] "%d Aplikasi berikut ini direkomendasikan, tetapi tidak akan dipasang:"
+msgstr[0] ""
+"%d Aplikasi berikut ini direkomendasikan, tetapi tidak akan dipasang:"
 
 #: src/Summary.cc:1228
 #, c-format, boost-format
@@ -1342,7 +1345,7 @@ msgstr "PackageKit sedang bekerja (kemungkinan sibuk)."
 msgid "Try again?"
 msgstr "Coba lagi?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Pengecualian tak terduga."
 
@@ -1373,12 +1376,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Opsi %s tidak berfungsi di sini. Abaikan."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Argumen program non-opsi: "
 
@@ -1491,7 +1494,8 @@ msgstr "Berkas penandatanganan kunci gpg '%1%' telah kedaluwarsa."
 #, boost-format
 msgid "The gpg key signing file '%1%' will expire in %2% day."
 msgid_plural "The gpg key signing file '%1%' will expire in %2% days."
-msgstr[0] "Berkas penandatanganan kunci gpg '%1%' akan kedaluwarsa dalam %2% hari."
+msgstr[0] ""
+"Berkas penandatanganan kunci gpg '%1%' akan kedaluwarsa dalam %2% hari."
 
 #: src/callbacks/keyring.h:152
 #, c-format, boost-format
@@ -1635,7 +1639,8 @@ msgstr "Verifikasi tanda tangan gagal untuk berkas '%1%'."
 #: src/callbacks/keyring.h:389
 #, boost-format
 msgid "Signature verification failed for file '%1%' from repository '%2%'."
-msgstr "Verifikasi tanda tangan gagal untuk berkas '%1%' dari repositori '%2%'."
+msgstr ""
+"Verifikasi tanda tangan gagal untuk berkas '%1%' dari repositori '%2%'."
 
 #: src/callbacks/keyring.h:438
 msgid ""
@@ -1664,7 +1669,8 @@ msgstr ""
 #, boost-format
 msgid "Received %1% new package signing key from repository \"%2%\":"
 msgid_plural "Received %1% new package signing keys from repository \"%2%\":"
-msgstr[0] "Menerima %1% kunci penandatanganan paket baru dari repositori \"%2%\":"
+msgstr[0] ""
+"Menerima %1% kunci penandatanganan paket baru dari repositori \"%2%\":"
 
 #: src/callbacks/keyring.h:472
 msgid ""
@@ -2129,17 +2135,17 @@ msgid "Commands:"
 msgstr "Perintah:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Tampilkan ringkasan pemasangan terperinci."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Select packages by plain name, not by capability.Tipe paket (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2147,10 +2153,16 @@ msgstr ""
 "Lakukan pendekatan 'langkah terbaik' untuk pemutakhiran. Pemutakhiran ke "
 "versi yang rendah dari yang terbaru juga dapat diterima."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr ""
 "Pertimbangkan hanya tambalan yang memengaruhi manajemen paket itu sendiri."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2232,7 +2244,7 @@ msgstr "zypper [--OPSI-GLOBAL] <PERINTAH> [--OPSI-PERINTAH] [ARGUMEN]"
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <SUBPERINTAH> [--OPSI-PERINTAH] [ARGUMEN]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Cetak bantuan"
 
@@ -2340,10 +2352,10 @@ msgid ""
 "Patches are not installed in sense of copied files, database records,\n"
 "or similar."
 msgstr ""
-"Status tambalan yang dipasang ditentukan semata-mata berdasarkan dependensi."
-"\n"
-"Tambalan tidak terpasang dalam arti berkas yang disalin, rekaman basis data,"
-"\n"
+"Status tambalan yang dipasang ditentukan semata-mata berdasarkan "
+"dependensi.\n"
+"Tambalan tidak terpasang dalam arti berkas yang disalin, rekaman basis "
+"data,\n"
 "atau serupa."
 
 #: src/commands/installremove.cc:126
@@ -2455,22 +2467,22 @@ msgstr ""
 "mengganti paket dependensi dengan versi pemutakhiran resmi mereka."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [OPSI]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Daftar tambalan yang tersedia."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Daftar semua tambalan yang bisa diterapkan."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Daftar semua tambalan, tidak hanya yang bisa diterapkan saja."
 
@@ -2525,35 +2537,39 @@ msgstr ""
 "locale yang tersedia dengan memanggil '%s'."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [OPSI] [LOCALE] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Daftar locale yang diminta (kode bahasa)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Daftar locale yang diminta dan paket yang sesuai."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Tampilkan paket yang sesuai."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Daftar semua locale yang tersedia."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr "Mengabaikan argumen posisi karena argumen --all diberikan."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "Locale tempat informasi harus dicetak."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2561,16 +2577,16 @@ msgstr ""
 "Dapatkan semua locale dengan kode bahasa 'en' yang memiliki kode negara "
 "sendiri, tidak termasuk fallback 'en':"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 "Dapatkan semua locale dengan kode bahasa 'en' dengan atau tanpa kode negara:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "Dapatkan locale yang cocok dengan argumen yang tepat: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "Dapatkan daftar paket yang tersedia untuk 'de' dan 'en':"
 
@@ -2679,11 +2695,11 @@ msgstr[0] "Kunci %lu dihapus."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Nama"
 
@@ -2693,8 +2709,8 @@ msgstr "Cocok"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Tipe"
@@ -2702,7 +2718,7 @@ msgstr "Tipe"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Repositori"
@@ -3064,8 +3080,8 @@ msgid ""
 msgstr ""
 "Selain itu coba perbarui semua paket yang tidak tercakup oleh tambalan. "
 "Pilihannya diabaikan, jika perintah tambalan harus memutakhirkan "
-"pemutakhiran stack terlebih dahulu. Tidak bisa digabungkan dengan "
-"--updatestack-only."
+"pemutakhiran stack terlebih dahulu. Tidak bisa digabungkan dengan --"
+"updatestack-only."
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/patchcheck.cc:17
@@ -3164,7 +3180,7 @@ msgid "Command"
 msgstr "Perintah"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Layanan"
 
@@ -3335,40 +3351,41 @@ msgid "Show detailed information for products."
 msgstr "Tampilkan informasi terperinci untuk produk."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [OPSI] [REPOSITORI] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Daftar semua paket yang tersedia."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Daftar semua paket yang tersedia dalam repositori tertentu."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
-msgstr "Menampilkan paket terinstal yang secara otomatis dipilih oleh resolver."
+msgstr ""
+"Menampilkan paket terinstal yang secara otomatis dipilih oleh resolver."
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 "Menampilkan paket terinstal yang secara eksplisit dipilih oleh pengguna."
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 "Tampilkan paket terinstal yang tidak disediakan oleh repositori mana pun."
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
@@ -3377,84 +3394,84 @@ msgstr ""
 "kandidat pembaruan)."
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Tampilkan paket yang disarankan."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Tampilkan paket yang direkomendasikan."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Tampilkan paket yang tidak diperlukan."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Urutkan daftar berdasarkan nama paket."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Urutkan daftar berdasarkan repositori."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [REPOSITORI] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Daftar semua tambalan yang tersedia."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Daftar semua tambalan yang tersedia pada repositori tertentu."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [OPSI] [REPOSITORI] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Daftar semua pola yang tersedia."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Daftar semua pola yang tersedia dalam repositori tertentu."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [OPSI] [REPOSITORI] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Daftar semua produk yang tersedia."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Daftar semua produk yang tersedia pada repositori yang ditentukan."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Hanya keluaran XML: Secara harfiah meneruskan tag XML yang ditemukan di "
 "berkas produk."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "Opsi %1% tidak berpengaruh tanpa opsi global %2%."
@@ -3495,13 +3512,13 @@ msgstr "Jangan periksa URI, periksa nanti selama penyegaran."
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr "Jenis repositori selalu dideteksi otomatis. Opsi ini diabaikan."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 "Tidak dapat menggunakan %s bersama dengan %s. Menggunakan pengaturan %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3546,113 +3563,117 @@ msgstr "Bersihkan singgahan metadata raw."
 msgid "Clean both metadata and package caches."
 msgstr "Bersihkan keduanya, metadata dan singgahan paket."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Aktifkan"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Periksa GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Prioritas"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Segarkan otomatis"
 
 # OM
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Nyala"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Mati"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Simpan Paket"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "Kunci URI GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Prefix Path"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Layanan Induk"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Kata Kunci"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Path info Repo"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Path Singgahan MD"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [OPSI] [REPO] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Daftar semua repositori yang ditentukan."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 "Ekspor semua repositori yang ditetapkan sebagai satu berkas .repo lokal."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Galat saat membaca repositori:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Tidak dapat membuka %s untuk menulis."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Mungkin Anda tidak memiliki izin menulis?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Repositori telah berhasil diekspor ke %s."
@@ -3660,20 +3681,20 @@ msgstr "Repositori telah berhasil diekspor ke %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Segarkan"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "Simpan"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Tidak ada repositori yang ditentukan."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 "Gunakan perintah 'zypper addrepo' untuk menambah satu atau beberapa "
@@ -3783,7 +3804,7 @@ msgstr "Opsi global '%s' tidak berpengaruh di sini."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Argumen tidak diizinkan jika '%s' digunakan."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Repositori yang ditentukan: "
 
@@ -3792,7 +3813,7 @@ msgstr "Repositori yang ditentukan: "
 msgid "Refreshing repository '%s'."
 msgstr "Menyegarkan repositori '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Memindai isi repositori yang tidak aktif '%s'."
@@ -3802,7 +3823,7 @@ msgstr "Memindai isi repositori yang tidak aktif '%s'."
 msgid "Skipping disabled repository '%s'"
 msgstr "Melewati repositori '%s' yang dinonaktifkan"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Melewati repositori '%s' karena galat di atas."
@@ -3830,7 +3851,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "Tidak dapat menyegarkan repositori karena galat."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Beberapa repositori belum disegarkan karena ada galat."
 
@@ -3885,12 +3906,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Repositori '%s' diganti namanya menjadi '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "Repositori bernama '%s' sudah ada. Silakan gunakan alias lain."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Galat saat memodifikasi repositori:"
 
@@ -4354,28 +4375,29 @@ msgid ""
 "Like --details, with additional information where the search has matched "
 "(useful for search in dependencies)."
 msgstr ""
-"Seperti --details, dengan informasi tambahan di mana pencarian yang cocok ("
-"berguna untuk pencarian dalam dependensi)."
+"Seperti --details, dengan informasi tambahan di mana pencarian yang cocok "
+"(berguna untuk pencarian dalam dependensi)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Repositori '%s' yang telah ditentukan dinonaktifkan."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Tidak ditemukan item yang cocok."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
-msgstr "Masalah terjadi menginisialisasi atau mengeksekusi permintaan pencarian"
+msgstr ""
+"Masalah terjadi menginisialisasi atau mengeksekusi permintaan pencarian"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Lihat pesan di atas untuk petunjuk."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 "Menjalankan 'zypper refresh' sebagai root mungkin bisa menyelesaikan masalah."
@@ -4471,7 +4493,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Masalah mengambil berkas indeks repositori untuk layanan '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Melewati layanan '%s' karena galat di atas."
@@ -4490,24 +4512,28 @@ msgstr "Menghapus layanan '%s':"
 msgid "Service '%s' has been removed."
 msgstr "Layanan '%s' telah dihapus."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [OPSI]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Daftar semua layanan yang ditetapkan."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Daftar layanan yang ditentukan."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Tidak ada layanan yang ditentukan. Gunakan perintah '%s' untuk menambahkan "
 "satu atau lebih layanan."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5124,8 +5150,8 @@ msgid ""
 "Download all versions matching the commandline arguments. Otherwise only the "
 "best version of each matching package is downloaded."
 msgstr ""
-"Unduh semua versi-versi yang cocok dengan argumen baris perintah. Jika tidak "
-", hanya versi yang terbaik dari setiap paket yang cocok diunduh."
+"Unduh semua versi-versi yang cocok dengan argumen baris perintah. Jika "
+"tidak , hanya versi yang terbaik dari setiap paket yang cocok diunduh."
 
 #. translators: Label text; is followed by ': cmdline argument'
 #: src/commands/utils/download.cc:236
@@ -5439,15 +5465,15 @@ msgstr "%s lebih tua dari %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Versi"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arsitektur"
 
@@ -5582,13 +5608,13 @@ msgstr "(kosong)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Dependensi"
 
@@ -5625,7 +5651,7 @@ msgid "Flavor"
 msgstr "Rasa"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Adalah Basis"
 
@@ -5887,57 +5913,57 @@ msgstr[0] "Repositori %1%"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Memeriksa apakah akan menyegarkan metadata untuk %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Repositori '%s' sudah termutakhir."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Pemeriksaan pemutakhiran '%s' telah ditunda."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Memaksa penyegaran metadata raw"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Mengambil metadata repositori '%s'"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Apakah Anda ingin menonaktifkan repositori %s secara permanen?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Galat saat menonaktifkan repositori '%s'."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Masalah mengambil berkas dari '%s'."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Silahkan lihat pesan galat di atas sebagai petunjuk."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Tidak ada URI yang ditentukan untuk '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -5946,16 +5972,16 @@ msgstr ""
 "Silakan tambahkan satu atau lebih entri basis URI (baseurl=URI) ke %s untuk "
 "repositori '%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Tidak ada alias yang ditentukan untuk repositori ini."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Repositori '%s' tidak valid."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -5963,22 +5989,22 @@ msgstr ""
 "Periksa apakah URI yang ditetapkan untuk repositori ini menunjuk ke "
 "repositori yang valid."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Galat saat mengambil metadata untuk '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Memaksa membangun singgahan repositori"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Galat mengurai metadata untuk '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5990,42 +6016,42 @@ msgstr ""
 "ajukan laporan kutu dengan mengikuti petunjuk di http://en.opensuse.org/"
 "Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Metadata repositori untuk '%s' tidak ditemukan di singgahan lokal."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Galat saat membangun singgahan:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Repositori '%s' tidak ditemukan berdasarkan alias, nomor atau URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Gunakan '%s' untuk mendapatkan daftar repositori yang ditentukan."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Mengabaikan repositori yang dinonaktifkan '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "Opsi global '%s' dapat digunakan untuk mengaktifkan repositori sementara."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Mengabaikan repositori '%s' karena opsi '%s'."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Mengaktifkan repository '%s' sementara."
@@ -6033,7 +6059,7 @@ msgstr "Mengaktifkan repository '%s' sementara."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6042,7 +6068,7 @@ msgstr ""
 "Repositori '%s' sudah usang. Anda bisa melakukan 'zypper refresh' dari root "
 "untuk memperbaruinya."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6051,108 +6077,108 @@ msgstr ""
 "Singgahan metadata perlu dibangun untuk repositori '%s'. Anda bisa jalankan "
 "'zypper refresh' sebagai root untuk melakukan ini."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Repositori '%s' tetap dinonaktifkan."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Inisialisasi Target"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Inisialisasi target gagal:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Membersihkan singgahan metadata untuk '%s'."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Membersihkan singgahan metadata raw untuk '%s'."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Menyimpan singgahan metadata raw untuk %s '%s'."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Membersihkan paket untuk '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Tidak dapat membersihkan repositori '%s' karena galat."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Membersihkan singgahan paket yang dipasang."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 "Tidak dapat membersihkan singgahan paket yang dipasang karena kesalahan."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Tidak dapat membersihkan repositori karena kesalahan."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Beberapa repositori belum dibersihkan karena ada kesalahan."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Repositori yang ditentukan telah dibersihkan."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Semua repositori telah dibersihkan."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Ini adalah media hanya-baca yang dapat diubah (CD/DVD), menonaktifkan "
 "penyegaran otomatis."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Alias repositori tidak valid: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
-"Tidak dapat menentukan tipe repositori. Periksa apakah URI yang ditetapkan ("
-"lihat di bawah) menunjuk ke repositori yang valid:"
+"Tidak dapat menentukan tipe repositori. Periksa apakah URI yang ditetapkan "
+"(lihat di bawah) menunjuk ke repositori yang valid:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Tidak dapat menemukan repositori yang valid di lokasi yang ditentukan:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Masalah mentransfer data repositori dari URI yang ditentukan:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Harap periksa apakah URI yang ditentukan dapat diakses."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Masalah tidak dikenal saat menambahkan repositori:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6161,135 +6187,135 @@ msgstr ""
 "Pemeriksaan GPG dinonaktifkan dalam konfigurasi repositori '%1%'. Integritas "
 "dan asal paket tidak dapat diverifikasi."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Repositori '%s' berhasil ditambahkan"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Membaca data dari media '%s'"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Masalah saat membaca data dari media '%s'"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Silakan periksa apakah media pemasangan Anda valid dan mudah dibaca."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Membaca data dari media '%s' ditunda hingga penyegaran berikutnya."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Membaca data dari media '%s'"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Masalah saat membaca data dari media '%s'"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Silakan periksa apakah media pemasangan Anda valid dan mudah dibaca."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Masalah saat mengakses berkas pada URI yang ditentukan"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Harap periksa apakah URI valid dan dapat diakses."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Masalah penguraian berkas pada URI yang ditentukan"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Apakah ini berkas .repo?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Terjadi masalah saat mencoba membaca berkas di URI yang ditentukan"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Repositori tanpa alias yang ditemukan dalam berkas, lewati."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Repositori '%s' tidak memiliki URI yang ditentukan, lewati."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Repositori '%s' telah dihapus."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Prioritas '%s' dari repositori tidak berubah (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Repositori '%s' telah berhasil diaktifkan."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Repositori '%s' telah berhasil dinonaktifkan."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Segarkan otomatis telah diaktifkan untuk repositori '%s'."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Segarkan otomatis telah dinonaktifkan untuk repositori '%s'."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Singgahan berkas RPM telah diaktifkan untuk repositori '%s'."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Singgahan berkas RPM telah dinonaktifkan untuk repositori '%s'."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Pemeriksaan GPG telah diaktifkan untuk repositori '%s'."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Pemeriksaan GPG telah dinonaktifkan untuk repositori '%s'."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Prioritas repositori '%s' telah diatur ke %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Nama repositori '%s' telah ditetapkan ke '%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Tidak ada yang berubah untuk repositori '%s'."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Membiarkan repositori %s tidak berubah."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Memuat data repositori..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6297,79 +6323,79 @@ msgstr ""
 "Tidak ada repositori yang ditentukan. Beroperasi hanya dengan perbaikan yang "
 "terpasang. Tidak ada yang bisa dipasang."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Mengambil data repositori '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Repositori '%s' tidak di-singgahan. Membuat singgahan..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Masalah memuat data dari '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "Repositori '%s' tidak dapat disegarkan. Menggunakan singgahan lama."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Perbaikan dari '%s' tidak dimuat karena kesalahan."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "Metadata repositori '%1%' kedaluwarsa sejak %2%."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Coba '%s', atau bahkan '%s' sebelum melakukannya."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
 "not solve the issue, it could be that you are using a broken mirror or the "
 "server has actually discontinued to support the repository."
 msgstr ""
-"Metadata repositori kedaluwarsa: Periksa apakah 'autorefresh' diaktifkan ("
-"zypper lr), jika tidak segarkan repositori secara manual (zypper ref). Jika "
+"Metadata repositori kedaluwarsa: Periksa apakah 'autorefresh' diaktifkan "
+"(zypper lr), jika tidak segarkan repositori secara manual (zypper ref). Jika "
 "ini tidak menyelesaikan masalah, bisa jadi Anda menggunakan cermin yang "
 "rusak atau peladen yang sebenarnya telah dihentikan untuk mendukung "
 "repositori."
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Membaca paket yang dipasang..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Masalah terjadi saat membaca paket yang dipasang:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' tampak seperti berkas RPM. Akan mencoba mengunduhnya."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Masalah dengan berkas RPM yang ditentukan sebagai '%s', lewati."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Masalah saat membaca header RPM dari %s. Apakah ini berkas RPM?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Singgahan berkas RPM biasa"
 
@@ -6377,25 +6403,25 @@ msgstr "Singgahan berkas RPM biasa"
 msgid "System Packages"
 msgstr "Paket Sistem"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Tidak ada tambalan yang dibutuhkan."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Tidak ada pola yang ditemukan."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Tidak ada paket yang ditemukan."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Nama Internal"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Tidak ada produk yang ditemukan."
 
@@ -6424,7 +6450,8 @@ msgstr "Informasi detail: "
 #: src/solve-commit.cc:138
 msgid "Choose the above solution using '1' or skip, retry or cancel"
 msgid_plural "Choose from above solutions by number or skip, retry or cancel"
-msgstr[0] "Pilih solusi di atas menggunakan '1' atau lewati, coba lagi atau batal"
+msgstr[0] ""
+"Pilih solusi di atas menggunakan '1' atau lewati, coba lagi atau batal"
 
 #. translators: translate 'c' to whatever you translated the 'c' in
 #. "c" and "s/r/c" strings
@@ -6786,7 +6813,7 @@ msgid "Updatestack"
 msgstr "Updatestack"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Tambalan"
 
@@ -6811,7 +6838,7 @@ msgstr ""
 "Pemutakhiran pengelolaan perangkat lunak yang diperlukan akan dipasang "
 "terlebih dahulu:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Tidak ada pemutakhiran yang ditemukan."
 
@@ -6820,52 +6847,53 @@ msgstr "Tidak ada pemutakhiran yang ditemukan."
 msgid "The following updates are also available:"
 msgstr "Pemutakhiran berikut ini juga tersedia:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Pemutakhiran paket"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Pemutakhiran pola"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Pemutakhiran produk"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Versi Saat Ini"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Versi yang Tersedia"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Tidak ditemukan isu yang cocok."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Kecocokan berikut dengan nomor isu telah ditemukan:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 "Kecocokan dalam deskripsi tambalan dari tambalan berikut telah ditemukan:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "Perbaikan untuk isu bugzilla nomor %s tidak ditemukan atau tidak dibutuhkan."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
-msgstr "Perbaikan untuk isu CVE nomor %s tidak ditemukan atau tidak diperlukan."
+msgstr ""
+"Perbaikan untuk isu CVE nomor %s tidak ditemukan atau tidak diperlukan."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "Perbaikan untuk isu %s nomor %s tidak ditemukan atau tidak diperlukan."
@@ -6901,7 +6929,8 @@ msgstr "Berkas konfigurasi '%1%' tidak ada."
 #: src/utils/Augeas.cc:635
 #, boost-format
 msgid "%1%: Option '%2%' is defined multiple times. Using the last one."
-msgstr "%1%: Opsi '%2%' didefinisikan beberapa kali. Menggunakan yang terakhir."
+msgstr ""
+"%1%: Opsi '%2%' didefinisikan beberapa kali. Menggunakan yang terakhir."
 
 #: src/utils/Augeas.cc:656
 msgid "No config file is in use."

--- a/po/ie.po
+++ b/po/ie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Occidental <https://l10n.opensuse.org/projects/zypper/master/"
@@ -1353,7 +1353,7 @@ msgstr ""
 msgid "Try again?"
 msgstr ""
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr ""
 
@@ -1381,12 +1381,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2066,24 +2066,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2153,7 +2159,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2334,22 +2340,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2400,49 +2406,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2543,11 +2553,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr ""
 
@@ -2557,8 +2567,8 @@ msgstr ""
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr ""
@@ -2566,7 +2576,7 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr ""
@@ -2980,7 +2990,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr ""
 
@@ -3140,120 +3150,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3292,12 +3302,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3339,111 +3349,115 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr ""
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr ""
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr ""
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr ""
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr ""
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr ""
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3451,20 +3465,20 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr ""
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr ""
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3565,7 +3579,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr ""
 
@@ -3574,7 +3588,7 @@ msgstr ""
 msgid "Refreshing repository '%s'."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr ""
@@ -3584,7 +3598,7 @@ msgstr ""
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3611,7 +3625,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3664,12 +3678,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr ""
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr ""
 
@@ -4095,25 +4109,25 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr ""
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr ""
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4203,7 +4217,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr ""
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4222,21 +4236,25 @@ msgstr ""
 msgid "Service '%s' has been removed."
 msgstr ""
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5106,15 +5124,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr ""
 
@@ -5248,13 +5266,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr ""
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -5291,7 +5309,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5545,94 +5563,94 @@ msgstr[1] ""
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr ""
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr ""
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr ""
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr ""
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr ""
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr ""
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr ""
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr ""
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr ""
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr ""
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5640,41 +5658,41 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr ""
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr ""
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr ""
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr ""
@@ -5682,294 +5700,294 @@ msgstr ""
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr ""
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr ""
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr ""
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr ""
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr ""
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr ""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr ""
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr ""
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr ""
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr ""
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr ""
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr ""
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr ""
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr ""
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr ""
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr ""
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -5977,30 +5995,30 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr ""
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr ""
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6008,25 +6026,25 @@ msgstr ""
 msgid "System Packages"
 msgstr ""
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr ""
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr ""
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr ""
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr ""
 
@@ -6397,7 +6415,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr ""
 
@@ -6420,7 +6438,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr ""
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr ""
 
@@ -6429,50 +6447,50 @@ msgstr ""
 msgid "The following updates are also available:"
 msgstr ""
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr ""
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr ""
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr ""
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr ""
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr ""
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -11,11 +11,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-08-01 17:59+0000\n"
 "Last-Translator: Davide Aiello <davide.aiello@novilingulists.com>\n"
-"Language-Team: Italian <https://l10n.opensuse.org/projects/zypper/master/it/>"
-"\n"
+"Language-Team: Italian <https://l10n.opensuse.org/projects/zypper/master/it/"
+">\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -233,7 +233,8 @@ msgstr ""
 #. translators: --reposd-dir, -D <DIR>
 #: src/Config.cc:397
 msgid "Use alternative repository definition file directory."
-msgstr "Usa una directory alternativa per i file di definizione dei repository."
+msgstr ""
+"Usa una directory alternativa per i file di definizione dei repository."
 
 #. translators: --cache-dir, -C <DIR>
 #: src/Config.cc:412
@@ -807,7 +808,8 @@ msgstr[1] "Le seguenti %d applicazioni stanno per essere aggiornate:"
 #, c-format, boost-format
 msgid "The following package is going to be downgraded:"
 msgid_plural "The following %d packages are going to be downgraded:"
-msgstr[0] "Il seguente pacchetto sta per essere portato alla versione precedente:"
+msgstr[0] ""
+"Il seguente pacchetto sta per essere portato alla versione precedente:"
 msgstr[1] ""
 "I seguenti %d pacchetti stanno per essere portati alla versione precedente:"
 
@@ -823,7 +825,8 @@ msgstr[1] ""
 #, c-format, boost-format
 msgid "The following pattern is going to be downgraded:"
 msgid_plural "The following %d patterns are going to be downgraded:"
-msgstr[0] "Il seguente modello sta per essere portato alla versione precedente:"
+msgstr[0] ""
+"Il seguente modello sta per essere portato alla versione precedente:"
 msgstr[1] ""
 "I seguenti %d modelli stanno per essere portati alla versione precedente:"
 
@@ -831,7 +834,8 @@ msgstr[1] ""
 #, c-format, boost-format
 msgid "The following product is going to be downgraded:"
 msgid_plural "The following %d products are going to be downgraded:"
-msgstr[0] "Il seguente prodotto sta per essere portato alla versione precedente:"
+msgstr[0] ""
+"Il seguente prodotto sta per essere portato alla versione precedente:"
 msgstr[1] ""
 "I seguenti %d prodotti stanno per essere portati alla versione precedente:"
 
@@ -885,7 +889,8 @@ msgstr[1] "Le seguenti %d applicazioni verranno re-installate:"
 msgid "The following recommended package was automatically selected:"
 msgid_plural ""
 "The following %d recommended packages were automatically selected:"
-msgstr[0] "Il seguente pacchetto raccomandato è stato selezionato automaticamente:"
+msgstr[0] ""
+"Il seguente pacchetto raccomandato è stato selezionato automaticamente:"
 msgstr[1] ""
 "I seguenti %d pacchetti raccomandati sono stati selezionati automaticamente:"
 
@@ -903,7 +908,8 @@ msgstr[1] ""
 msgid "The following recommended pattern was automatically selected:"
 msgid_plural ""
 "The following %d recommended patterns were automatically selected:"
-msgstr[0] "Il seguente modello raccomandato è stato selezionato automaticamente:"
+msgstr[0] ""
+"Il seguente modello raccomandato è stato selezionato automaticamente:"
 msgstr[1] ""
 "I seguenti %d modelli raccomandati sono stati selezionati automaticamente:"
 
@@ -912,7 +918,8 @@ msgstr[1] ""
 msgid "The following recommended product was automatically selected:"
 msgid_plural ""
 "The following %d recommended products were automatically selected:"
-msgstr[0] "Il seguente prodotto raccomandato è stato selezionato automaticamente:"
+msgstr[0] ""
+"Il seguente prodotto raccomandato è stato selezionato automaticamente:"
 msgstr[1] ""
 "I seguenti %d prodotti raccomandati sono stati selezionati automaticamente:"
 
@@ -951,8 +958,8 @@ msgstr[0] ""
 "Il seguente pacchetto è raccomandato, ma non verrà installato (verranno "
 "installati solo i pacchetti richiesti):"
 msgstr[1] ""
-"I seguenti %d pacchetti sono raccomandati, ma non verranno installati ("
-"verranno installati solo i pacchetti richiesti):"
+"I seguenti %d pacchetti sono raccomandati, ma non verranno installati "
+"(verranno installati solo i pacchetti richiesti):"
 
 #: src/Summary.cc:1159
 #, c-format, boost-format
@@ -998,7 +1005,8 @@ msgid "The following pattern is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d patterns are recommended, but will not be installed:"
 msgstr[0] "Il seguente modello è raccomandato, ma non verrà installato:"
-msgstr[1] "I seguenti %d modelli sono raccomandati, ma non verranno installati:"
+msgstr[1] ""
+"I seguenti %d modelli sono raccomandati, ma non verranno installati:"
 
 #: src/Summary.cc:1190
 #, c-format, boost-format
@@ -1006,7 +1014,8 @@ msgid "The following product is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d products are recommended, but will not be installed:"
 msgstr[0] "Il seguente prodotto è raccomandato, ma non verrà installato:"
-msgstr[1] "I seguenti %d prodotti sono raccomandati, ma non verranno installati:"
+msgstr[1] ""
+"I seguenti %d prodotti sono raccomandati, ma non verranno installati:"
 
 #: src/Summary.cc:1195
 #, c-format, boost-format
@@ -1055,7 +1064,8 @@ msgid "The following application is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d applications are suggested, but will not be installed:"
 msgstr[0] "La seguente applicazione è suggerita, ma non verrà installata:"
-msgstr[1] "Le seguenti %d applicazioni sono suggerite, ma non verranno installate:"
+msgstr[1] ""
+"Le seguenti %d applicazioni sono suggerite, ma non verranno installate:"
 
 #: src/Summary.cc:1274
 #, c-format, boost-format
@@ -1211,7 +1221,8 @@ msgstr[1] "I seguenti %d aggiornamenti di prodotto NON verranno installati:"
 msgid "The following application update will NOT be installed:"
 msgid_plural "The following %d application updates will NOT be installed:"
 msgstr[0] "Il seguente aggiornamento di applicazione NON verrà installato:"
-msgstr[1] "I seguenti %d aggiornamenti di applicazione NON verranno installati:"
+msgstr[1] ""
+"I seguenti %d aggiornamenti di applicazione NON verranno installati:"
 
 #: src/Summary.cc:1504
 #, c-format, boost-format
@@ -1466,7 +1477,7 @@ msgstr "PackageKit è ancora in esecuzione (probabilmente è occupato)."
 msgid "Try again?"
 msgstr "Riprovare?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Eccezione imprevista."
 
@@ -1491,19 +1502,19 @@ msgid ""
 "The /etc/products.d/baseproduct symlink is dangling or missing!\n"
 "The link must point to your core products .prod file in /etc/products.d.\n"
 msgstr ""
-"Il collegamento simbolico /etc/products.d/baseproduct è pendente o mancante."
-"\n"
+"Il collegamento simbolico /etc/products.d/baseproduct è pendente o "
+"mancante.\n"
 "Il collegamento deve puntare al file dei prodotti principali .prod in /etc/"
 "products.d.\n"
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "L'opzione %s non ha alcun effetto e verrà ignorata."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Argomenti del programma diversi dalle opzioni: "
 
@@ -1618,8 +1629,10 @@ msgstr "La chiave gpg di firma del file '%1%' è scaduta."
 #, boost-format
 msgid "The gpg key signing file '%1%' will expire in %2% day."
 msgid_plural "The gpg key signing file '%1%' will expire in %2% days."
-msgstr[0] "La chiave gpg usata per firmare il file '%1%' scadrà tra %2% giorno."
-msgstr[1] "La chiave gpg usata per firmare il file '%1%' scadrà tra %2% giorni."
+msgstr[0] ""
+"La chiave gpg usata per firmare il file '%1%' scadrà tra %2% giorno."
+msgstr[1] ""
+"La chiave gpg usata per firmare il file '%1%' scadrà tra %2% giorni."
 
 #: src/callbacks/keyring.h:152
 #, c-format, boost-format
@@ -1889,7 +1902,8 @@ msgstr "Sbloccare o ignorare?"
 #: src/callbacks/locks.h:27
 msgid ""
 "The following query locks the same objects as the one you want to remove:"
-msgstr "La seguente interrogazione blocca oggetti uguali a quello da rimuovere:"
+msgstr ""
+"La seguente interrogazione blocca oggetti uguali a quello da rimuovere:"
 
 #: src/callbacks/locks.h:30
 msgid "The following query locks some of the objects you want to unlock:"
@@ -1927,7 +1941,8 @@ msgstr ""
 #. help text for the "Abort, retry, ignore?" prompt for media errors
 #: src/callbacks/media.cc:34
 msgid "Change current base URI and try retrieving the file again."
-msgstr "Modifica l'URI di base attuale e prova a recuperare nuovamente il file."
+msgstr ""
+"Modifica l'URI di base attuale e prova a recuperare nuovamente il file."
 
 #. translators: this is a prompt label, will appear as "New URI: "
 #: src/callbacks/media.cc:49
@@ -1946,7 +1961,8 @@ msgstr "a/r/i/c/d"
 
 #: src/callbacks/media.cc:79
 msgid "Disable SSL certificate authority check and continue."
-msgstr "Disabilita il controllo sull'autorità di certificazione SSL e continua."
+msgstr ""
+"Disabilita il controllo sull'autorità di certificazione SSL e continua."
 
 #. translators: this is a prompt text
 #: src/callbacks/media.cc:82 src/callbacks/media.cc:174
@@ -2264,17 +2280,17 @@ msgid "Commands:"
 msgstr "Comandi:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Mostra il riepilogo dettagliato dell'installazione."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Tipo di pacchetto (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2283,9 +2299,15 @@ msgstr ""
 "gli aggiornamenti a una versione precedente a quella più recente sono "
 "accettabili."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "Considera solo le patch relative alla gestione stessa dei pacchetti."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2368,7 +2390,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <sottocomando> [--opzioni-del-comando] [argomenti]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Stampa l'aiuto"
 
@@ -2453,8 +2475,8 @@ msgid ""
 "Remove packages with specified capabilities. A capability is NAME[.ARCH]"
 "[OP<VERSION>], where OP is one of <, <=, =, >=, >."
 msgstr ""
-"Rimuove i pacchetti con le funzionalità specificate. Una funzionalità è NOME"
-"[.ARCH][OP<VERSIONE>], dove OP può essere uno tra <, <=, =, >=, >."
+"Rimuove i pacchetti con le funzionalità specificate. Una funzionalità è "
+"NOME[.ARCH][OP<VERSIONE>], dove OP può essere uno tra <, <=, =, >=, >."
 
 #: src/commands/installremove.cc:104 src/commands/installremove.cc:234
 #: src/utils/messages.cc:53
@@ -2590,22 +2612,22 @@ msgstr ""
 "versioni di aggiornamento ufficiali."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [OPZIONI]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Elenca tutte le patch."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Elenca tutte le patch applicabili."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Elenca tutte le patch, non solo quelle applicabili."
 
@@ -2664,38 +2686,42 @@ msgstr ""
 "lingua. Per ottenere un elenco di impostazioni internazionali chiamare '%s'."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [OPZIONI] [IMPOSTAZIONE INTERNAZIONALE]..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Elenca le impostazioni internazionali richieste (codici lingua)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Elenca le impostazioni internazionali e i pacchetti corrispondenti."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Mostra i pacchetti corrispondenti."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Elenca tutte le impostazioni internazionali disponibili."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 "Gli argomenti posizionali vengono ignorati perché è stato fornito "
 "l'argomento --all."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 "Le impostazioni internazionali per le quali saranno stampate le informazioni."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2703,19 +2729,19 @@ msgstr ""
 "Ottieni tutte le impostazioni internazionali con codice lingua 'en' con "
 "codice paese proprio, tranne fallback 'en':"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 "Ottieni tutte le impostazioni internazionali con codice lingua 'en' con o "
 "senza codice paese:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 "Ottieni l'impostazione internazionale che corrisponde esattamente "
 "all'argomento: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "Ottieni l'elenco dei pacchetti disponibili per 'de' e 'en':"
 
@@ -2799,7 +2825,8 @@ msgstr[1] "I blocchi specificati sono stati aggiunti con successo."
 
 #: src/commands/locks/add.cc:88
 msgid "Problem adding the package lock:"
-msgstr "Si è verificato un problema durante l'aggiunta del blocco al pacchetto:"
+msgstr ""
+"Si è verificato un problema durante l'aggiunta del blocco al pacchetto:"
 
 # =============================================================================
 #: src/commands/locks/clean.cc:16
@@ -2832,11 +2859,11 @@ msgstr[1] "Rimossi %lu blocchi."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Nome"
 
@@ -2846,8 +2873,8 @@ msgstr "Corrispondenze"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Tipo"
@@ -2855,7 +2882,7 @@ msgstr "Tipo"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Repository"
@@ -3138,8 +3165,8 @@ msgid ""
 "download-as-needed disables the fileconflict check."
 msgstr ""
 "Installa i pacchetti anche se sostituiscono i file di altri pacchetti già "
-"installati. Per default, i conflitti tra file vengono considerati errori. "
-"--download-as-needed disabilita la verifica dei conflitti tra file."
+"installati. Per default, i conflitti tra file vengono considerati errori. --"
+"download-as-needed disabilita la verifica dei conflitti tra file."
 
 #. translators: -y, --no-confirm
 #: src/commands/optionsets.cc:291
@@ -3322,7 +3349,7 @@ msgid "Command"
 msgstr "Comando"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Servizio"
 
@@ -3498,22 +3525,22 @@ msgid "Show detailed information for products."
 msgstr "Mostra informazioni dettagliate per i prodotti."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [opzioni] [repository] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Elenca tutti i pacchetti disponibili."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Elenca tutti i pacchetti disponibili nei repository specificati."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
@@ -3521,20 +3548,20 @@ msgstr ""
 "risolutore."
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 "Mostra i pacchetti installati che sono stati esplicitamente selezionati "
 "dall'utente."
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 "Mostra i pacchetti installati che non sono forniti da nessun repository."
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
@@ -3543,82 +3570,82 @@ msgstr ""
 "senza candidato all'aggiornamento)."
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Mostra pacchetti consigliati."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Mostra pacchetti raccomandati."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Mostra pacchetti non necessari."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Ordina l'elenco per nome del pacchetto."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Ordina l'elenco per repository."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [REPOSITORY]..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Elenca tutte le patch disponibili."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Elenca gli aggiornamenti disponibili nei repository specificati."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [opzioni] [repository] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Elenca tutti i modelli disponibili."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Elenca tutti i modelli disponibili nei repository specificati."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [opzioni] [repository] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Elenca tutti i prodotti disponibili."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Elenca tutti i prodotti disponibili nei repository specificati."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr "Solo output XML: inoltra i tag XML trovati nel file di prodotto."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "L'opzione %1% non produce effetti senza l'opzione globale %2%."
@@ -3657,16 +3684,17 @@ msgstr "Aggiunge l'archivio come disabilitato."
 
 #: src/commands/repos/add.cc:46
 msgid "The repository type is always autodetected. This option is ignored."
-msgstr "Il tipo di repository è sempre autorilevato. Questa opzione è ignorata."
+msgstr ""
+"Il tipo di repository è sempre autorilevato. Questa opzione è ignorata."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 "Impossibile utilizzare %s insieme con %s. Verranno utilizzate le "
 "impostazioni di %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3710,111 +3738,115 @@ msgstr "Pulisce la cache dei metadati non elaborati."
 msgid "Clean both metadata and package caches."
 msgstr "Pulisce entrambe le cache, dei metadati e del pacchetto."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Abilitato"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Controllo GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Priorità"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Aggiornamento automatico"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Attivo"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Disattivo"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Mantieni i pacchetti"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI della chiave GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Prefisso del percorso"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Servizio principale"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Parole chiave"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Percorso delle informazioni del repository"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Percorso della cache MD"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [OPZIONI] [REPO]..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Elenca tutti i repository definiti."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "Esporta tutti i repository definiti come un singolo file .repo locale."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Errore durante la lettura dei repository:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Impossibile aprire %s in scrittura."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Verificare di disporre delle autorizzazioni di scrittura."
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Repository esportati correttamente in %s."
@@ -3822,20 +3854,20 @@ msgstr "Repository esportati correttamente in %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Aggiornamento"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "Mantieni"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Nessun repository definito."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr "Usare il comando 'zypper addrepo' per aggiungere uno o più repository."
 
@@ -3943,7 +3975,7 @@ msgstr "L'opzione globale '%s' non ha effetto."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Se viene usato '%s' non sono ammessi argomenti."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Repository specificati: "
 
@@ -3952,7 +3984,7 @@ msgstr "Repository specificati: "
 msgid "Refreshing repository '%s'."
 msgstr "Aggiornamento repository '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Scansione del contenuto del repository disabilitato '%s'."
@@ -3962,7 +3994,7 @@ msgstr "Scansione del contenuto del repository disabilitato '%s'."
 msgid "Skipping disabled repository '%s'"
 msgstr "Esclusione del repository disabilitato '%s'"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Esclusione del repository '%s' a causa dell'errore precedente."
@@ -3989,7 +4021,7 @@ msgstr "Usare i comandi '%s' o '%s' per aggiungere o abilitare i repository."
 msgid "Could not refresh the repositories because of errors."
 msgstr "Impossibile aggiornare i repository a causa di errori."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Alcuni repository non sono stati aggiornati a causa di un errore."
 
@@ -4044,12 +4076,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Repository '%s' rinominato come '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "Esiste già un repository di nome '%s'. Usare un altro alias."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Errore durante la modifica del repository:"
 
@@ -4517,27 +4549,27 @@ msgstr ""
 "Come --details, con informazioni aggiuntive dove la ricerca ha trovato "
 "corrispondenza (utile per la ricerca nelle dipendenze)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Il repository specificato '%s' è disabilitato."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Nessun elemento corrispondente trovato."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 "Si è verificato un problema durante l'inizializzazione o l'esecuzione di "
 "un'interrogazione di ricerca"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Leggere il messaggio visualizzato sopra."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "È possibile risolvere il problema avviando 'zypper refresh' come root."
 
@@ -4635,7 +4667,7 @@ msgstr ""
 "repository per il servizio '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Il servizio '%s' verrà ignorato a causa dell'errore precedente."
@@ -4654,24 +4686,28 @@ msgstr "Rimozione del servizio '%s':"
 msgid "Service '%s' has been removed."
 msgstr "Il servizio '%s' è stato rimosso."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [opzioni]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Elenca tutti i servizi definiti."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Elenca i servizi definiti."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Non è stato definito alcun servizio. Utilizzare il comando '%s' per "
 "aggiungere uno o più servizi."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5143,8 +5179,8 @@ msgstr ""
 "\n"
 "Se è impossibile trovare un sottocomando in zypper_execdir, il wrapper\n"
 "lo cercherà nella parte rimanente di $PATH. È pertanto possibile\n"
-"scrivere estensioni zypper locali che non si trovano nello spazio di sistema."
-"\n"
+"scrivere estensioni zypper locali che non si trovano nello spazio di "
+"sistema.\n"
 
 #: src/commands/subcommand.cc:458
 #, boost-format
@@ -5428,7 +5464,8 @@ msgstr "Pacchetti sorgente richiesti:"
 
 #: src/commands/utils/source-download.cc:296
 msgid "Required source packages available in download directory:"
-msgstr "Pacchetti di origine richiesti disponibili nella directory di download:"
+msgstr ""
+"Pacchetti di origine richiesti disponibili nella directory di download:"
 
 #: src/commands/utils/source-download.cc:300
 msgid "Required source packages to be downloaded:"
@@ -5625,15 +5662,15 @@ msgstr "%s è meno recente di %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Versione"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arch."
 
@@ -5771,13 +5808,13 @@ msgstr "(vuoto)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Dipendenza"
 
@@ -5814,7 +5851,7 @@ msgid "Flavor"
 msgstr "Flavor"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "È Base"
 
@@ -6082,58 +6119,58 @@ msgstr[1] "%1% repository"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Verifica della necessità di aggiornare i metadati per %s in corso"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Il repository '%s' è aggiornato."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "La verifica dell'aggiornamento di '%s' è stata rinviata."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Aggiornamento forzato dei metadati non elaborati in corso"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Recupero dei metadati del repository '%s'"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Disabilitare permanentemente il repository %s?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Errore durante la disabilitazione del repository '%s'."
 
 # TLABEL modules/inst_config_x11.ycp:578
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Si è verificato un problema durante il recupero dei file da '%s'."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Leggere il messaggio di errore visualizzato sopra."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Nessun URI definito per '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -6142,16 +6179,16 @@ msgstr ""
 "Aggiungere una o più voci URI di base (baseurl=URI) a %s per il repository "
 "'%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Nessun alias definito per questo repository."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Il repository '%s' non è valido."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -6159,22 +6196,22 @@ msgstr ""
 "Verificare che gli URI definiti per questo repository puntino a un "
 "repository valido."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Errore durante il recupero dei metadati per '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Costruzione forzata della cache del repository"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Errore durante l'analisi sintattica dei metadati per '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6186,44 +6223,44 @@ msgstr ""
 "segnalare un bug seguendo le istruzioni riportate in http://en.opensuse.org/"
 "Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 "Impossibile trovare nella cache locale i metadati del repository per '%s'."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Errore durante la creazione della cache:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Impossibile trovare il repository '%s' tramite alias, numero o URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Usare '%s' per ottenere una lista dei repository definiti."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Il repository disabilitato '%s' viene ignorato"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "L'opzione globale '%s' può essere utilizzata per abilitare temporaneamente i "
 "repository."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Il repository '%s' viene ignorato a causa dell'opzione '%s'."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Abilitazione temporanea del repository '%s'."
@@ -6231,7 +6268,7 @@ msgstr "Abilitazione temporanea del repository '%s'."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6240,7 +6277,7 @@ msgstr ""
 "Il repository '%s' non è aggiornato. È possibile eseguire 'zypper refresh' "
 "da root per aggiornarlo."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6249,83 +6286,83 @@ msgstr ""
 "La cache dei metadati del repository '%s' deve essere creata. Per questo "
 "scopo, è possibile eseguire 'zypper refresh'."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Il repository '%s' rimane disabilitato."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Inizializzazione della destinazione"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Inizializzazione destinazione non riuscita:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Pulizia della cache dei metadati per '%s'."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Pulizia della cache dei metadati non elaborati per '%s'."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Mantenimento della cache dei metadati non elaborati per %s '%s'."
 
 # TLABEL modules/inst_config_x11.ycp:578
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Pulizia dei pacchetti per '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Impossibile pulire il repository '%s' a causa di un errore."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Pulizia della cache dei pacchetti installati."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 "Impossibile pulire la cache dei pacchetti installati a causa di un errore."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Impossibile pulire i repository a causa di errori."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Alcuni repository non sono stati puliti a causa di un errore."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "I repository specificati sono stati puliti."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Tutti i repository sono stati puliti."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Questo è un supporto a sola lettura (CD/DVD) sostituibile, aggiornamento "
 "automatico disabilitato."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Alias del repository non valido: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6333,28 +6370,28 @@ msgstr ""
 "Impossibile determinare il tipo del repository. Verificare che l'URI "
 "definito (vedi sotto) punti a un repository valido:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Impossibile trovare un repository valido nella posizione specificata:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 "Si è verificato un problema durante il trasferimento dei dati del repository "
 "dall'URI specificato:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Verificare che l'URI specificato sia accessibile."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr ""
 "Si è verificato un problema sconosciuto durante l'aggiunta del repository:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6363,153 +6400,154 @@ msgstr ""
 "Il controllo GPG è disabilitato nella configurazione del repository '%1%'. "
 "Impossibile verificare l'integrità e l'origine dei pacchetti."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Il repository '%s' è stato aggiunto"
 
 # TLABEL modules/inst_config_x11.ycp:578
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Lettura dei dati dal supporto '%s'"
-
-# TLABEL modules/inst_config_x11.ycp:578
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-"Si è verificato un problema durante la lettura dei dati dal supporto '%s'"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Verificare che il supporto di installazione sia valido e leggibile."
-
-# TLABEL modules/inst_config_x11.ycp:578
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 "La lettura dei dati dal supporto '%s' è posticipata al prossimo "
 "aggiornamento."
 
-#: src/repos.cc:1352
+# TLABEL modules/inst_config_x11.ycp:578
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Lettura dei dati dal supporto '%s'"
+
+# TLABEL modules/inst_config_x11.ycp:578
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+"Si è verificato un problema durante la lettura dei dati dal supporto '%s'"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Verificare che il supporto di installazione sia valido e leggibile."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 "Si è verificato un problema durante l'accesso al file all'URI specificato"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Verificare che l'URI specificato sia valido e accessibile."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 "Si è verificato un problema durante l'analisi del file all'URI specificato"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "È un file .repo?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 "Si è verificato un problema durante il tentativo di lettura del file all'URI "
 "specificato"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 "È stato trovato un repository senza un alias definito nel file; il "
 "repository verrà ignorato."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 "Non è stato definito alcun URI per il repository '%s'; il repository verrà "
 "ignorato."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Il repository '%s' è stato rimosso."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "La priorità del repository '%s' è rimasta invariata (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Il repository '%s' è stato abilitato."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Il repository '%s' è stato disabilitato."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "L'aggiornamento automatico è stato abilitato per il repository '%s'."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
-msgstr "L'aggiornamento automatico è stato disabilitato per il repository '%s'."
+msgstr ""
+"L'aggiornamento automatico è stato disabilitato per il repository '%s'."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 "È stata abilitata la memorizzazione nella cache dei file RPM per il "
 "repository '%s'."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 "È stata disabilitata la memorizzazione nella cache dei file RPM per il "
 "repository '%s'."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "La verifica GPG è stata abilitata per il repository '%s'."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "La verifica GPG è stata disabilitata per il repository '%s'."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "La priorità del repository '%s' è stata impostata a %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Il nome del repository '%s' è stato impostato a '%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Nessuna modifica per il repository '%s'."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Repository %s non modificato."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Caricamento dati del repository in corso..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6517,12 +6555,12 @@ msgstr ""
 "Nessun repository definito. Utilizzare solo i risolvibili installati. "
 "Impossibile installare."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Recupero dei dati del repository '%s' in corso..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
@@ -6530,34 +6568,34 @@ msgstr ""
 "in corso..."
 
 # TLABEL modules/inst_config_x11.ycp:578
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Si è verificato un problema durante il caricamento dei dati da '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 "Impossibile aggiornare il repository '%s'. Viene usata la vecchia cache."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Risolvibili da '%s' non caricati a causa di un errore."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "I metadati del repository '%1%' sono scaduti da %2%."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Provare '%s' oppure '%s' prima di continuare."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6565,39 +6603,39 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 "I metadati del repository sono scaduti: verificare che 'autorefresh' sia "
-"attivato su (zypper lr), altrimenti aggiornare manualmente il repository ("
-"zypper ref). Se il problema persiste, il mirror in uso potrebbe essere rotto "
-"o il server ha effettivamente smesso di supportare il repository."
+"attivato su (zypper lr), altrimenti aggiornare manualmente il repository "
+"(zypper ref). Se il problema persiste, il mirror in uso potrebbe essere "
+"rotto o il server ha effettivamente smesso di supportare il repository."
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Lettura dei pacchetti installati in corso..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr ""
 "Si è verificato un problema durante la lettura dei pacchetti installati:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' sembra un file RPM. Verrà effettuato un tentativo di download."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 "Si è verificato un problema con il file RPM specificato come '%s'; il file "
 "verrà ignorato."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 "Si è verificato un problema durante la lettura dell'intestazione RPM di %s. "
 "Verificare che si tratti di un file RPM."
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Cache file RPM"
 
@@ -6605,25 +6643,25 @@ msgstr "Cache file RPM"
 msgid "System Packages"
 msgstr "Pacchetti di sistema"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Non è stata trovata alcuna patch necessaria."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Non è stato trovato alcun modello."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Non è stato trovato alcun pacchetto."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Nome interno"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Non è stato trovato alcun prodotto."
 
@@ -6662,7 +6700,8 @@ msgstr[1] ""
 #: src/solve-commit.cc:145
 msgid "Choose the above solution using '1' or cancel using 'c'"
 msgid_plural "Choose from above solutions by number or cancel"
-msgstr[0] "Scegliere la soluzione precedente premendo '1' o annulla premendo 'a'"
+msgstr[0] ""
+"Scegliere la soluzione precedente premendo '1' o annulla premendo 'a'"
 msgstr[1] "Scegliere tra le soluzioni precedenti per numero o annulla"
 
 #. translators: answers for dependency problem solution input prompt:
@@ -6753,7 +6792,8 @@ msgstr "Generazione del caso di prova del solver in corso..."
 #: src/solve-commit.cc:547
 #, c-format, boost-format
 msgid "Solver test case generated successfully at %s."
-msgstr "Generazione del caso di prova del solver completata con successo su %s."
+msgstr ""
+"Generazione del caso di prova del solver completata con successo su %s."
 
 #: src/solve-commit.cc:550
 msgid "Error creating the solver test case."
@@ -7034,7 +7074,7 @@ msgid "Updatestack"
 msgstr "Aggiorna stack"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Patch"
 
@@ -7059,7 +7099,7 @@ msgstr ""
 "Verranno installati prima gli aggiornamenti necessari per la gestione dei "
 "programmi:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Nessun aggiornamento trovato."
 
@@ -7068,48 +7108,48 @@ msgstr "Nessun aggiornamento trovato."
 msgid "The following updates are also available:"
 msgstr "Sono disponibili anche i seguenti aggiornamenti:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Aggiornamenti pacchetto"
 
 # TLABEL modules/inst_config_x11.ycp:578
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Aggiornamenti del modello"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Aggiornamenti prodotto"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Versione attuale"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Versione disponibile"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Nessun problema corrispondente trovato."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Sono state trovate le seguenti corrispondenze nei numeri dei problemi:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 "Sono state trovate corrispondenze nelle descrizioni delle seguenti patch:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "La correzione del problema numero %s di bugzilla non è stata trovata o non è "
 "necessaria."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
@@ -7117,7 +7157,7 @@ msgstr ""
 "necessaria."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""
@@ -7390,8 +7430,8 @@ msgid ""
 "provided as a subcommand or plug-in (see '%2%')."
 msgstr ""
 "Nel caso in cui '%1%' non sia un errore di digitazione, probabilmente non si "
-"tratta di un comando integrato, ma viene fornito come subcommand o plug-in ("
-"si veda '%2%')."
+"tratta di un comando integrato, ma viene fornito come subcommand o plug-in "
+"(si veda '%2%')."
 
 #. translators: %1% and %2% are plug-in packages which might provide it.
 #. translators: The word 'subcommand' also refers to a zypper command and should not be translated.

--- a/po/ja.po
+++ b/po/ja.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Japanese <https://l10n.opensuse.org/projects/zypper/master/ja/"
@@ -145,12 +145,14 @@ msgstr "既定の設定ファイルの代わりに指定した設定ファイル
 
 #: src/Config.cc:277
 msgid "User data string must not contain nonprintable or newline characters!"
-msgstr "ユーザデータ文字列には、表示不可能な文字や改行を含めることができません！"
+msgstr ""
+"ユーザデータ文字列には、表示不可能な文字や改行を含めることができません！"
 
 #. translators: --userdata <STRING>
 #: src/Config.cc:283
 msgid "User defined transaction id used in history and plugins."
-msgstr "履歴やプラグインで使用されるユーザ定義のトランザクション ID を指定します。"
+msgstr ""
+"履歴やプラグインで使用されるユーザ定義のトランザクション ID を指定します。"
 
 #. translators: --quiet, -q
 #: src/Config.cc:291
@@ -197,8 +199,9 @@ msgstr "rebootSuggested フラグの設定されたパッチを、対話型と�
 #: src/Config.cc:347
 msgid ""
 "Do not treat patches as interactive, which have the rebootSuggested-flag set."
-msgstr "rebootSuggested (再起動を提案する) フラグが設定されたパッチに対して、 "
-"これらを対話的なパッチとして扱わないようにします。"
+msgstr ""
+"rebootSuggested (再起動を提案する) フラグが設定されたパッチに対して、 これら"
+"を対話的なパッチとして扱わないようにします。"
 
 #. translators: --xmlout, -x
 #: src/Config.cc:357
@@ -214,7 +217,8 @@ msgstr "不明なパッケージを無視します。"
 #: src/Config.cc:373
 msgid ""
 "Terse output for machine consumption. Implies --no-abbrev and --no-color."
-msgstr "スクリプトなどで処理するために出力を簡潔にします。 --no-abbrev と --no-color "
+msgstr ""
+"スクリプトなどで処理するために出力を簡潔にします。 --no-abbrev と --no-color "
 "の機能を含みます。"
 
 #. translators: --reposd-dir, -D <DIR>
@@ -259,7 +263,8 @@ msgstr "GPG による確認の失敗を無視して続行します。"
 #, c-format, boost-format
 msgid ""
 "Turning on '%s'. New repository signing keys will be automatically imported!"
-msgstr "'%s' を有効にしています。新しいリポジトリ署名鍵は自動的にインポートされます！"
+msgstr ""
+"'%s' を有効にしています。新しいリポジトリ署名鍵は自動的にインポートされます！"
 
 #. translators: --gpg-auto-import-keys
 #: src/Config.cc:477
@@ -277,13 +282,14 @@ msgid ""
 "Additionally use disabled repositories providing a specific keyword. Try '--"
 "plus-content debug' to enable repos indicating to provide debug packages."
 msgstr ""
-"特定のキーワードを含む無効化されたリポジトリを、追加で使用する たとえば "
-"'--plus-content debug' "
-"のように指定すると、デバッグ用のリポジトリを有効化することができます。"
+"特定のキーワードを含む無効化されたリポジトリを、追加で使用する たとえば '--"
+"plus-content debug' のように指定すると、デバッグ用のリポジトリを有効化するこ"
+"とができます。"
 
 #: src/Config.cc:491
 msgid "Repositories disabled, using the database of installed packages only."
-msgstr "リポジトリは無効化されています。インストール済みのパッケージデータベースのみ"
+msgstr ""
+"リポジトリは無効化されています。インストール済みのパッケージデータベースのみ"
 "を使用します。"
 
 #. translators: --disable-repositories
@@ -323,8 +329,9 @@ msgstr "リモートのリポジトリを無視します。"
 msgid ""
 "Set the value of $releasever in all .repo files (default: distribution "
 "version)"
-msgstr "すべての .repo ファイル内での $releasever の値を指定します (既定値: "
-"ディストリビューションのバージョン)"
+msgstr ""
+"すべての .repo ファイル内での $releasever の値を指定します (既定値: ディスト"
+"リビューションのバージョン)"
 
 #: src/Config.cc:530
 msgid "Target Options"
@@ -339,7 +346,8 @@ msgstr "指定したルートディレクトリ内で処理を実施します。
 #: src/Config.cc:541
 msgid ""
 "Operate on a different root directory, but share repositories with the host."
-msgstr "このホストと同じリポジトリを使用したまま、指定したルートディレクトリ内で処理"
+msgstr ""
+"このホストと同じリポジトリを使用したまま、指定したルートディレクトリ内で処理"
 "を実施します。"
 
 #: src/Config.cc:547
@@ -368,17 +376,17 @@ msgstr "オプションの保存に失敗しました。"
 #, c-format, boost-format
 msgid ""
 "'%s' install modifier must not be used without a package name or capability."
-msgstr "'%s' "
-"のインストール修飾子は、パッケージ名もしくは能力とともに使用しなければなりま"
-"せん。"
+msgstr ""
+"'%s' のインストール修飾子は、パッケージ名もしくは能力とともに使用しなければな"
+"りません。"
 
 #: src/PackageArgs.cc:167
 #, c-format, boost-format
 msgid ""
 "'%s' remove modifier must not be used without a package name or capability."
-msgstr "'%s' "
-"のアンインストール修飾子は、パッケージ名もしくは能力とともに使用しなければな"
-"りません。"
+msgstr ""
+"'%s' のアンインストール修飾子は、パッケージ名もしくは能力とともに使用しなけれ"
+"ばなりません。"
 
 #: src/PackageArgs.cc:219
 #, c-format, boost-format
@@ -393,7 +401,8 @@ msgstr "'%s' は正しいパッケージ名でも能力でもありません。"
 #: src/RequestFeedback.cc:40
 #, c-format, boost-format
 msgid "'%s' not found in package names. Trying capabilities."
-msgstr "'%s' はパッケージ名としては見つかりませんでした。能力として検索します。"
+msgstr ""
+"'%s' はパッケージ名としては見つかりませんでした。能力として検索します。"
 
 #: src/RequestFeedback.cc:46
 #, c-format, boost-format
@@ -496,9 +505,9 @@ msgstr "'%s' ('%s' を提供) は既にインストール済みです。"
 msgid ""
 "No update candidate for '%s'. The highest available version is already "
 "installed."
-msgstr "'%s' "
-"に対する更新候補はありません。既に最新のバージョンがインストールされています"
-"。"
+msgstr ""
+"'%s' に対する更新候補はありません。既に最新のバージョンがインストールされてい"
+"ます。"
 
 #: src/RequestFeedback.cc:109
 #, c-format, boost-format
@@ -510,9 +519,9 @@ msgstr "'%s' に対するアップデート候補がありません。"
 msgid ""
 "There is an update candidate '%s' for '%s', but it does not match the "
 "specified version, architecture, or repository."
-msgstr "アップデート候補 '%s' が '%s' "
-"に対して存在しますが、指定したバージョン、アーキテクチャ、またはリポジトリに"
-"一致しません。"
+msgstr ""
+"アップデート候補 '%s' が '%s' に対して存在しますが、指定したバージョン、アー"
+"キテクチャ、またはリポジトリに一致しません。"
 
 #: src/RequestFeedback.cc:124
 #, c-format, boost-format
@@ -520,8 +529,9 @@ msgid ""
 "There is an update candidate for '%s' from vendor '%s', while the current "
 "vendor is '%s'. Use '%s' to install this candidate."
 msgstr ""
-"ベンダ '%2$s' が更新候補 '%1$s' を提供していますが、現在お使いのベンダは '%3$"
-"s' です。この更新候補をインストールしたい場合は、 '%4$s' を実行してください。"
+"ベンダ '%2$s' が更新候補 '%1$s' を提供していますが、現在お使いのベンダは "
+"'%3$s' です。この更新候補をインストールしたい場合は、 '%4$s' を実行してくださ"
+"い。"
 
 #: src/RequestFeedback.cc:133
 #, c-format, boost-format
@@ -529,34 +539,35 @@ msgid ""
 "There is an update candidate for '%s', but it comes from a repository with a "
 "lower priority. Use '%s' to install this candidate."
 msgstr ""
-"'%s' "
-"に対する更新候補がありますが、この更新は優先度の低いリポジトリが提供するもの"
-"です。 '%s' を使用すると、この候補をインストールできます。"
+"'%s' に対する更新候補がありますが、この更新は優先度の低いリポジトリが提供する"
+"ものです。 '%s' を使用すると、この候補をインストールできます。"
 
 #: src/RequestFeedback.cc:143
 #, c-format, boost-format
 msgid ""
 "There is an update candidate for '%s', but it is locked. Use '%s' to unlock "
 "it."
-msgstr "'%s' に対する更新候補がありますが、これはロックされています。 '%s' "
-"を使用するとロックを解除することができます。"
+msgstr ""
+"'%s' に対する更新候補がありますが、これはロックされています。 '%s' を使用する"
+"とロックを解除することができます。"
 
 #: src/RequestFeedback.cc:149
 #, c-format, boost-format
 msgid ""
 "Package '%s' is not available in your repositories. Cannot reinstall, "
 "upgrade, or downgrade."
-msgstr "パッケージ '%s' "
-"はお使いのリポジトリ内には見つかりません。再インストールやアップグレード、ダ"
-"ウングレードを行うことができません。"
+msgstr ""
+"パッケージ '%s' はお使いのリポジトリ内には見つかりません。再インストールや"
+"アップグレード、ダウングレードを行うことができません。"
 
 #: src/RequestFeedback.cc:159
 #, c-format, boost-format
 msgid ""
 "The selected package '%s' from repository '%s' has lower version than the "
 "installed one."
-msgstr "選択したパッケージ '%s' (リポジトリ '%s' から選択) "
-"は、インストール済みのバージョンよりも古いものになっています。"
+msgstr ""
+"選択したパッケージ '%s' (リポジトリ '%s' から選択) は、インストール済みのバー"
+"ジョンよりも古いものになっています。"
 
 #. translators: %s = "zypper install --oldpackage package-version.arch"
 #: src/RequestFeedback.cc:163
@@ -580,14 +591,15 @@ msgid ""
 "Patch '%1%' is optional. Use '%2%' to install it, or '%3%' to include all "
 "optional patches."
 msgstr ""
-"パッチ '%1%' は任意指定です。これらをインストールするには '%2%' を、"
-"全ての任意指定のパッチを含めるには '%3%' をそれぞれお使いください。"
+"パッチ '%1%' は任意指定です。これらをインストールするには '%2%' を、全ての任"
+"意指定のパッチを含めるには '%3%' をそれぞれお使いください。"
 
 #: src/RequestFeedback.cc:193
 #, c-format, boost-format
 msgid "Patch '%s' is locked. Use '%s' to install it, or unlock it using '%s'."
-msgstr "パッチ '%s' はロックされています。インストールするには '%s' を、"
-"ロックを解除するには '%s' を使用してください。"
+msgstr ""
+"パッチ '%s' はロックされています。インストールするには '%s' を、ロックを解除"
+"するには '%s' を使用してください。"
 
 #: src/RequestFeedback.cc:200
 #, c-format, boost-format
@@ -622,7 +634,8 @@ msgstr "削除向けに '%s' を選択します。"
 #: src/RequestFeedback.cc:234
 #, c-format, boost-format
 msgid "'%s' is locked. Use '%s' to unlock it."
-msgstr "'%s' はロックされています。ロックを解除するには '%s' をお使いください。"
+msgstr ""
+"'%s' はロックされています。ロックを解除するには '%s' をお使いください。"
 
 #: src/RequestFeedback.cc:239
 #, c-format, boost-format
@@ -869,8 +882,9 @@ msgid ""
 msgid_plural ""
 "The following %d packages are recommended, but will not be installed (only "
 "required packages will be installed):"
-msgstr[0] "以下 %d 個のパッケージが推奨されていますが、インストールを行いません "
-"(必要なパッケージのみをインストールします):"
+msgstr[0] ""
+"以下 %d 個のパッケージが推奨されていますが、インストールを行いません (必要な"
+"パッケージのみをインストールします):"
 
 #: src/Summary.cc:1159
 #, c-format, boost-format
@@ -880,8 +894,9 @@ msgid ""
 msgid_plural ""
 "The following %d packages are recommended, but will not be installed because "
 "they are unwanted (were manually removed before):"
-msgstr[0] "以下 %d 個のパッケージが推奨されていますが、"
-"不要であるためインストールを行いません (以前に手動で削除されています):"
+msgstr[0] ""
+"以下 %d 個のパッケージが推奨されていますが、不要であるためインストールを行い"
+"ません (以前に手動で削除されています):"
 
 #: src/Summary.cc:1169
 #, c-format, boost-format
@@ -891,9 +906,9 @@ msgid ""
 msgid_plural ""
 "The following %d packages are recommended, but will not be installed due to "
 "conflicts or dependency issues:"
-msgstr[0] "以下 %d "
-"個のパッケージが推奨されていますが、矛盾または依存関係の問題があるため、イン"
-"ストールを行いません:"
+msgstr[0] ""
+"以下 %d 個のパッケージが推奨されていますが、矛盾または依存関係の問題があるた"
+"め、インストールを行いません:"
 
 #: src/Summary.cc:1182
 #, c-format, boost-format
@@ -921,14 +936,16 @@ msgstr[0] "以下 %d 個の製品が推奨されていますが、インスト�
 msgid "The following application is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d applications are recommended, but will not be installed:"
-msgstr[0] "以下 %d 個のアプリケーションが推奨されていますが、インストールを行いません:"
+msgstr[0] ""
+"以下 %d 個のアプリケーションが推奨されていますが、インストールを行いません:"
 
 #: src/Summary.cc:1228
 #, c-format, boost-format
 msgid "The following package is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d packages are suggested, but will not be installed:"
-msgstr[0] "以下 %d 個のパッケージが提案されていますが、インストールを行いません:"
+msgstr[0] ""
+"以下 %d 個のパッケージが提案されていますが、インストールを行いません:"
 
 #: src/Summary.cc:1233
 #, c-format, boost-format
@@ -956,7 +973,8 @@ msgstr[0] "以下 %d 個の製品が提案されていますが、インスト�
 msgid "The following application is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d applications are suggested, but will not be installed:"
-msgstr[0] "以下 %d 個のアプリケーションが提案されていますが、インストールを行いません:"
+msgstr[0] ""
+"以下 %d 個のアプリケーションが提案されていますが、インストールを行いません:"
 
 #: src/Summary.cc:1274
 #, c-format, boost-format
@@ -1023,7 +1041,8 @@ msgstr[0] "以下 %d 個のアプリケーションのベンダを変更しま�
 msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
-msgstr[0] "以下 %d 個のパッケージには、ベンダ側でのサポート情報が記されていません:"
+msgstr[0] ""
+"以下 %d 個のパッケージには、ベンダ側でのサポート情報が記されていません:"
 
 #: src/Summary.cc:1382
 #, c-format, boost-format
@@ -1037,7 +1056,8 @@ msgid ""
 "The following package needs additional customer contract to get support:"
 msgid_plural ""
 "The following %d packages need additional customer contract to get support:"
-msgstr[0] "以下 %d 個のパッケージのサポートを得るには、追加の顧客契約が必要です:"
+msgstr[0] ""
+"以下 %d 個のパッケージのサポートを得るには、追加の顧客契約が必要です:"
 
 #: src/Summary.cc:1417
 msgid "was superseded by"
@@ -1051,9 +1071,9 @@ msgid ""
 msgid_plural ""
 "The following %d packages were discontinued and have been superseded by a "
 "new packages with different names."
-msgstr[0] "以下の %d "
-"個のパッケージは廃止済みとなり、異なる名前の新しいパッケージによって置き換え"
-"られました。"
+msgstr[0] ""
+"以下の %d 個のパッケージは廃止済みとなり、異なる名前の新しいパッケージによっ"
+"て置き換えられました。"
 
 #: src/Summary.cc:1435
 msgid ""
@@ -1062,7 +1082,8 @@ msgid ""
 msgid_plural ""
 "The successor packages should be installed as soon as possible to receive "
 "continued support:"
-msgstr[0] "サポートを受け続けるには、できる限り速やかに後継パッケージをインストールする"
+msgstr[0] ""
+"サポートを受け続けるには、できる限り速やかに後継パッケージをインストールする"
 "必要があります:"
 
 #: src/Summary.cc:1460
@@ -1117,7 +1138,8 @@ msgstr[0] "以下 %d 個のパッチを適用するには、システムの再�
 #, c-format, boost-format
 msgid "The following package requires a system reboot:"
 msgid_plural "The following %d packages require a system reboot:"
-msgstr[0] "以下 %d 個のパッケージをインストールするには、システムの再起動が必要です:"
+msgstr[0] ""
+"以下 %d 個のパッケージをインストールするには、システムの再起動が必要です:"
 
 #: src/Summary.cc:1563
 msgid "Skipped needed patches which do not apply without conflict:"
@@ -1258,16 +1280,17 @@ msgstr[0] "個のソースパッケージのインストール"
 msgid ""
 "Package manager restart required. (Run this command once again after the "
 "update stack got updated)"
-msgstr "パッケージマネージャの再起動が必要です。 "
-"(更新スタックの更新後、再度このコマンドを実行してください)"
+msgstr ""
+"パッケージマネージャの再起動が必要です。 (更新スタックの更新後、再度このコマ"
+"ンドを実行してください)"
 
 #. translator: %1% is an option string like  "--dry-run"
 #: src/Summary.cc:1824
 #, boost-format
 msgid "%1% is set, otherwise a system reboot would be required."
-msgstr "今回は %1% "
-"が指定されているためシステムの再起動は不要ですが、これを指定しない場合、シス"
-"テムの再起動が必要となります。"
+msgstr ""
+"今回は %1% が指定されているためシステムの再起動は不要ですが、これを指定しない"
+"場合、システムの再起動が必要となります。"
 
 #: src/Summary.cc:1826
 msgid "System reboot required."
@@ -1298,9 +1321,8 @@ msgid ""
 "We can ask PackageKit to interrupt the current action as soon as possible, "
 "but it depends on PackageKit how fast it will respond to this request."
 msgstr ""
-"PackageKit "
-"に対して、現在のセッションをできる限り速やかに中断するよう依頼しますが、"
-"どれだけの時間を要するのかは PackageKit 側の都合によります。"
+"PackageKit に対して、現在のセッションをできる限り速やかに中断するよう依頼しま"
+"すが、どれだけの時間を要するのかは PackageKit 側の都合によります。"
 
 #: src/Zypper.cc:96
 msgid "Ask PackageKit to quit?"
@@ -1314,7 +1336,7 @@ msgstr "PackageKitが稼働中です(おそらくビジーです)。"
 msgid "Try again?"
 msgstr "再試行しますか？"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "予期しない例外が発生しました。"
 
@@ -1339,19 +1361,19 @@ msgid ""
 "The /etc/products.d/baseproduct symlink is dangling or missing!\n"
 "The link must point to your core products .prod file in /etc/products.d.\n"
 msgstr ""
-"/etc/products.d/"
-"baseproductのシンボリックリンクに参照先がないか、見つかりません。\n"
-"このリンクは、/etc/"
-"products.d内にあるコア製品の.prodファイルを示していなければなりません。\n"
+"/etc/products.d/baseproductのシンボリックリンクに参照先がないか、見つかりませ"
+"ん。\n"
+"このリンクは、/etc/products.d内にあるコア製品の.prodファイルを示していなけれ"
+"ばなりません。\n"
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "%s オプションはここでは意味がありません。無視します。"
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "オプション以外のプログラム引数: "
 
@@ -1362,10 +1384,9 @@ msgid ""
 "the repository provider or check their web site. Many providers maintain a "
 "web page showing the fingerprints of the GPG keys they are using."
 msgstr ""
-"GPG 公開鍵は、名前ではなく指紋で必ずご確認ください。 "
-"また、提示された鍵に確証が持てない場合は、リポジトリの提供者もしくは Web "
-"サイトをご確認ください。多くの場合、 Web サイトにて GPG 鍵の指紋を公開 "
-"しています。"
+"GPG 公開鍵は、名前ではなく指紋で必ずご確認ください。 また、提示された鍵に確証"
+"が持てない場合は、リポジトリの提供者もしくは Web サイトをご確認ください。多く"
+"の場合、 Web サイトにて GPG 鍵の指紋を公開 しています。"
 
 #: src/callbacks/keyring.h:38
 msgid ""
@@ -1374,10 +1395,10 @@ msgid ""
 "signature can lead to a corrupted system and in extreme cases even to a "
 "system compromise."
 msgstr ""
-"データへの署名は、受信者に署名後の改ざんが無いことを示すための仕組みです。 "
-"署名のないデータや誤った署名のデータ、もしくは未知の署名が書かれたデータを "
-"受け付けてしまうと、システムを壊すことにも繋がってしまうほか、場合によっては "
-"システムに不正侵入を許してしまう結果にもなりかねません。"
+"データへの署名は、受信者に署名後の改ざんが無いことを示すための仕組みです。 署"
+"名のないデータや誤った署名のデータ、もしくは未知の署名が書かれたデータを 受け"
+"付けてしまうと、システムを壊すことにも繋がってしまうほか、場合によっては シス"
+"テムに不正侵入を許してしまう結果にもなりかねません。"
 
 #. translator: %1% is a file name
 #: src/callbacks/keyring.h:46
@@ -1385,9 +1406,9 @@ msgstr ""
 msgid ""
 "File '%1%' is the repositories master index file. It ensures the integrity "
 "of the whole repo."
-msgstr "ファイル '%1%' "
-"はリポジトリのマスターインデックスファイルです。リポジトリ全体の整合性を確認"
-"するために用意されています。"
+msgstr ""
+"ファイル '%1%' はリポジトリのマスターインデックスファイルです。リポジトリ全体"
+"の整合性を確認するために用意されています。"
 
 #: src/callbacks/keyring.h:52
 msgid ""
@@ -1416,11 +1437,11 @@ msgid ""
 "the signature verification might fail. After a few minutes, when the server "
 "has updated its data, it should work again."
 msgstr ""
-"サーバ側で新しいデータを受信途中の場合、一時的に問題が発生する場合があります"
-"。これは、データファイルと署名が別々のファイルでありながら、互いに合致してい"
-"なければならない仕組みであるためです。データファイルと署名のどちらか片方だけ"
-"が受信済みの場合、署名検証は失敗します。しばらくして両方が受信済みになると、"
-"署名検証が成功するようになるはずです。"
+"サーバ側で新しいデータを受信途中の場合、一時的に問題が発生する場合がありま"
+"す。これは、データファイルと署名が別々のファイルでありながら、互いに合致して"
+"いなければならない仕組みであるためです。データファイルと署名のどちらか片方だ"
+"けが受信済みの場合、署名検証は失敗します。しばらくして両方が受信済みになる"
+"と、署名検証が成功するようになるはずです。"
 
 #: src/callbacks/keyring.h:88
 msgid "Repository:"
@@ -1490,14 +1511,16 @@ msgstr "リポジトリ '%2%' からのファイル '%1%' には署名があり�
 #: src/callbacks/keyring.h:201
 #, c-format, boost-format
 msgid "Accepting file '%s' signed with an unknown key '%s'."
-msgstr "受け入れようとしているファイル '%s' は不明な鍵 '%s' で署名されています。"
+msgstr ""
+"受け入れようとしているファイル '%s' は不明な鍵 '%s' で署名されています。"
 
 #: src/callbacks/keyring.h:205
 #, c-format, boost-format
 msgid ""
 "Accepting file '%s' from repository '%s' signed with an unknown key '%s'."
-msgstr "受け入れようとしているファイル '%s' (リポジトリ '%s') は不明な鍵 '%s' "
-"で署名されています。"
+msgstr ""
+"受け入れようとしているファイル '%s' (リポジトリ '%s') は不明な鍵 '%s' で署名"
+"されています。"
 
 #. translator: %1% is a file name, %2% is a gpg key ID
 #: src/callbacks/keyring.h:214
@@ -1509,7 +1532,8 @@ msgstr "ファイル '%1%' は不明な鍵 '%2%' で署名されています。"
 #: src/callbacks/keyring.h:217
 #, boost-format
 msgid "File '%1%' from repository '%3%' is signed with an unknown key '%2%'."
-msgstr "リポジトリ '%3%' からのファイル '%1%' は不明な鍵 '%2%' で署名されています。"
+msgstr ""
+"リポジトリ '%3%' からのファイル '%1%' は不明な鍵 '%2%' で署名されています。"
 
 #: src/callbacks/keyring.h:246
 msgid "Automatically importing the following key:"
@@ -1526,8 +1550,9 @@ msgstr "新しいリポジトリまたはパッケージの署名鍵を受信し
 #. translators: this message is shown after showing description of the key
 #: src/callbacks/keyring.h:284
 msgid "Do you want to reject the key, trust temporarily, or trust always?"
-msgstr "鍵を拒否しますか(R)? "
-"一時的に信頼しますか(T)?それとも今後ずっと信頼しますか(A)?"
+msgstr ""
+"鍵を拒否しますか(R)? 一時的に信頼しますか(T)?それとも今後ずっと信頼しますか"
+"(A)?"
 
 #. translators: this message is shown after showing description of the key
 #: src/callbacks/keyring.h:287
@@ -1581,12 +1606,14 @@ msgstr "ファイル '%s' に対する署名検証が失敗しましたが、無
 #, c-format, boost-format
 msgid ""
 "Ignoring failed signature verification for file '%s' from repository '%s'!"
-msgstr "ファイル '%s' (リポジトリ '%s') "
-"に対する署名検証が失敗しましたが、無視しています!"
+msgstr ""
+"ファイル '%s' (リポジトリ '%s') に対する署名検証が失敗しましたが、無視してい"
+"ます!"
 
 #: src/callbacks/keyring.h:376
 msgid "Double-check this is not caused by some malicious changes in the file!"
-msgstr "ファイルに対して悪意のある変更が行われていないか、もう一度ご確認ください！"
+msgstr ""
+"ファイルに対して悪意のある変更が行われていないか、もう一度ご確認ください！"
 
 #. translator: %1% is a file name
 #: src/callbacks/keyring.h:386
@@ -1605,9 +1632,8 @@ msgid ""
 "The rpm database seems to contain old V3 version gpg keys which are "
 "meanwhile obsolete and considered insecure:"
 msgstr ""
-"RPM データベース内に、古い V3 形式の GPG "
-"鍵が存在しているものと思われます。この形式は既に古く、機密が保持できないもの"
-"と考えられています:"
+"RPM データベース内に、古い V3 形式の GPG 鍵が存在しているものと思われます。こ"
+"の形式は既に古く、機密が保持できないものと考えられています:"
 
 #: src/callbacks/keyring.h:445
 #, boost-format
@@ -1619,15 +1645,17 @@ msgstr "鍵についての詳細を表示するには、 '%1%' を実行して�
 msgid ""
 "Unless you believe the key in question is still in use, you can remove it "
 "from the rpm database calling '%1%'."
-msgstr "本件の鍵を現在もなお使用している場合を除き、 '%1%' で RPM "
-"データベースから鍵を削除しておくことをお勧めします。"
+msgstr ""
+"本件の鍵を現在もなお使用している場合を除き、 '%1%' で RPM データベースから鍵"
+"を削除しておくことをお勧めします。"
 
 #. translator: %1% is the number of keys, %2% the name of a repository
 #: src/callbacks/keyring.h:468
 #, boost-format
 msgid "Received %1% new package signing key from repository \"%2%\":"
 msgid_plural "Received %1% new package signing keys from repository \"%2%\":"
-msgstr[0] "リポジトリ 「%2%」 から %1% 個の新しいパッケージ署名鍵を受信しました:"
+msgstr[0] ""
+"リポジトリ 「%2%」 から %1% 個の新しいパッケージ署名鍵を受信しました:"
 
 #: src/callbacks/keyring.h:472
 msgid ""
@@ -1636,8 +1664,8 @@ msgid ""
 "installation the new keys will be imported into the rpm database."
 msgstr ""
 "これらの追加鍵は通常、リポジトリから提供されるパッケージに対する署名で使用さ"
-"れます。ダウンロードやインストールの際、パッケージの検証を行うため、"
-"これらの新しい鍵を RPM データベース内に取り込みます。"
+"れます。ダウンロードやインストールの際、パッケージの検証を行うため、これらの"
+"新しい鍵を RPM データベース内に取り込みます。"
 
 #: src/callbacks/keyring.h:474
 msgid "New:"
@@ -1647,7 +1675,8 @@ msgstr "新規:"
 msgid ""
 "The repository metadata introducing the new keys have been signed and "
 "validated by the trusted key:"
-msgstr "新しい鍵を指し示しているリポジトリのメタデータが、下記の信頼済み鍵で署名され"
+msgstr ""
+"新しい鍵を指し示しているリポジトリのメタデータが、下記の信頼済み鍵で署名され"
 "ていることを確認しました:"
 
 #: src/callbacks/keyring.h:503
@@ -1679,7 +1708,8 @@ msgstr ""
 msgid ""
 "Accepting packages with wrong checksums can lead to a corrupted system and "
 "in extreme cases even to a system compromise."
-msgstr "チェックサムが正しくないパッケージを受け入れてしまうと、システムを壊す可能性"
+msgstr ""
+"チェックサムが正しくないパッケージを受け入れてしまうと、システムを壊す可能性"
 "があるほか、不正なソフトウエアを動作させることにもなります。"
 
 #: src/callbacks/keyring.h:548
@@ -1692,8 +1722,8 @@ msgid ""
 "to unblock using this file on your own risk. Empty input will discard the "
 "file.\n"
 msgstr ""
-"チェックサム '%1%..' "
-"のファイルが不正に改変されておらず、間違いのないことが分かっている場合で、\n"
+"チェックサム '%1%..' のファイルが不正に改変されておらず、間違いのないことが分"
+"かっている場合で、\n"
 "この操作を続行したい場合は、チェックサムの冒頭4文字を入力し、自己責任で\n"
 "保護を解除してください。何も入力しないと、対象のファイルは廃棄されます。\n"
 
@@ -1720,11 +1750,13 @@ msgstr "保護を解除しますか？それとも破棄しますか？"
 #: src/callbacks/locks.h:27
 msgid ""
 "The following query locks the same objects as the one you want to remove:"
-msgstr "下記の問い合わせは、削除しようとしているオブジェクトをロックしてしまいます:"
+msgstr ""
+"下記の問い合わせは、削除しようとしているオブジェクトをロックしてしまいます:"
 
 #: src/callbacks/locks.h:30
 msgid "The following query locks some of the objects you want to unlock:"
-msgstr "下記の問い合わせは、ロックを解除しようとしているオブジェクトをロックしてしま"
+msgstr ""
+"下記の問い合わせは、ロックを解除しようとしているオブジェクトをロックしてしま"
 "います:"
 
 # power-off message
@@ -1840,8 +1872,9 @@ msgstr "メディアを取り出します。"
 msgid ""
 "Please insert medium [%s] #%d and type 'y' to continue or 'n' to cancel the "
 "operation."
-msgstr "メディア [%s] #%d を挿入し 'y' を入力して続行するか、 'n' "
-"を入力してキャンセルしてください。"
+msgstr ""
+"メディア [%s] #%d を挿入し 'y' を入力して続行するか、 'n' を入力してキャンセ"
+"ルしてください。"
 
 #. translators: a/r/i/u are replies to the "Abort, retry, ignore?" prompt
 #. Translate the a/r/i part exactly as you did the a/r/i string.
@@ -1855,8 +1888,9 @@ msgstr "a/r/i/u"
 msgid ""
 "Authentication required to access %s. You need to be root to be able to read "
 "the credentials from %s."
-msgstr "%s にアクセスするには認証が必要です。%s "
-"からの証明書を読むには、rootである必要があります。"
+msgstr ""
+"%s にアクセスするには認証が必要です。%s からの証明書を読むには、rootである必"
+"要があります。"
 
 #: src/callbacks/media.cc:314 src/callbacks/media.cc:321
 msgid "User Name"
@@ -1975,9 +2009,9 @@ msgid ""
 msgid_plural ""
 "%1% packages had to be excluded from file conflicts check because they are "
 "not yet downloaded."
-msgstr[0] "%1% "
-"個のパッケージはダウンロードを行っていないため、ファイルの競合チェックからは"
-"除外されています。"
+msgstr[0] ""
+"%1% 個のパッケージはダウンロードを行っていないため、ファイルの競合チェックか"
+"らは除外されています。"
 
 #. TranslatorExplanation %1%(commandline option)
 #: src/callbacks/rpm.h:513
@@ -1987,9 +2021,9 @@ msgid ""
 "in advance in order to access their file lists. See option '%1%' in the "
 "zypper manual page for details."
 msgstr ""
-"ファイルの競合の確認では、インストールされていないパッケージを事前にダウンロ"
-"ードしてファイルリストを入手する必要があります。詳細については、"
-"zypperのオプション '%1%' に関するマニュアルページをお読みください。"
+"ファイルの競合の確認では、インストールされていないパッケージを事前にダウン"
+"ロードしてファイルリストを入手する必要があります。詳細については、zypperのオ"
+"プション '%1%' に関するマニュアルページをお読みください。"
 
 #. TranslatorExplanation %1%(number of conflicts); detailed list follows
 #: src/callbacks/rpm.h:523
@@ -2084,26 +2118,33 @@ msgid "Commands:"
 msgstr "コマンド:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "インストールの詳細なサマリを表示します。"
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "パッケージの種類を指定します (%1%) 。"
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
-msgstr "「ベストエフォート」方式での更新を指定します。最新・最良ではない古いバージョ"
+msgstr ""
+"「ベストエフォート」方式での更新を指定します。最新・最良ではない古いバージョ"
 "ンへの更新も受け入れるようにします。"
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "パッケージ管理システム自身に影響するパッチのみを使用します。"
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2121,7 +2162,8 @@ msgstr ""
 msgid ""
 "The target filesystem is mounted as read-only. Please make sure the target "
 "filesystem is writeable."
-msgstr "ターゲットのファイルシステムが読み込み専用でマウントされています。書き込み可"
+msgstr ""
+"ターゲットのファイルシステムが読み込み専用でマウントされています。書き込み可"
 "能な状態にしてください。"
 
 #. translators: command synopsis; do not translate lowercase words
@@ -2152,17 +2194,17 @@ msgid ""
 "enabled repositories fail to refresh. This may severely damage the system. "
 "If a failing repository is actually not needed, it must be disabled."
 msgstr ""
-"孤立したパッケージを処理する目的から、 dist-upgrade "
-"を使用する場合は、リポジトリ設定に関して特に注意を払わなければなりません。特"
-"に、更新できなくなっているリポジトリがある場合、そのまま続行してはなりません"
-"。これによってシステムに深刻な被害が生じる可能性があるためです。また、更新で"
-"きなくなっているリポジトリが不要なリポジトリであれば、無効化しなければなりま"
-"せん。"
+"孤立したパッケージを処理する目的から、 dist-upgrade を使用する場合は、リポジ"
+"トリ設定に関して特に注意を払わなければなりません。特に、更新できなくなってい"
+"るリポジトリがある場合、そのまま続行してはなりません。これによってシステムに"
+"深刻な被害が生じる可能性があるためです。また、更新できなくなっているリポジト"
+"リが不要なリポジトリであれば、無効化しなければなりません。"
 
 #: src/commands/distupgrade.cc:57
 msgid "See 'man zypper' for more information about this command."
-msgstr "このコマンドに関する詳細については、 'man zypper' "
-"で表示されるマニュアルページをお読みください。"
+msgstr ""
+"このコマンドに関する詳細については、 'man zypper' で表示されるマニュアルペー"
+"ジをお読みください。"
 
 #: src/commands/distupgrade.cc:88
 #, c-format, boost-format
@@ -2178,15 +2220,16 @@ msgstr ""
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/help.cc:22
 msgid "zypper [--GLOBAL-OPTIONS] <COMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
-msgstr "zypper [--グローバルオプション] <コマンド> [--コマンドオプション] "
-"[パラメータ]"
+msgstr ""
+"zypper [--グローバルオプション] <コマンド> [--コマンドオプション] [パラメー"
+"タ]"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/help.cc:25
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <サブコマンド> [--コマンドオプション] [パラメータ]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "zypper のヘルプを表示します"
 
@@ -2203,7 +2246,8 @@ msgstr "verify (ve) [オプション]"
 #. translators: command summary: install-new-recommends, inr
 #: src/commands/inrverify.cc:81
 msgid "Install newly added packages recommended by installed packages."
-msgstr "インストール済みのパッケージが推奨する新しいパッケージをインストールします。"
+msgstr ""
+"インストール済みのパッケージが推奨する新しいパッケージをインストールします。"
 
 #. translators: command summary: verify, ve
 #: src/commands/inrverify.cc:84
@@ -2233,10 +2277,9 @@ msgid ""
 "supporting available hardware, languages or filesystems. Useful after having "
 "added e.g. new hardware or driver repos."
 msgstr ""
-"'%1%' "
-"として実行します。これにより、利用可能なハードウエアや言語、ファイルシステム"
-"に対応するパッケージのみを参照するように制限します。新しいハードウエアやドラ"
-"イバのリポジトリを追加したような場合に便利です。"
+"'%1%' として実行します。これにより、利用可能なハードウエアや言語、ファイルシ"
+"ステムに対応するパッケージのみを参照するように制限します。新しいハードウエア"
+"やドライバのリポジトリを追加したような場合に便利です。"
 
 #. translators: command description
 #: src/commands/inrverify.cc:101
@@ -2272,8 +2315,8 @@ msgid ""
 "[OP<VERSION>], where OP is one of <, <=, =, >=, >."
 msgstr ""
 "指定した能力設定を持つパッケージを削除します。 能力設定はNAME[.ARCH]"
-"[OP<VERSION>]の形式で記述します。 "
-"「OP」は<、<=、=、>=、>のうちのいずれかを指定します。"
+"[OP<VERSION>]の形式で記述します。 「OP」は<、<=、=、>=、>のうちのいずれかを指"
+"定します。"
 
 #: src/commands/installremove.cc:104 src/commands/installremove.cc:234
 #: src/utils/messages.cc:53
@@ -2300,7 +2343,8 @@ msgstr ""
 
 #: src/commands/installremove.cc:126
 msgid "Uninstallation of a source package not defined and implemented."
-msgstr "ソースパッケージのアンインストールは定義されておらず、実装もされていません。"
+msgstr ""
+"ソースパッケージのアンインストールは定義されておらず、実装もされていません。"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/installremove.cc:166
@@ -2319,10 +2363,10 @@ msgid ""
 "location. A capability is NAME[.ARCH][OP<VERSION>], where OP is one of <, "
 "<=, =, >=, >."
 msgstr ""
-"指定した能力設定を解決してパッケージのインストールを行うか、"
-"もしくは指定した場所から "
-"RPMパッケージファイルをインストールします。能力設定はNAME[.ARCH][OP<VERSION>]"
-"の形式で記述します。 「OP」は<、<=、=、>=、>のうちのいずれかを指定します。"
+"指定した能力設定を解決してパッケージのインストールを行うか、もしくは指定した"
+"場所から RPMパッケージファイルをインストールします。能力設定はNAME[.ARCH]"
+"[OP<VERSION>]の形式で記述します。 「OP」は<、<=、=、>=、>のうちのいずれかを指"
+"定します。"
 
 #. translators: --from <ALIAS|#|URI>
 #: src/commands/installremove.cc:195 src/commands/utils/download.cc:170
@@ -2335,14 +2379,15 @@ msgid ""
 "Allows one to replace a newer item with an older one. Handy if you are doing "
 "a rollback. Unlike --force it will not enforce a reinstall."
 msgstr ""
-"新しいものを古いもので置き換えることができるように "
-"します。古いバージョンに戻す場合に有用です。--force "
-"とは異なり、再インストールを強制することはありません。"
+"新しいものを古いもので置き換えることができるように します。古いバージョンに戻"
+"す場合に有用です。--force とは異なり、再インストールを強制することはありませ"
+"ん。"
 
 #: src/commands/installremove.cc:203
 msgid "Silently install unsigned rpm packages given as commandline parameters."
-msgstr "コマンドラインパラメータで指定した未署名の RPM "
-"パッケージを、警告を発することなくインストールします。"
+msgstr ""
+"コマンドラインパラメータで指定した未署名の RPM パッケージを、警告を発すること"
+"なくインストールします。"
 
 #. translators: -f, --force
 #: src/commands/installremove.cc:208
@@ -2350,10 +2395,9 @@ msgid ""
 "Install even if the item is already installed (reinstall), downgraded or "
 "changes vendor or architecture."
 msgstr ""
-"既にインストールされている場合であっても、インストールします(再インストール)"
-"。 "
-"ダウングレードやベンダの変更、アーキテクチャの変更などが発生する場合がありま"
-"す。"
+"既にインストールされている場合であっても、インストールします(再インストー"
+"ル)。 ダウングレードやベンダの変更、アーキテクチャの変更などが発生する場合が"
+"あります。"
 
 #. translators: rug related message, shown if
 #. 'zypper in --entire-catalog foorepo someargument' is specified
@@ -2386,10 +2430,9 @@ msgid ""
 "Temporary Fix)."
 msgstr ""
 "依存関係にあるパッケージの削除よりも置換を優先する削除コマンドです。実際に、 "
-"install コマンドで削除演算子 (-) "
-"を指定してインストールした場合と同じ動作になり、たとえば 'removeptf foo' は "
-"'install -- -foo' の意味になります。なお、 install "
-"コマンドと同じオプションを指定することができます。このコマンドは PTF "
+"install コマンドで削除演算子 (-) を指定してインストールした場合と同じ動作にな"
+"り、たとえば 'removeptf foo' は 'install -- -foo' の意味になります。なお、 "
+"install コマンドと同じオプションを指定することができます。このコマンドは PTF "
 "(プログラム一時修正; Program Temporary Fix) を削除する際の推奨コマンドです。"
 
 #: src/commands/installremove.cc:317
@@ -2400,29 +2443,29 @@ msgid ""
 "remove command would do. The removeptf command however will aim to replace "
 "the dependant packages by their official update versions."
 msgstr ""
-"通常、 PTF は対象のパッケージに公式な更新が公開されるとすぐに削除されますが、"
-" PTF を削除しようとして通常の削除コマンドを実行してしまうと、 PTF "
-"だけでなく対象のパッケージまで削除してしまいます。 removeptf "
-"コマンドはこのような問題に対応するためのコマンドで、 PTF "
-"を公式の更新版に置き換えることを目的としたコマンドです。"
+"通常、 PTF は対象のパッケージに公式な更新が公開されるとすぐに削除されます"
+"が、 PTF を削除しようとして通常の削除コマンドを実行してしまうと、 PTF だけで"
+"なく対象のパッケージまで削除してしまいます。 removeptf コマンドはこのような問"
+"題に対応するためのコマンドで、 PTF を公式の更新版に置き換えることを目的とした"
+"コマンドです。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [オプション]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "利用可能なパッチを一覧で表示します。"
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "適用可能なパッチを一覧で表示します。"
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "適用可能なものだけでなく、すべてのパッチを一覧で表示します。"
 
@@ -2446,8 +2489,9 @@ msgstr "利用可能な更新の一覧を表示します。"
 msgid ""
 "List all packages for which newer versions are available, regardless whether "
 "they are installable or not."
-msgstr "インストール可能であるかどうかを問わず、 新しいバージョンが利用可能な "
-"全てのパッケージを一覧表示します。"
+msgstr ""
+"インストール可能であるかどうかを問わず、 新しいバージョンが利用可能な 全ての"
+"パッケージを一覧表示します。"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/locale/addlocalecmd.cc:20
@@ -2471,56 +2515,63 @@ msgstr "指定したロケールに対するパッケージをインストール
 msgid ""
 "Specify locale which shall be supported by the language code. Get a list of "
 "all available locales by calling '%s'."
-msgstr "対応すべきロケールを、言語コードで指定します。利用可能なロケールの一覧は、 "
+msgstr ""
+"対応すべきロケールを、言語コードで指定します。利用可能なロケールの一覧は、 "
 "'%s' を実行することで表示することができます。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [オプション] [ロケール] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "必要なロケール (言語コード) の一覧を表示します。"
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
-msgstr "必要であるとして指定したロケールと、対応するパッケージを一覧で表示します。"
+msgstr ""
+"必要であるとして指定したロケールと、対応するパッケージを一覧で表示します。"
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "対応するパッケージを表示します。"
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "利用可能なロケールの一覧を表示します。"
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr "-all パラメータが指定されているため、固定引数が無視されます。"
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "表示すべきロケールを指定します。"
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
-msgstr "'en' で始まるロケールのうち、フォールバックである 'en' "
-"そのものを除外したものを表示したい場合は、下記のようにします:"
+msgstr ""
+"'en' で始まるロケールのうち、フォールバックである 'en' そのものを除外したもの"
+"を表示したい場合は、下記のようにします:"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
-msgstr "言語コード 'en' "
-"に対応する全てのロケールのうち、国コードがあるものと無いものの両方を表示しま"
-"す:"
+msgstr ""
+"言語コード 'en' に対応する全てのロケールのうち、国コードがあるものと無いもの"
+"の両方を表示します:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "指定したパラメータに正確に一致するロケールを表示します: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "'de' と 'en' の両方に対して、利用可能なパッケージを表示します:"
 
@@ -2542,7 +2593,8 @@ msgstr "指定したロケールを、必要なロケールの一覧から削除
 msgid ""
 "Specify locales which shall be removed by the language code. Get the list of "
 "requested locales by calling '%s'."
-msgstr "削除すべきロケールを、言語コードで指定します。利用可能なロケールの一覧は、 "
+msgstr ""
+"削除すべきロケールを、言語コードで指定します。利用可能なロケールの一覧は、 "
 "'%s' を実行することで表示することができます。"
 
 #: src/commands/locale/removelocalecmd.cc:46
@@ -2567,10 +2619,10 @@ msgid ""
 "type option."
 msgstr ""
 "\"ロック指定\" は '[種類:]名前[ 演算子 エディション]' の形式で指定します。 "
-"\"種類\" には * や ? "
-"のワイルドカード文字を利用したグロブパターンを記述することもできます。また、"
-"パッケージ以外のものを指定したい場合は、 'patch:foo' (パッチを指定する場合) "
-"などのように指定するか、もしくは --type オプションをお使いください。"
+"\"種類\" には * や ? のワイルドカード文字を利用したグロブパターンを記述するこ"
+"ともできます。また、パッケージ以外のものを指定したい場合は、 'patch:foo' "
+"(パッチを指定する場合) などのように指定するか、もしくは --type オプションをお"
+"使いください。"
 
 #: src/commands/locks/add.cc:36
 msgid ""
@@ -2580,8 +2632,8 @@ msgid ""
 msgstr ""
 "名前のみを指定する基本形の場合、該当する全てのエディションを対象とすることに"
 "なります。必要であれば、特定のエディションもしくはその範囲を指定するため、 "
-"=, <, <=, >, >=, != "
-"のいずれかの演算子を使用し、その後ろにエディションを記述することもできます。"
+"=, <, <=, >, >=, != のいずれかの演算子を使用し、その後ろにエディションを記述"
+"することもできます。"
 
 #: src/commands/locks/add.cc:46
 msgid "Restrict the lock to the specified repository."
@@ -2630,11 +2682,11 @@ msgstr[0] "%lu 個のパッケージロックを削除しました。"
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "名前"
 
@@ -2644,8 +2696,8 @@ msgstr "適合条件"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "種類"
@@ -2653,7 +2705,7 @@ msgstr "種類"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "リポジトリ"
@@ -2722,8 +2774,9 @@ msgstr "パッケージロックを削除します。"
 msgid ""
 "Remove a package lock. Specify the lock to remove by its number obtained "
 "with '%1%' or by package name."
-msgstr "パッケージロックを解除します。 '%1%' "
-"で表示される番号かパッケージの名前で指定してください。"
+msgstr ""
+"パッケージロックを解除します。 '%1%' で表示される番号かパッケージの名前で指定"
+"してください。"
 
 #: src/commands/locks/remove.cc:45
 msgid "Remove only locks with specified repository."
@@ -2761,14 +2814,15 @@ msgid ""
 msgstr ""
 "直前の中枢ライブラリやサービスの更新もしくはインストールによって、要再起動フ"
 "ラグが設定されたかどうかを確認します。\n"
-"再起動が必要な場合は ZYPPER_EXIT_INF_REBOOT_NEEDED の終了コードを返し、"
-"それ以外の場合は ZYPPER_EXIT_OK の終了コードを返します。"
+"再起動が必要な場合は ZYPPER_EXIT_INF_REBOOT_NEEDED の終了コードを返し、それ以"
+"外の場合は ZYPPER_EXIT_OK の終了コードを返します。"
 
 #: src/commands/needs-rebooting.cc:26
 msgid ""
 "This is the recommended way for scripts to test whether a system reboot is "
 "suggested."
-msgstr "これはスクリプトからシステムの再起動が必要かどうかを判断するための推奨方式で"
+msgstr ""
+"これはスクリプトからシステムの再起動が必要かどうかを判断するための推奨方式で"
 "す。"
 
 #: src/commands/needs-rebooting.cc:38
@@ -2834,9 +2888,9 @@ msgid ""
 "The command is an alias for '%1%' and performs a case-insensitive search. "
 "For a case-sensitive search call the search command and add the '%2%' option."
 msgstr ""
-"このコマンドは '%1%' "
-"の別名で、大文字と小文字を区別せずに検索します。大文字と小文字を区別して検索"
-"したい場合は、検索コマンドのオプションに '%2%' オプションを追加してください。"
+"このコマンドは '%1%' の別名で、大文字と小文字を区別せずに検索します。大文字と"
+"小文字を区別して検索したい場合は、検索コマンドのオプションに '%2%' オプション"
+"を追加してください。"
 
 #. "what-provides" is obsolete
 #. The "what-provides" now is included in "search" command, e.g.
@@ -2862,9 +2916,9 @@ msgstr "何も変更しません。何が行われるのかだけを表示しま
 msgid ""
 "A meaningful file conflict check can only be performed if used together with "
 "'%1%'."
-msgstr "'%1%' "
-"を指定して実行した場合にのみ、意味のあるファイルの競合チェックが実施されます"
-"。"
+msgstr ""
+"'%1%' を指定して実行した場合にのみ、意味のあるファイルの競合チェックが実施さ"
+"れます。"
 
 #. translators: -r, --repo <ALIAS|#|URI>
 #: src/commands/optionsets.cc:67
@@ -2906,15 +2960,17 @@ msgstr "インストールされていないパッケージのみを表示しま
 msgid ""
 "Automatically say 'yes' to third party license confirmation prompt. See 'man "
 "zypper' for more details."
-msgstr "サードパーティのライセンス確認プロンプトに対して、自動的に 'yes' "
-"と回答します。詳しくは 'man zypper' をお読みください。"
+msgstr ""
+"サードパーティのライセンス確認プロンプトに対して、自動的に 'yes' と回答しま"
+"す。詳しくは 'man zypper' をお読みください。"
 
 #: src/commands/optionsets.cc:244
 msgid ""
 "Automatically accept product licenses only. See 'man zypper' for more "
 "details."
-msgstr "製品のライセンスに対してのみ自動的に回答します。詳しくは 'man zypper' "
-"をお読みください。"
+msgstr ""
+"製品のライセンスに対してのみ自動的に回答します。詳しくは 'man zypper' をお読"
+"みください。"
 
 #. translators: --replacefiles
 #: src/commands/optionsets.cc:264
@@ -2923,18 +2979,18 @@ msgid ""
 "installed, packages. Default is to treat file conflicts as an error. --"
 "download-as-needed disables the fileconflict check."
 msgstr ""
-"既にインストール済みの他のファイルを置き換える "
-"ことになる場合でも、パッケージをインストールします。デフォルトではファイルの"
-"衝突をエラーとして扱います。--download-as-"
-"neededを指定するとファイルの衝突の確認が無効になります。"
+"既にインストール済みの他のファイルを置き換える ことになる場合でも、パッケージ"
+"をインストールします。デフォルトではファイルの衝突をエラーとして扱います。--"
+"download-as-neededを指定するとファイルの衝突の確認が無効になります。"
 
 #. translators: -y, --no-confirm
 #: src/commands/optionsets.cc:291
 msgid ""
 "Don't require user interaction. Alias for the --non-interactive global "
 "option."
-msgstr "ユーザの操作を不要にします。 --non-interactive "
-"グローバルオプションの別名です。"
+msgstr ""
+"ユーザの操作を不要にします。 --non-interactive グローバルオプションの別名で"
+"す。"
 
 #: src/commands/optionsets.cc:309
 msgid ""
@@ -2991,8 +3047,8 @@ msgid ""
 "When updating the affected/vulnerable packages described by a patch, zypper "
 "always aims for the latest available version."
 msgstr ""
-"パッチ内に示されている対象パッケージ (脆弱性の影響を受けるパッケージ) "
-"を更新する際、 zypper は常に利用可能な最新バージョンに更新しようとします。"
+"パッチ内に示されている対象パッケージ (脆弱性の影響を受けるパッケージ) を更新"
+"する際、 zypper は常に利用可能な最新バージョンに更新しようとします。"
 
 #: src/commands/patch.cc:50
 msgid "Skip needed patches which do not apply without conflict."
@@ -3004,9 +3060,9 @@ msgid ""
 "is ignored, if the patch command must update the update stack first. Can not "
 "be combined with --updatestack-only."
 msgstr ""
-"パッチには含まれていない全てのパッケージも追加で更新しようとします。 patch "
-"コマンドでは、更新スタック自身を更新しなければならない場合、このオプションは"
-"無視されます。また、 --updatestack-only と同時に指定することはできません。"
+"パッチには含まれていない全てのパッケージも追加で更新しようとします。 patch コ"
+"マンドでは、更新スタック自身を更新しなければならない場合、このオプションは無"
+"視されます。また、 --updatestack-only と同時に指定することはできません。"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/patchcheck.cc:17
@@ -3024,9 +3080,9 @@ msgid ""
 "Display stats about applicable patches. The command returns 100 if needed "
 "patches were found, 101 if there is at least one needed security patch."
 msgstr ""
-"適用可能なパッチに関する統計情報を表示します。このコマンドは、"
-"必要なパッチが見つかった場合には 100 を、少なくとも 1 "
-"つ以上の必要なセキュリティパッチが見つかった場合は 101 を返します。"
+"適用可能なパッチに関する統計情報を表示します。このコマンドは、必要なパッチが"
+"見つかった場合には 100 を、少なくとも 1 つ以上の必要なセキュリティパッチが見"
+"つかった場合は 101 を返します。"
 
 #. translators: command synopsis; do not translate the command 'name (abbreviations)' or '-option' names
 #: src/commands/ps.cc:27
@@ -3038,7 +3094,8 @@ msgstr "ps [オプション]"
 msgid ""
 "List running processes which might still use files and libraries deleted by "
 "recent upgrades."
-msgstr "直近のアップグレードによって削除されたファイルとライブラリについて、これらを"
+msgstr ""
+"直近のアップグレードによって削除されたファイルとライブラリについて、これらを"
 "まだ使用している可能性のある実行中プロセスを一覧表示します。"
 
 #. translators: -s, --short
@@ -3060,9 +3117,9 @@ msgid ""
 "followed by a newline. Any '%s' directive in <format> is replaced by the "
 "system service name."
 msgstr ""
-"関連付けられたシステムサービスごとに、標準出力に対して <format> "
-"で指定した書式の内容を出力し、改行します。 <format> 内に '%s' "
-"ディレクティブを指定すると、その箇所はシステムサービス名に置き換えられます。"
+"関連付けられたシステムサービスごとに、標準出力に対して <format> で指定した書"
+"式の内容を出力し、改行します。 <format> 内に '%s' ディレクティブを指定する"
+"と、その箇所はシステムサービス名に置き換えられます。"
 
 #. translators: -d, --debugFile <path>
 #: src/commands/ps.cc:52
@@ -3104,7 +3161,7 @@ msgid "Command"
 msgstr "コマンド"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "サービス"
 
@@ -3138,10 +3195,9 @@ msgid ""
 "permission to examine with the system stat(2) function. The result might be "
 "incomplete."
 msgstr ""
-"注意: "
-"rootとして実行しない場合、システムのstat(2)関数を実行する際に許可の制限を受け"
-"るため、ファイルの検索が制限されます。したがって、結果が不完全なものになる場"
-"合があります。"
+"注意: rootとして実行しない場合、システムのstat(2)関数を実行する際に許可の制限"
+"を受けるため、ファイルの検索が制限されます。したがって、結果が不完全なものに"
+"なる場合があります。"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/query/info.cc:19
@@ -3161,10 +3217,10 @@ msgid ""
 "partially matching use option '--match-substrings' or use wildcards (*?) in "
 "name."
 msgstr ""
-"指定したパッケージに関する詳細情報を表示します。 "
-"デフォルトでは、指定の名前と完全に一致するパッケージが表示されます。 "
-"部分的に一致するパッケージも取得するには、「--match-"
-"substrings」オプションを使用するか、 名前でワイルドカード(*?)を使用します。"
+"指定したパッケージに関する詳細情報を表示します。 デフォルトでは、指定の名前と"
+"完全に一致するパッケージが表示されます。 部分的に一致するパッケージも取得する"
+"には、「--match-substrings」オプションを使用するか、 名前でワイルドカード(*?)"
+"を使用します。"
 
 #: src/commands/query/info.cc:25
 msgid ""
@@ -3276,126 +3332,129 @@ msgid "Show detailed information for products."
 msgstr "製品についての詳細情報を表示します。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [オプション] [リポジトリ] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "利用可能なパッケージをすべてリストします。"
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "指定したリポジトリ内で利用可能なすべてのパッケージを表示します。"
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
-msgstr "解決器によって自動的に選択され、インストールされたパッケージを表示します。"
+msgstr ""
+"解決器によって自動的に選択され、インストールされたパッケージを表示します。"
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr "明示的にインストールするよう指定したパッケージを表示します。"
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
-msgstr "どのリポジトリにも存在していないインストール済みパッケージを表示します。"
+msgstr ""
+"どのリポジトリにも存在していないインストール済みパッケージを表示します。"
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
-msgstr "孤立したシステムパッケージ "
-"(どのリポジトリにも存在せず、かつ更新される予定もないパッケージ) "
-"を表示します。"
+msgstr ""
+"孤立したシステムパッケージ (どのリポジトリにも存在せず、かつ更新される予定も"
+"ないパッケージ) を表示します。"
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "提案されているパッケージを表示します。"
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "推奨パッケージを表示します。"
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "不要なパッケージを表示します。"
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "リストをパッケージ名順に並べ替します。"
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "リストをリポジトリ名順で並べ替します。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [リポジトリ] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "利用可能なパッチをすべてリストします。"
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "指定したリポジトリにあるすべてのパッチの一覧を表示します。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [オプション] [リポジトリ] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "利用可能なパターンをすべてリストします。"
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "指定したリポジトリ内で利用可能なすべてのパターンを表示します。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [オプション] [リポジトリ] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "利用可能な製品をすべてリストします。"
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "指定したリポジトリ内で利用可能なすべての製品を表示します。"
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr "XML 出力のみ: 製品ファイル内にある XML タグをそのまま出力します。"
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
-msgstr "%2% のグローバルオプションが指定されていないと、オプション %1% "
-"は効果がありません。"
+msgstr ""
+"%2% のグローバルオプションが指定されていないと、オプション %1% は効果がありま"
+"せん。"
 
 #: src/commands/repos/add.cc:23
 msgid "addrepo (ar) [OPTIONS] <URI> <ALIAS>"
@@ -3433,16 +3492,17 @@ msgstr "URIを検索しません。更新後に検索します。"
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr "リポジトリタイプは常に自動検出されます。このオプションは無視されます。"
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "%s と %s を同時に指定することはできません。 %s の設定を使用します。"
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
-msgstr "1 つのパラメータのみ指定した場合は、 .repo ファイルのある URI "
-"を指定しなければなりません。"
+msgstr ""
+"1 つのパラメータのみ指定した場合は、 .repo ファイルのある URI を指定しなけれ"
+"ばなりません。"
 
 #: src/commands/repos/add.cc:130
 msgid "Specified type is not a valid repository type:"
@@ -3451,7 +3511,8 @@ msgstr "指定した種類は無効なリポジトリタイプです:"
 #: src/commands/repos/add.cc:131
 #, c-format, boost-format
 msgid "See '%s' or '%s' to get a list of known repository types."
-msgstr "既知のリポジトリ種類の一覧については、 '%s' または '%s' をお読みください。"
+msgstr ""
+"既知のリポジトリ種類の一覧については、 '%s' または '%s' をお読みください。"
 
 #: src/commands/repos/clean.cc:16
 msgid "clean (cc) [ALIAS|#|URI] ..."
@@ -3481,111 +3542,115 @@ msgstr "未加工のメタデータキャッシュを削除します。"
 msgid "Clean both metadata and package caches."
 msgstr "メタデータとパッケージの両方のキャッシュを削除します。"
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "別名"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "有効"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "GPGチェック"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "優先順位"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "自動更新"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "オン"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "オフ"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "パッケージを維持"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "GPG鍵URI"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "パスプレフィックス"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "親サービス"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "キーワード"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "リポジトリ情報パス"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "MDキャッシュパス"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [オプション] [リポジトリ] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "定義済みリポジトリのリストを表示します。"
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "すべての定義済みリポジトリを単一の.repoファイルにエクスポートします。"
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "リポジトリの読み込みでエラー:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "ファイル %s を書き込み用に開くことができません。"
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "書き込み許可が与えられていないのではありませんか？"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "%s へのリポジトリ出力処理が成功しました。"
@@ -3593,22 +3658,23 @@ msgstr "%s へのリポジトリ出力処理が成功しました。"
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "更新"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "維持"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "リポジトリが定義されていません。"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
-msgstr "「zypper addrepo」コマンドを使用して、リポジトリを1つ以上追加してください。"
+msgstr ""
+"「zypper addrepo」コマンドを使用して、リポジトリを1つ以上追加してください。"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/repos/modify.cc:24
@@ -3632,8 +3698,9 @@ msgstr "指定したリポジトリを修正します。"
 msgid ""
 "Modify properties of repositories specified by alias, number, or URI, or by "
 "the '%1%' aggregate options."
-msgstr "別名 (<alias>), 番号, URI, または統合オプション '%1%' "
-"で指定したリポジトリの情報を修正します。"
+msgstr ""
+"別名 (<alias>), 番号, URI, または統合オプション '%1%' で指定したリポジトリの"
+"情報を修正します。"
 
 #: src/commands/repos/modify.cc:89
 #, c-format, boost-format
@@ -3655,9 +3722,9 @@ msgid ""
 "Refresh repositories specified by their alias, number or URI. If none are "
 "specified, all enabled repositories will be refreshed."
 msgstr ""
-"別名 (<alias>) 、番号、またはURIで指定したリポジトリの情報を更新します。 "
-"何も指定しない場合は無効に設定されているものを除くすべてのリポジトリを更新し"
-"ます。"
+"別名 (<alias>) 、番号、またはURIで指定したリポジトリの情報を更新します。 何も"
+"指定しない場合は無効に設定されているものを除くすべてのリポジトリを更新しま"
+"す。"
 
 #. translators: -f, --force
 #: src/commands/repos/refresh.cc:80 src/commands/services/refresh.cc:113
@@ -3682,7 +3749,8 @@ msgstr "データベースを構築し直すだけで、メタデータのダウ
 #. translators: -D, --download-only
 #: src/commands/repos/refresh.cc:100
 msgid "Only download raw metadata, don't build the database."
-msgstr "未加工のメタデータをダウンロードするだけでデータベースの再構築を行いません。"
+msgstr ""
+"未加工のメタデータをダウンロードするだけでデータベースの再構築を行いません。"
 
 #. translators: --include-all-archs
 #: src/commands/repos/refresh.cc:105
@@ -3714,7 +3782,7 @@ msgstr "'%s' グローバルオプションはここでは意味がありませ�
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "'%s' を使用したときは引数は使用できません。"
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "指定したリポジトリ: "
 
@@ -3723,7 +3791,7 @@ msgstr "指定したリポジトリ: "
 msgid "Refreshing repository '%s'."
 msgstr "リポジトリ '%s' を更新しています。"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "無効化されたリポジトリ '%s' の内容をスキャンしています。"
@@ -3733,7 +3801,7 @@ msgstr "無効化されたリポジトリ '%s' の内容をスキャンしてい
 msgid "Skipping disabled repository '%s'"
 msgstr "無効化されたリポジトリ '%s' をスキップします"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "上記のエラーにより、リポジトリ '%s' をスキップします。"
@@ -3741,7 +3809,8 @@ msgstr "上記のエラーにより、リポジトリ '%s' をスキップしま
 #: src/commands/repos/refresh.cc:318
 msgid ""
 "Some of the repositories have not been refreshed because they were not known."
-msgstr "既知のものではないことから、いくつかのリポジトリを更新することができませんで"
+msgstr ""
+"既知のものではないことから、いくつかのリポジトリを更新することができませんで"
 "した。"
 
 #: src/commands/repos/refresh.cc:325
@@ -3755,14 +3824,15 @@ msgstr "有効化されているリポジトリが設定されていません。
 #: src/commands/repos/refresh.cc:331
 #, c-format, boost-format
 msgid "Use '%s' or '%s' commands to add or enable repositories."
-msgstr "リポジトリを追加したり有効化したりするには、それぞれ '%s' コマンドや '%s' "
-"コマンドをご利用ください。"
+msgstr ""
+"リポジトリを追加したり有効化したりするには、それぞれ '%s' コマンドや '%s' コ"
+"マンドをご利用ください。"
 
 #: src/commands/repos/refresh.cc:337
 msgid "Could not refresh the repositories because of errors."
 msgstr "エラーによりリポジトリの更新ができませんでした。"
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "エラーにより、いくつかのリポジトリを更新することができませんでした。"
 
@@ -3808,20 +3878,22 @@ msgstr "リポジトリ '%s' は別名／番号／URIのいずれでも見つか
 msgid ""
 "Cannot change alias of '%s' repository. The repository belongs to service "
 "'%s' which is responsible for setting its alias."
-msgstr "リポジトリ '%s' の別名を変更できません。このリポジトリは、"
-"別名を設定する責任のあるサービス '%s' に属しています。"
+msgstr ""
+"リポジトリ '%s' の別名を変更できません。このリポジトリは、別名を設定する責任"
+"のあるサービス '%s' に属しています。"
 
 #: src/commands/repos/rename.cc:43
 #, c-format, boost-format
 msgid "Repository '%s' renamed to '%s'."
 msgstr "リポジトリ '%s' は '%s' に名前を変更しました。"
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
-msgstr "'%s' という名前のリポジトリは既に存在します。他の別名を設定してください。"
+msgstr ""
+"'%s' という名前のリポジトリは既に存在します。他の別名を設定してください。"
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "リポジトリを修正する際にエラー:"
 
@@ -3842,12 +3914,14 @@ msgstr "指定したリポジトリの名前を変更します。"
 #. translators: command description
 #: src/commands/repos/rename.cc:67
 msgid "Assign new alias to the repository specified by alias, number or URI."
-msgstr "別名 (<alias>) 、番号、またはURIで指定したリポジトリの名前を変更し、 <new-"
+msgstr ""
+"別名 (<alias>) 、番号、またはURIで指定したリポジトリの名前を変更し、 <new-"
 "alias>にします。"
 
 #: src/commands/repos/rename.cc:92
 msgid "Too few arguments. At least URI and alias are required."
-msgstr "パラメータが少なすぎます。少なくともURIと別名を指定する必要があります。"
+msgstr ""
+"パラメータが少なすぎます。少なくともURIと別名を指定する必要があります。"
 
 #: src/commands/repos/rename.cc:114
 #, c-format, boost-format
@@ -3859,9 +3933,9 @@ msgstr "リポジトリ '%s' が見つかりません。"
 msgid ""
 "Invalid priority '%s'. Use a positive integer number. The greater the "
 "number, the lower the priority."
-msgstr "正しくない優先順位 '%s' "
-"です。正の整数で入力してください。より大きい数字がより低い優先順位になります"
-"。"
+msgstr ""
+"正しくない優先順位 '%s' です。正の整数で入力してください。より大きい数字がよ"
+"り低い優先順位になります。"
 
 #: src/commands/reposerviceoptionsets.cc:72
 msgid "Set a descriptive name for the service."
@@ -3962,16 +4036,16 @@ msgstr "'%s' の省略形です。"
 
 #: src/commands/reposerviceoptionsets.cc:143
 msgid "Enable GPG check but allow the repository metadata to be unsigned."
-msgstr "GPG "
-"チェックを有効にしますが、リポジトリのメタデータについては未署名を許可します"
-"。"
+msgstr ""
+"GPG チェックを有効にしますが、リポジトリのメタデータについては未署名を許可し"
+"ます。"
 
 #: src/commands/reposerviceoptionsets.cc:144
 msgid ""
 "Enable GPG check but allow installing unsigned packages from this repository."
-msgstr "GPG "
-"チェックを有効にしますが、このリポジトリからのものについては未署名のパッケー"
-"ジのインストールを許可します。"
+msgstr ""
+"GPG チェックを有効にしますが、このリポジトリからのものについては未署名のパッ"
+"ケージのインストールを許可します。"
 
 #: src/commands/reposerviceoptionsets.cc:145
 msgid "Disable GPG check for this repository."
@@ -3981,8 +4055,9 @@ msgstr "このリポジトリに対して、 GPG チェックを無効にしま�
 msgid ""
 "Use the global GPG check setting defined in /etc/zypp/zypp.conf. This is the "
 "default."
-msgstr "/etc/zypp/zypp.conf に設定されている GPG "
-"チェックのグローバル設定を使用します。これが既定値です。"
+msgstr ""
+"/etc/zypp/zypp.conf に設定されている GPG チェックのグローバル設定を使用しま"
+"す。これが既定値です。"
 
 #. translators: -a, --alias
 #: src/commands/reposerviceoptionsets.cc:182
@@ -4056,8 +4131,9 @@ msgstr "リストをリポジトリの優先順位順にソートします。"
 msgid ""
 "For an extended search including not yet activated remote resources please "
 "use '%1%'."
-msgstr "まだ有効にしていないリモートのリソースを含めて検索するには、 '%1%' "
-"をお使いください。"
+msgstr ""
+"まだ有効にしていないリモートのリソースを含めて検索するには、 '%1%' をお使いく"
+"ださい。"
 
 #. translator: %1% denotes a zypper command to execute. Like 'zypper search-packages'.
 #: src/commands/search/search-packages-hinthack.cc:74
@@ -4065,15 +4141,17 @@ msgstr "まだ有効にしていないリモートのリソースを含めて検
 msgid ""
 "The package providing this subcommand is currently not installed. You can "
 "install it by calling '%1%'."
-msgstr "このサブコマンドを提供するパッケージがインストールされていません。 '%1%' "
-"でインストールしてください。"
+msgstr ""
+"このサブコマンドを提供するパッケージがインストールされていません。 '%1%' でイ"
+"ンストールしてください。"
 
 #: src/commands/search/search-packages-hinthack.cc:87
 #, boost-format
 msgid ""
 "For an extended search including not yet activated remote resources you may "
 "run '%1%' at any time."
-msgstr "現時点では有効化していないリモートのリソースを含めた拡張検索を行うには、 "
+msgstr ""
+"現時点では有効化していないリモートのリソースを含めた拡張検索を行うには、 "
 "'%1%' を実行する必要があります。"
 
 #: src/commands/search/search-packages-hinthack.cc:88
@@ -4084,8 +4162,9 @@ msgstr "今すぐ '%1%' を実行しますか？"
 #: src/commands/search/search-packages-hinthack.cc:104
 #, boost-format
 msgid "Run '%1%' to search in not yet activated remote resources."
-msgstr "まだ有効化していないリモートの資源を検索したい場合は、 '%1%' "
-"を実行してください。"
+msgstr ""
+"まだ有効化していないリモートの資源を検索したい場合は、 '%1%' を実行してくださ"
+"い。"
 
 #. translators: command summary: search, se
 #: src/commands/search/search.cc:76
@@ -4108,8 +4187,8 @@ msgid ""
 "* and ? wildcards can also be used within search strings. If a search string "
 "is enclosed in '/', it's interpreted as a regular expression."
 msgstr ""
-"* ? ワイルドカードも検索文字列内でも使用できる追加情報と共に使用されます。 "
-"検索文字列が「/」で囲まれている場合、正規表現であると解釈されます。"
+"* ? ワイルドカードも検索文字列内でも使用できる追加情報と共に使用されます。 検"
+"索文字列が「/」で囲まれている場合、正規表現であると解釈されます。"
 
 #. translators: --match-substrings
 #: src/commands/search/search.cc:105
@@ -4171,7 +4250,8 @@ msgstr "検索文字列を拡張するパッケージを検索します。"
 msgid ""
 "Search for all packages that provide any of the provides of the package(s) "
 "matched by the input parameters."
-msgstr "入力パラメータに合致するパッケージの提供物のうち、いずれかを提供するパッケー"
+msgstr ""
+"入力パラメータに合致するパッケージの提供物のうち、いずれかを提供するパッケー"
 "ジを検索します。"
 
 #. translators: --requires-pkg
@@ -4179,15 +4259,17 @@ msgstr "入力パラメータに合致するパッケージの提供物のうち
 msgid ""
 "Search for all packages that require any of the provides of the package(s) "
 "matched by the input parameters."
-msgstr "入力パラメータに合致するパッケージの提供物のうち、いずれかを必要とするパッケ"
-"ージを検索します。"
+msgstr ""
+"入力パラメータに合致するパッケージの提供物のうち、いずれかを必要とするパッ"
+"ケージを検索します。"
 
 #. translators: --recommends-pkg
 #: src/commands/search/search.cc:157
 msgid ""
 "Search for all packages that recommend any of the provides of the package(s) "
 "matched by the input parameters."
-msgstr "入力パラメータに合致するパッケージの提供物のうち、いずれかを推奨するパッケー"
+msgstr ""
+"入力パラメータに合致するパッケージの提供物のうち、いずれかを推奨するパッケー"
 "ジを検索します。"
 
 #. translators: --supplements-pkg
@@ -4195,7 +4277,8 @@ msgstr "入力パラメータに合致するパッケージの提供物のうち
 msgid ""
 "Search for all packages that supplement any of the provides of the "
 "package(s) matched by the input parameters."
-msgstr "入力パラメータに合致するパッケージの提供物のうち、いずれかを補足するパッケー"
+msgstr ""
+"入力パラメータに合致するパッケージの提供物のうち、いずれかを補足するパッケー"
 "ジを検索します。"
 
 #. translators: --conflicts-pkg
@@ -4203,7 +4286,8 @@ msgstr "入力パラメータに合致するパッケージの提供物のうち
 msgid ""
 "Search for all packages that conflict with any of the package(s) matched by "
 "the input parameters."
-msgstr "入力パラメータに合致するパッケージのうちのいずれかと矛盾するパッケージを検索"
+msgstr ""
+"入力パラメータに合致するパッケージのうちのいずれかと矛盾するパッケージを検索"
 "します。"
 
 #. translators: --obsoletes-pkg
@@ -4211,7 +4295,8 @@ msgstr "入力パラメータに合致するパッケージのうちのいずれ
 msgid ""
 "Search for all packages that obsolete any of the package(s) matched by the "
 "input parameters."
-msgstr "入力パラメータに合致するパッケージのうちのいずれかを廃止対象とするパッケージ"
+msgstr ""
+"入力パラメータに合致するパッケージのうちのいずれかを廃止対象とするパッケージ"
 "を検索します。"
 
 #. translators: --suggests-pkg
@@ -4219,7 +4304,8 @@ msgstr "入力パラメータに合致するパッケージのうちのいずれ
 msgid ""
 "Search for all packages that suggest any of the provides of the package(s) "
 "matched by the input parameters."
-msgstr "入力パラメータに合致するパッケージの提供物のうち、いずれかを提案するパッケー"
+msgstr ""
+"入力パラメータに合致するパッケージの提供物のうち、いずれかを提案するパッケー"
 "ジを検索します。"
 
 #. translators: --enhances-pkg
@@ -4227,8 +4313,9 @@ msgstr "入力パラメータに合致するパッケージの提供物のうち
 msgid ""
 "Search for all packages that enhance any of the provides of the package(s) "
 "matched by the input parameters."
-msgstr "入力したパラメータに合致する任意のパッケージに対して、それを拡張する全てのパ"
-"ッケージを検索します。"
+msgstr ""
+"入力したパラメータに合致する任意のパッケージに対して、それを拡張する全ての"
+"パッケージを検索します。"
 
 #. translators: -t, --type <TYPE>
 #: src/commands/search/search.cc:181
@@ -4240,8 +4327,9 @@ msgstr "指定されたタイプのパッケージのみを検索します。"
 msgid ""
 "Useful together with dependency options, otherwise searching in package name "
 "is default."
-msgstr "依存関係オプションと共に使用する場合に役立ちます。そうでない場合、 "
-"パッケージ名の検索がデフォルトです。"
+msgstr ""
+"依存関係オプションと共に使用する場合に役立ちます。そうでない場合、 パッケージ"
+"名の検索がデフォルトです。"
 
 #. translators: -f, --file-list
 #: src/commands/search/search.cc:189
@@ -4268,30 +4356,32 @@ msgstr "各リポジトリ内で使用可能な各バージョンを別の行に
 msgid ""
 "Like --details, with additional information where the search has matched "
 "(useful for search in dependencies)."
-msgstr "--details と同様に、追加情報を検索対象に含めます (依存関係内の検索に便利です)"
-" 。"
+msgstr ""
+"--details と同様に、追加情報を検索対象に含めます (依存関係内の検索に便利で"
+"す) 。"
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "指定したリポジトリ '%s' は無効化されています。"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "該当する項目がありません。"
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "検索の問い合わせを準備する際、または実行する際に問題が発生しました"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "解決へのヒントとして上記のメッセージをお読みください。"
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
-msgstr "root ユーザで 'zypper refresh' を実行すると問題を解決できるかもしれません。"
+msgstr ""
+"root ユーザで 'zypper refresh' を実行すると問題を解決できるかもしれません。"
 
 #. translators: -g, --category <CATEGORY>
 #: src/commands/selectpatchoptionset.cc:24
@@ -4306,8 +4396,9 @@ msgstr "指定した重要度のパッチのみを選択します。"
 #. translators: --date <YYYY-MM-DD>
 #: src/commands/selectpatchoptionset.cc:32
 msgid "Select patches issued up to, but not including, the specified date"
-msgstr "指定した日付まで (ただし指定した日付そのものは含みません) "
-"に公開されたパッチのみを選択します"
+msgstr ""
+"指定した日付まで (ただし指定した日付そのものは含みません) に公開されたパッチ"
+"のみを選択します"
 
 #. translators: -b, --bugzilla
 #: src/commands/selectpatchoptionset.cc:36
@@ -4329,15 +4420,17 @@ msgstr "指定した文字列に合致するもののみを選択します。"
 #, boost-format
 msgid ""
 "Service '%1%' with URL '%2%' already exists. Just updating the settings."
-msgstr "URL '%2%' のサービス '%1%' が既に存在しているため、設定の更新を実施します。"
+msgstr ""
+"URL '%2%' のサービス '%1%' が既に存在しているため、設定の更新を実施します。"
 
 #: src/commands/services/add.cc:58
 #, boost-format
 msgid ""
 "Service '%1%' already exists but uses a different URL '%2%'. Please use "
 "another alias."
-msgstr "サービス '%1%' は既に存在していますが、異なる URL '%2%' "
-"が設定されています。異なる別名を指定してください。"
+msgstr ""
+"サービス '%1%' は既に存在していますが、異なる URL '%2%' が設定されています。"
+"異なる別名を指定してください。"
 
 #: src/commands/services/add.cc:70
 #, c-format, boost-format
@@ -4378,10 +4471,11 @@ msgstr "サービス '%s' を更新しています。"
 #: src/commands/services/common.cc:136 src/commands/services/common.cc:146
 #, c-format, boost-format
 msgid "Problem retrieving the repository index file for service '%s':"
-msgstr "サービス '%s' からリポジトリのインデックスファイルを取得する際にエラー:"
+msgstr ""
+"サービス '%s' からリポジトリのインデックスファイルを取得する際にエラー:"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "上記のエラーにより、サービス '%s' をスキップしています。"
@@ -4400,22 +4494,27 @@ msgstr "サービス '%s' を削除しています:"
 msgid "Service '%s' has been removed."
 msgstr "サービス '%s' を削除しました。"
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [オプション]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "定義済みのサービスを一覧表示します。"
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "定義済みサービスのリストを表示します。"
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
-msgstr "サービスが見つかりません。 '%s' コマンドでサービスを追加することができます。"
+msgstr ""
+"サービスが見つかりません。 '%s' コマンドでサービスを追加することができます。"
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4437,8 +4536,9 @@ msgstr "指定したサービスを修正します。"
 msgid ""
 "Modify properties of services specified by alias, number, or URI, or by the "
 "'%1%' aggregate options."
-msgstr "別名 (<alias>) 、番号、 URI 、または統合オプション '%1%' "
-"で指定したサービスの情報を修正します。"
+msgstr ""
+"別名 (<alias>) 、番号、 URI 、または統合オプション '%1%' で指定したサービスの"
+"情報を修正します。"
 
 #: src/commands/services/modify.cc:41
 msgid "Advanced:"
@@ -4511,14 +4611,16 @@ msgstr "サービス '%s' の名前を '%s' に設定しました。"
 msgid "Repository '%s' has been added to enabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been added to enabled repositories of service '%s'"
-msgstr[0] "リポジトリ「%s」を有効化されているサービスのリポジトリ「%s」に追加しました"
+msgstr[0] ""
+"リポジトリ「%s」を有効化されているサービスのリポジトリ「%s」に追加しました"
 
 #: src/commands/services/modify.cc:262
 #, c-format, boost-format
 msgid "Repository '%s' has been added to disabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been added to disabled repositories of service '%s'"
-msgstr[0] "リポジトリ「%s」を無効化されているサービスのリポジトリ「%s」に追加しました"
+msgstr[0] ""
+"リポジトリ「%s」を無効化されているサービスのリポジトリ「%s」に追加しました"
 
 #: src/commands/services/modify.cc:269
 #, c-format, boost-format
@@ -4526,7 +4628,8 @@ msgid ""
 "Repository '%s' has been removed from enabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been removed from enabled repositories of service '%s'"
-msgstr[0] "リポジトリ「%s」を有効化されているサービスのリポジトリ「%s」から削除しました"
+msgstr[0] ""
+"リポジトリ「%s」を有効化されているサービスのリポジトリ「%s」から削除しました"
 
 #: src/commands/services/modify.cc:276
 #, c-format, boost-format
@@ -4535,7 +4638,8 @@ msgid ""
 msgid_plural ""
 "Repositories '%s' have been removed from disabled repositories of service "
 "'%s'"
-msgstr[0] "リポジトリ「%s」を無効化されているサービスのリポジトリ「%s」から削除しました"
+msgstr[0] ""
+"リポジトリ「%s」を無効化されているサービスのリポジトリ「%s」から削除しました"
 
 #: src/commands/services/modify.cc:285
 #, c-format, boost-format
@@ -4589,8 +4693,9 @@ msgstr "無効化されたサービス '%s' をスキップしています"
 #: src/commands/services/refresh.cc:237
 #, c-format, boost-format
 msgid "Use '%s' or '%s' commands to add or enable services."
-msgstr "サービスを追加したり有効化したりするには、それぞれ '%s' コマンドや '%s' "
-"コマンドをご利用ください。"
+msgstr ""
+"サービスを追加したり有効化したりするには、それぞれ '%s' コマンドや '%s' コマ"
+"ンドをご利用ください。"
 
 #: src/commands/services/refresh.cc:240
 msgid "Specified services are not enabled or defined."
@@ -4683,8 +4788,9 @@ msgstr "必要なパッケージに加え、推奨パッケージについても
 
 #: src/commands/solveroptionset.cc:39
 msgid "Do not install recommended packages, only required ones."
-msgstr "推奨パッケージについてはインストールせず、必要なもののみをインストールします"
-"。"
+msgstr ""
+"推奨パッケージについてはインストールせず、必要なもののみをインストールしま"
+"す。"
 
 #: src/commands/solveroptionset.cc:61
 msgid "Create a solver test case for debugging."
@@ -4710,23 +4816,27 @@ msgstr "熟練者向けオプション"
 
 #: src/commands/solveroptionset.cc:87
 msgid "Whether to allow downgrading installed resolvables."
-msgstr "インストール済みの解決方法に対して、ダウングレードを許可するかどうかを指定し"
+msgstr ""
+"インストール済みの解決方法に対して、ダウングレードを許可するかどうかを指定し"
 "ます。"
 
 #: src/commands/solveroptionset.cc:89
 msgid "Whether to allow changing the names of installed resolvables."
-msgstr "インストール済みの解決方法に対して、名前の変更を許可するかどうかを指定します"
-"。"
+msgstr ""
+"インストール済みの解決方法に対して、名前の変更を許可するかどうかを指定しま"
+"す。"
 
 #: src/commands/solveroptionset.cc:91
 msgid "Whether to allow changing the architecture of installed resolvables."
-msgstr "インストール済みの解決方法に対して、アーキテクチャの変更を許可するかどうかを"
+msgstr ""
+"インストール済みの解決方法に対して、アーキテクチャの変更を許可するかどうかを"
 "指定します。"
 
 #: src/commands/solveroptionset.cc:93
 msgid "Whether to allow changing the vendor of installed resolvables."
-msgstr "インストールされている resolvable "
-"のベンダ変更を許可するかどうかを指定します。"
+msgstr ""
+"インストールされている resolvable のベンダ変更を許可するかどうかを指定しま"
+"す。"
 
 #. translators: -u, --clean-deps
 #: src/commands/solveroptionset.cc:117
@@ -4751,7 +4861,8 @@ msgstr "構築の際に依存するものを含めてソースパッケージを
 #. translators: command description
 #: src/commands/sourceinstall.cc:25
 msgid "Install specified source packages and their build dependencies."
-msgstr "指定したソースパッケージと、ビルドの際に依存するパッケージのソースコードをイ"
+msgstr ""
+"指定したソースパッケージと、ビルドの際に依存するパッケージのソースコードをイ"
 "ンストールします。"
 
 #: src/commands/sourceinstall.cc:26
@@ -4761,15 +4872,16 @@ msgid ""
 "value can be changed in your local rpm configuration. In case of doubt try "
 "executing '%2%'."
 msgstr ""
-"rpm がソースパッケージをインストールする際の既定のインストール先は '%1%' "
-"ですが、 rpm 側で設定を行うことで、インストール先を変更することができます。"
-"具体的には '%2%' を実行してください。"
+"rpm がソースパッケージをインストールする際の既定のインストール先は '%1%' です"
+"が、 rpm 側で設定を行うことで、インストール先を変更することができます。具体的"
+"には '%2%' を実行してください。"
 
 #. translators: -d, --build-deps-only
 #: src/commands/sourceinstall.cc:48
 msgid "Install only build dependencies of specified packages."
-msgstr "指定したパッケージのうちビルドの際に依存するもののソースコードのみをインスト"
-"ールします。"
+msgstr ""
+"指定したパッケージのうちビルドの際に依存するもののソースコードのみをインス"
+"トールします。"
 
 #. translators: -D, --no-build-deps
 #: src/commands/sourceinstall.cc:52
@@ -4819,7 +4931,8 @@ msgstr "%1% に対する waitpid が失敗しました (%2%)"
 #: src/commands/subcommand.cc:370
 #, boost-format
 msgid "waitpid for %1% returns unexpected pid %2% while waiting for %3%"
-msgstr "%1% に対する waitpid が pid %2% を返しました。本来返すべき値は pid %3% でした"
+msgstr ""
+"%1% に対する waitpid が pid %2% を返しました。本来返すべき値は pid %3% でした"
 
 #. translators: %1% - command name or path
 #. translators: %2% - signal number
@@ -4896,15 +5009,17 @@ msgstr "お使いの $PATH 内の他の場所で利用可能な zypper サブコ
 msgid ""
 "Using zypper subcommands available from elsewhere on your $PATH is disabled "
 "in zypper.conf."
-msgstr "zypper.conf の設定で、 $PATH 内にある zypper "
-"サブコマンドの使用が無効化されています。"
+msgstr ""
+"zypper.conf の設定で、 $PATH 内にある zypper サブコマンドの使用が無効化されて"
+"います。"
 
 #. translators: helptext; %1% is a zypper command
 #: src/commands/subcommand.cc:485
 #, boost-format
 msgid "Type '%1%' to get subcommand-specific help if available."
-msgstr "サブコマンドのヘルプ (利用可能であれば) を表示するには、 '%1%' "
-"と入力してください。"
+msgstr ""
+"サブコマンドのヘルプ (利用可能であれば) を表示するには、 '%1%' と入力してくだ"
+"さい。"
 
 #. translators: %1% - command name
 #: src/commands/subcommand.cc:508
@@ -4921,8 +5036,8 @@ msgid ""
 "Lists available subcommands. Using zypper subcommands found on your $PATH is "
 "disabled in zypper.conf."
 msgstr ""
-"利用可能なサブコマンドを一覧表示します。なお zypper.conf の設定により、 $"
-"PATH 内にある zypper サブコマンドの使用が無効化されています。"
+"利用可能なサブコマンドを一覧表示します。なお zypper.conf の設定により、 "
+"$PATH 内にある zypper サブコマンドの使用が無効化されています。"
 
 #. Currently no concept how to handle global options and ZYPPlock
 #: src/commands/subcommand.cc:626
@@ -4949,7 +5064,8 @@ msgstr "インストール済みのパッケージを新しいバージョンに
 #: src/commands/update.cc:26
 msgid ""
 "Update all or specified installed packages with newer versions, if possible."
-msgstr "可能であれば、全てのインストール済みパッケージもしくは指定したインストール済"
+msgstr ""
+"可能であれば、全てのインストール済みパッケージもしくは指定したインストール済"
 "みパッケージを、新しいバージョンに更新します。"
 
 #: src/commands/update.cc:69 src/commands/update.cc:76
@@ -4968,14 +5084,15 @@ msgid ""
 "Zypper does not keep track of installed source packages. To install the "
 "latest source package and its build dependencies, use '%s'."
 msgstr ""
-"zypper "
-"ではインストール済みのソースパッケージを管理することができません。最新のソー"
-"スパッケージと構築依存関係をインストールするには、 '%s' をお使いください。"
+"zypper ではインストール済みのソースパッケージを管理することができません。最新"
+"のソースパッケージと構築依存関係をインストールするには、 '%s' をお使いくださ"
+"い。"
 
 #: src/commands/update.cc:83
 msgid ""
 "Cannot use multiple types when specific packages are given as arguments."
-msgstr "引数にパッケージを指定した場合は、複数の種類を指定することができません。"
+msgstr ""
+"引数にパッケージを指定した場合は、複数の種類を指定することができません。"
 
 #: src/commands/utils/download.cc:129 src/commands/utils/source-download.cc:212
 #, c-format, boost-format
@@ -4990,7 +5107,8 @@ msgstr "download [オプション] <パッケージ>..."
 #. translators: command summary: download
 #: src/commands/utils/download.cc:144
 msgid "Download rpms specified on the commandline to a local directory."
-msgstr "コマンドラインで指定したRPMを、ローカルのディレクトリにダウンロードします。"
+msgstr ""
+"コマンドラインで指定したRPMを、ローカルのディレクトリにダウンロードします。"
 
 #. translators: command description
 #: src/commands/utils/download.cc:148
@@ -5000,11 +5118,11 @@ msgid ""
 "packages; for non-root users $XDG_CACHE_HOME/zypp/packages), but this can be "
 "changed by using the global --pkg-cache-dir option."
 msgstr ""
-"コマンドラインで指定したパッケージを、ローカルのディレクトリに "
-"ダウンロードします。既定では libzypp のパッケージキャッシュ (/var/cache/zypp/"
-"packages; root 以外のユーザで実行した場合は $XDG_CACHE_HOME/zypp/packages) "
-"内にダウンロードしますが、 グローバルオプションの --pkg-cache-dir "
-"を指定することで、 ダウンロード先を変更することができます。"
+"コマンドラインで指定したパッケージを、ローカルのディレクトリに ダウンロードし"
+"ます。既定では libzypp のパッケージキャッシュ (/var/cache/zypp/packages; "
+"root 以外のユーザで実行した場合は $XDG_CACHE_HOME/zypp/packages) 内にダウン"
+"ロードしますが、 グローバルオプションの --pkg-cache-dir を指定することで、 ダ"
+"ウンロード先を変更することができます。"
 
 #. translators: command description
 #: src/commands/utils/download.cc:151
@@ -5023,9 +5141,9 @@ msgid ""
 "Download all versions matching the commandline arguments. Otherwise only the "
 "best version of each matching package is downloaded."
 msgstr ""
-"コマンドラインで指定したパッケージの全バージョン "
-"をダウンロードします。これを指定しない場合は、 "
-"該当するパッケージの中で最良のバージョンをダウン ロードします。"
+"コマンドラインで指定したパッケージの全バージョン をダウンロードします。これを"
+"指定しない場合は、 該当するパッケージの中で最良のバージョンをダウン ロードし"
+"ます。"
 
 #. translators: Label text; is followed by ': cmdline argument'
 #: src/commands/utils/download.cc:236
@@ -5066,12 +5184,14 @@ msgstr "licenses"
 #. translators: command summary: licenses
 #: src/commands/utils/licenses.cc:21
 msgid "Print report about licenses and EULAs of installed packages."
-msgstr "インストール済みのパッケージに対し、ライセンスと使用許諾契約を表示します。"
+msgstr ""
+"インストール済みのパッケージに対し、ライセンスと使用許諾契約を表示します。"
 
 #. translators: command description
 #: src/commands/utils/licenses.cc:23
 msgid "Report licenses and EULAs of currently installed software packages."
-msgstr "現在インストール済みのソフトウエアパッケージについて、ライセンスと使用許諾契"
+msgstr ""
+"現在インストール済みのソフトウエアパッケージについて、ライセンスと使用許諾契"
 "約を表示します。"
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5091,10 +5211,10 @@ msgid ""
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""
-"/etc/zypp/zypp.conf 内の multiversion.kernels "
-"で指定された「保持すべきカーネル」の設定に従って、不要なカーネルを自動削除し"
-"ます。なお multiversion.kernels の値には、バージョン番号そのもののほか、"
-"新しいものから n 個分や古いものから n 個分のように設定することができます。"
+"/etc/zypp/zypp.conf 内の multiversion.kernels で指定された「保持すべきカーネ"
+"ル」の設定に従って、不要なカーネルを自動削除します。なお "
+"multiversion.kernels の値には、バージョン番号そのもののほか、新しいものから "
+"n 個分や古いものから n 個分のように設定することができます。"
 
 #: src/commands/utils/purge-kernels.cc:51
 msgid "Preparing to purge obsolete kernels..."
@@ -5170,8 +5290,9 @@ msgstr "インストール済みパッケージ"
 
 #: src/commands/utils/source-download.cc:368
 msgid "Use '--verbose' option for a full list of required source packages."
-msgstr "必要なソースパッケージをすべて表示するには、 '--verbose' "
-"オプションをご利用ください。"
+msgstr ""
+"必要なソースパッケージをすべて表示するには、 '--verbose' オプションをご利用く"
+"ださい。"
 
 #: src/commands/utils/source-download.cc:377
 msgid "Deleting superfluous source packages"
@@ -5210,8 +5331,9 @@ msgstr "ダウンロードすべきソースパッケージはありません。
 #: src/commands/utils/source-download.cc:481
 #: src/commands/utils/source-download.cc:483
 msgid "Download source rpms for all installed packages to a local directory."
-msgstr "全てのインストール済みパッケージに対して、対応するソース RPM をローカル "
-"ディレクトリにダウンロードします。"
+msgstr ""
+"全てのインストール済みパッケージに対して、対応するソース RPM をローカル ディ"
+"レクトリにダウンロードします。"
 
 #. translators: -d, --directory <DIR>
 #: src/commands/utils/source-download.cc:495
@@ -5221,16 +5343,18 @@ msgstr "全てのソース RPM を、このディレクトリにダウンロー�
 #. translators: --delete/--no-delete
 #: src/commands/utils/source-download.cc:501
 msgid "Whether to delete extraneous source rpms in the local directory."
-msgstr "ローカルディレクトリ内にある無関係なソース RPM "
-"を削除するかどうかを指定します。"
+msgstr ""
+"ローカルディレクトリ内にある無関係なソース RPM を削除するかどうかを指定しま"
+"す。"
 
 #. translators: --status
 #: src/commands/utils/source-download.cc:505
 msgid ""
 "Don't download any source rpms, but show which source rpms are missing or "
 "extraneous."
-msgstr "ソース RPM をダウンロードしない代わりに、存在しないものや "
-"不要なものを表示します。"
+msgstr ""
+"ソース RPM をダウンロードしない代わりに、存在しないものや 不要なものを表示し"
+"ます。"
 
 #. translators: command summary: targetos, tos
 #: src/commands/utils/system-architecture.cc:20
@@ -5253,26 +5377,25 @@ msgid ""
 "the XPath:/product/register/target entry in /etc/products.d/baseproduct."
 msgstr ""
 "ターゲットオペレーティングシステムの ID 文字列を表示します。この文字列は /"
-"etc/products.d/baseproduct ファイル内の XPath:/product/register/target "
-"という項目で指定されているものです。"
+"etc/products.d/baseproduct ファイル内の XPath:/product/register/target という"
+"項目で指定されているものです。"
 
 #: src/commands/utils/targetos.cc:25
 msgid ""
 "If the baseproduct does not provide this entry, or if no baseproduct is "
 "installed at all, the value is empty if the --terse global option is used."
 msgstr ""
-"baseproduct ファイル内に該当する項目が存在しない場合や、 baseproduct "
-"ファイルが存在しない場合、 --terse "
-"グローバルオプションが指定されていると、値は空になります。"
+"baseproduct ファイル内に該当する項目が存在しない場合や、 baseproduct ファイル"
+"が存在しない場合、 --terse グローバルオプションが指定されていると、値は空にな"
+"ります。"
 
 #: src/commands/utils/targetos.cc:26
 msgid ""
 "In not-terse mode the distribution label is shown instead of an empty value, "
 "if a baseproduct is installed."
 msgstr ""
-"--terse オプションが指定されていない場合で baseproduct "
-"ファイルが存在する場合は、空文字の代わりに distribution "
-"ラベルが表示されます。"
+"--terse オプションが指定されていない場合で baseproduct ファイルが存在する場合"
+"は、空文字の代わりに distribution ラベルが表示されます。"
 
 #: src/commands/utils/targetos.cc:36
 msgid "Show the baseproducts distribution and short label instead."
@@ -5317,13 +5440,14 @@ msgid ""
 "The exit code is 0 if the versions are equal, 11 if VERSION1 is newer, and "
 "12 if VERSION2 is newer."
 msgstr ""
-"バージョンが等しければ 0 を、バージョン1のほうが新しければ 11 を、"
-"バージョン2のほうが新しければ 12 を、それぞれ終了コードとして設定します。"
+"バージョンが等しければ 0 を、バージョン1のほうが新しければ 11 を、バージョン2"
+"のほうが新しければ 12 を、それぞれ終了コードとして設定します。"
 
 #. translators: -m, --match
 #: src/commands/utils/versioncmp.cc:38
 msgid "Takes missing release number as any release."
-msgstr "リリース番号が存在しないときはどんなリリースでもかまわないものとします。"
+msgstr ""
+"リリース番号が存在しないときはどんなリリースでもかまわないものとします。"
 
 #: src/commands/utils/versioncmp.cc:85
 #, c-format, boost-format
@@ -5343,15 +5467,15 @@ msgstr "%s は %s よりも古くなっています"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "バージョン"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "アーキテクチャ"
 
@@ -5407,12 +5531,14 @@ msgstr "後継パッケージは既にインストール済みです。"
 msgid ""
 "The successor package should be installed as soon as possible to receive "
 "continued support."
-msgstr "サポートを受け続けるには、できる限り速やかに後継パッケージをインストールする"
+msgstr ""
+"サポートを受け続けるには、できる限り速やかに後継パッケージをインストールする"
 "必要があります。"
 
 #: src/info.cc:435
 msgid "Unfortunately the successor package is not provided by any repository."
-msgstr "残念ながら、後継パッケージはどのリポジトリ内においても提供されていません。"
+msgstr ""
+"残念ながら、後継パッケージはどのリポジトリ内においても提供されていません。"
 
 #. translators: property name; short; used like "Name: value"
 #: src/info.cc:445
@@ -5485,13 +5611,13 @@ msgstr "(何もありません)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "依存関係"
 
@@ -5528,7 +5654,7 @@ msgid "Flavor"
 msgstr "フレーバー"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "ベース"
 
@@ -5630,7 +5756,8 @@ msgstr "終了処理中です。しばらくお待ちください..."
 #. translators: this will show up if you press ctrl+c twice
 #: src/main.cc:154
 msgid "Zypper is currently cleaning up, exiting as soon as possible."
-msgstr "zypper はクリーンアップ処理を実行中です。できる限り速やかに終了します。"
+msgstr ""
+"zypper はクリーンアップ処理を実行中です。できる限り速やかに終了します。"
 
 #. translators: the first %s is name of the resolvable,
 #. the second is its kind (e.g. 'zypper package')
@@ -5647,8 +5774,9 @@ msgstr "自動的に %s %s ライセンスに同意します。"
 msgid ""
 "In order to install '%s'%s, you must agree to terms of the following license "
 "agreement:"
-msgstr "'%s'%s をインストールするには下記のライセンス (使用許諾) "
-"契約の条項に同意する必要があります:"
+msgstr ""
+"'%s'%s をインストールするには下記のライセンス (使用許諾) 契約の条項に同意する"
+"必要があります:"
 
 #. lincense prompt
 #: src/misc.cc:187
@@ -5657,8 +5785,9 @@ msgstr "ライセンス (使用許諾) 契約条項に同意しますか？"
 
 #: src/misc.cc:193
 msgid "Aborting installation due to the need for license confirmation."
-msgstr "ライセンス (使用許諾) "
-"契約に同意する必要があるため、インストールを中止します。"
+msgstr ""
+"ライセンス (使用許諾) 契約に同意する必要があるため、インストールを中止しま"
+"す。"
 
 #. translators: %s is '--auto-agree-with-licenses'
 #: src/misc.cc:196
@@ -5666,15 +5795,17 @@ msgstr "ライセンス (使用許諾) "
 msgid ""
 "Please restart the operation in interactive mode and confirm your agreement "
 "with required licenses, or use the %s option."
-msgstr "対話モードで起動しなおして必要なライセンス (使用許諾) 契約の確認を行うか、"
-"コマンドラインオプションに %s を指定してください。"
+msgstr ""
+"対話モードで起動しなおして必要なライセンス (使用許諾) 契約の確認を行うか、コ"
+"マンドラインオプションに %s を指定してください。"
 
 #. translators: e.g. "... with flash package license."
 #: src/misc.cc:209
 #, c-format, boost-format
 msgid "Aborting installation due to user disagreement with %s %s license."
-msgstr "%s %s のライセンス (使用許諾) "
-"契約に同意しなかったため、インストールを中止しました。"
+msgstr ""
+"%s %s のライセンス (使用許諾) 契約に同意しなかったため、インストールを中止し"
+"ました。"
 
 #: src/misc.cc:248
 msgid "License"
@@ -5745,9 +5876,8 @@ msgid ""
 "Repo '%1%' is managed by service '%2%'. Volatile changes are reset by the "
 "next service refresh!"
 msgstr ""
-"リポジトリ '%1%' はサービス '%2%' "
-"で管理されています。ここで変更を行っても、次回のサービス更新の際にリセットさ"
-"れてしまうことにご注意ください！"
+"リポジトリ '%1%' はサービス '%2%' で管理されています。ここで変更を行っても、"
+"次回のサービス更新の際にリセットされてしまうことにご注意ください！"
 
 #: src/repos.cc:75
 msgid "default priority"
@@ -5769,7 +5899,8 @@ msgstr "はい (y)"
 msgid ""
 "Repository priorities are without effect. All enabled repositories share the "
 "same priority."
-msgstr "リポジトリの優先順位は無効化されています。有効化されている全てのリポジトリが"
+msgstr ""
+"リポジトリの優先順位は無効化されています。有効化されている全てのリポジトリが"
 "同じ優先順位になっています。"
 
 #: src/repos.cc:184
@@ -5789,96 +5920,98 @@ msgstr[0] "%1% 個のリポジトリ"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "%s に対するメタデータを更新する必要があるか確認しています"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "リポジトリ '%s' は最新の状態に更新済みです。"
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "'%s' の最新状態の確認を延期しました。"
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "未加工のメタデータの更新を強制しています"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "リポジトリ '%s' のメタデータを取り出しています"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "リポジトリ %s を完全に無効にしますか?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "リポジトリ '%s' を無効にする際にエラーが発生しました。"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "'%s' からのファイル取得中に問題が発生しました。"
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "解決へのヒントとして上記のエラーメッセージをお読みください。"
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "'%s' に対して何も URI が設定されていません。"
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
-msgstr "%s (リポジトリ '%s')に (baseurl=URI) "
-"の形式で1つ以上のベースURIエントリを設定してください。"
+msgstr ""
+"%s (リポジトリ '%s')に (baseurl=URI) の形式で1つ以上のベースURIエントリを設定"
+"してください。"
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "このリポジトリの別名は定義されていません。"
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "リポジトリ '%s' は無効です。"
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
-msgstr "このリポジトリに定義された URI "
-"が正しい場所を指しているかどうか確認してください。"
+msgstr ""
+"このリポジトリに定義された URI が正しい場所を指しているかどうか確認してくださ"
+"い。"
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "'%s' のメタデータ取得に失敗:"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "リポジトリキャッシュを強制的に再構築しています"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "'%s' のメタデータの解析中にエラーが発生しました:"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5886,46 +6019,49 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 "この問題はリポジトリ内に無効なメタデータが含まれているか、メタデータ解析プロ"
-"グラムにバグがある場合に発生することがあります。後者をお疑いの場合は、https:/"
-"/ja.opensuse.org/"
-"SDB:Zypperのトラブルシューティングにある手順でバグ報告をお願いいたします。"
+"グラムにバグがある場合に発生することがあります。後者をお疑いの場合は、"
+"https://ja.opensuse.org/SDB:Zypperのトラブルシューティングにある手順でバグ報"
+"告をお願いいたします。"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
-msgstr "ローカルキャッシュ内には '%s' のリポジトリメタデータは見つかりませんでした。"
+msgstr ""
+"ローカルキャッシュ内には '%s' のリポジトリメタデータは見つかりませんでした。"
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "キャッシュの構築の際にエラー:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "リポジトリ '%s' は別名／番号／URLのいずれでも見つかりません。"
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
-msgstr "設定したリポジトリの一覧を取得するには '%s' コマンドを使用してください。"
+msgstr ""
+"設定したリポジトリの一覧を取得するには '%s' コマンドを使用してください。"
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "無効化されたリポジトリ「%s」を無視しています"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
-msgstr "リポジトリを一時的に有効化するには、グローバルオプション '%s' "
-"をご利用ください。"
+msgstr ""
+"リポジトリを一時的に有効化するには、グローバルオプション '%s' をご利用くださ"
+"い。"
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "リポジトリ '%s' を '%s' オプションのため無視しています。"
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "リポジトリ '%s' を一時的に有効化しています。"
@@ -5933,15 +6069,16 @@ msgstr "リポジトリ '%s' を一時的に有効化しています。"
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
-msgstr "リポジトリ '%s' が古くなっています。 root ユーザで 'zypper refresh' "
-"コマンドを実行すると更新できます。"
+msgstr ""
+"リポジトリ '%s' が古くなっています。 root ユーザで 'zypper refresh' コマンド"
+"を実行すると更新できます。"
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -5950,326 +6087,335 @@ msgstr ""
 "リポジトリ '%s' に対するメタデータキャッシュの構築が必要です。 root ユーザで "
 "'zypper refresh' コマンドを実行すると行うことができます。"
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "リポジトリ '%s' は無効なままです。"
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "ターゲットを準備しています"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "ターゲットの準備に失敗しました:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "'%s' のメタデータのキャッシュを削除しています。"
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "'%s' の未加工のメタデータのキャッシュを削除しています。"
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "%s '%s' に対する未加工のメタデータのキャッシュを保持しています。"
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "'%s' のパッケージのキャッシュを削除しています。"
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
-msgstr "エラーが発生したため、リポジトリ '%s' "
-"のキャッシュ削除を行うことができませんでした。"
+msgstr ""
+"エラーが発生したため、リポジトリ '%s' のキャッシュ削除を行うことができません"
+"でした。"
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "インストール済みのパッケージキャッシュを削除しています。"
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
-msgstr "エラーが発生したため、インストール済みパッケージのキャッシュ削除を行うことが"
+msgstr ""
+"エラーが発生したため、インストール済みパッケージのキャッシュ削除を行うことが"
 "できませんでした。"
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
-msgstr "エラーが発生したため、リポジトリのキャッシュ削除を行うことができませんでした"
-"。"
+msgstr ""
+"エラーが発生したため、リポジトリのキャッシュ削除を行うことができませんでし"
+"た。"
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
-msgstr "エラーが発生したため、いくつかのリポジトリのキャッシュを削除することができま"
+msgstr ""
+"エラーが発生したため、いくつかのリポジトリのキャッシュを削除することができま"
 "せんでした。"
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "指定したリポジトリのキャッシュ削除が完了しました。"
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "すべてのリポジトリについてキャッシュ削除が完了しました。"
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
-msgstr "これは交換可能な読み込み専用デバイス (CD または DVD) "
-"です、自動更新を無効に設定します。"
+msgstr ""
+"これは交換可能な読み込み専用デバイス (CD または DVD) です、自動更新を無効に設"
+"定します。"
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "リポジトリの別名が正しくありません:'%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
-msgstr "リポジトリの種類を判別できませんでした。 指定した下記の URI "
-"が正しい場所を示しているかどうか確認してください:"
+msgstr ""
+"リポジトリの種類を判別できませんでした。 指定した下記の URI が正しい場所を示"
+"しているかどうか確認してください:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "下記の場所には有効なリポジトリが見つかりません:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "指定した URI からリポジトリデータを転送する際にエラー:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "指定した URI がアクセス可能かどうかを確認してください。"
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "リポジトリを追加する際に未知の問題:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
-msgstr "リポジトリ '%1%' は、 "
-"GPGの検証を無効化するように設定されています。パッケージの正当性と作成元は検証"
-"されません。"
+msgstr ""
+"リポジトリ '%1%' は、 GPGの検証を無効化するように設定されています。パッケージ"
+"の正当性と作成元は検証されません。"
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "リポジトリ '%s' を正常に追加しました"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "メディア '%s' からデータを読み込んでいます"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "メディア '%s' からデータを読み取る際に問題"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "インストールメディアが有効で読み取り可能かどうか確認してください。"
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "メディア '%s' からのデータ読み込みは、次回の更新まで行いません。"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "メディア '%s' からデータを読み込んでいます"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "メディア '%s' からデータを読み取る際に問題"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "インストールメディアが有効で読み取り可能かどうか確認してください。"
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "指定した URI にあるファイルにアクセスする際に問題"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "指定した URI が有効でアクセス可能であることを確認してください。"
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "指定した URI のファイルを処理する際に問題"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "指定のものは本当に .repo ファイルですか？"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "指定した URI にあるファイルを読む際に問題が発生しました"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
-msgstr "ファイル内に別名定義のないリポジトリが見つかりました。スキップしています。"
+msgstr ""
+"ファイル内に別名定義のないリポジトリが見つかりました。スキップしています。"
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "リポジトリ '%s' には URI が設定されていません。スキップしています。"
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "リポジトリ %s を削除しました。"
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "リポジトリ '%s' の優先順位を変更しませんでした (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "リポジトリ '%s' を有効に設定しました。"
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "リポジトリ '%s' を無効に設定しました。"
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "リポジトリ '%s' の自動更新を有効に設定しました。"
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "リポジトリ '%s' の自動更新を無効に設定しました。"
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "リポジトリ '%s' の RPM ファイルキャッシュ設定を有効にしました。"
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "リポジトリ '%s' の RPM ファイルキャッシュ設定を無効にしました。"
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "リポジトリ '%s' に対してGPGチェックを有効にしました。"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "リポジトリ '%s' に対してGPGチェックを無効にしました。"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "リポジトリ '%s' の優先順位を %d に設定しました。"
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "リポジトリ '%s' の名前を '%s' に設定しました。"
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "リポジトリ '%s' に対して変更することは何もありません。"
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "リポジトリ %s を修正せずそのままにします。"
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "リポジトリのデータを読み込んでいます..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
-msgstr "リポジトリが定義されていません。操作はインストール済みの解決方法についてのみ"
+msgstr ""
+"リポジトリが定義されていません。操作はインストール済みの解決方法についてのみ"
 "行われます。何もインストールできません。"
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "リポジトリ '%s' のデータを取り出しています..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "リポジトリ '%s' はキャッシュされていません。キャッシュしています..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "'%s' からのデータ読み込みの際に問題"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "リポジトリ '%s' を更新できませんでした。古いキャッシュを使用します。"
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "エラーにより '%s' からの解決方法が読み取れませんでした。"
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "リポジトリ '%1%' のメタデータは %2% で期限切れになっています。"
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "それを行う前に '%s' または '%s' を試してみてください。"
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
 "not solve the issue, it could be that you are using a broken mirror or the "
 "server has actually discontinued to support the repository."
 msgstr ""
-"リポジトリのメタデータの有効期限が切れています: 'autorefresh' "
-"の設定が有効化されていること (zypper lr で表示できます) を確認するか、"
-"もしくは手作業でリポジトリを更新してください (zypper ref で実行できます) "
-"。手作業で更新しても問題が解決しない場合は、お使いのミラーサーバの更新が止ま"
-"っているか、提供を終了しているものと考えられます。"
+"リポジトリのメタデータの有効期限が切れています: 'autorefresh' の設定が有効化"
+"されていること (zypper lr で表示できます) を確認するか、もしくは手作業でリポ"
+"ジトリを更新してください (zypper ref で実行できます) 。手作業で更新しても問題"
+"が解決しない場合は、お使いのミラーサーバの更新が止まっているか、提供を終了し"
+"ているものと考えられます。"
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "インストール済みのパッケージを読み込んでいます..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "インストール済みのパッケージを読み込む際にエラー:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' は RPM ファイルのようです。ダウンロードを行います。"
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "'%s' で指定したRPMファイルで問題が発生しました。スキップしています。"
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
-msgstr "%s のRPMヘッダを読み込む際に問題が発生しました。 "
-"RPMファイルでない可能性があります。"
+msgstr ""
+"%s のRPMヘッダを読み込む際に問題が発生しました。 RPMファイルでない可能性があ"
+"ります。"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "RPM ファイルキャッシュ"
 
@@ -6277,25 +6423,25 @@ msgstr "RPM ファイルキャッシュ"
 msgid "System Packages"
 msgstr "システムパッケージ"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "適用すべきパッチが見つかりません。"
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "パターンが見つかりません。"
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "パッケージが見つかりません。"
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "内部名"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "製品が見つかりません。"
 
@@ -6324,7 +6470,8 @@ msgstr "詳細情報: "
 #: src/solve-commit.cc:138
 msgid "Choose the above solution using '1' or skip, retry or cancel"
 msgid_plural "Choose from above solutions by number or skip, retry or cancel"
-msgstr[0] "「1」を使用して上記の解決策を受け入れるか、スキップ、再試行、またはキャンセル"
+msgstr[0] ""
+"「1」を使用して上記の解決策を受け入れるか、スキップ、再試行、またはキャンセル"
 "のいずれかを選択してください"
 
 #. translators: translate 'c' to whatever you translated the 'c' in
@@ -6332,8 +6479,9 @@ msgstr[0] "「1」を使用して上記の解決策を受け入れるか、ス�
 #: src/solve-commit.cc:145
 msgid "Choose the above solution using '1' or cancel using 'c'"
 msgid_plural "Choose from above solutions by number or cancel"
-msgstr[0] "「1」を選択して上記の解決策を選択するか、「c」 "
-"を使用してキャンセルしてください"
+msgstr[0] ""
+"「1」を選択して上記の解決策を選択するか、「c」 を使用してキャンセルしてくださ"
+"い"
 
 #. translators: answers for dependency problem solution input prompt:
 #. "Choose from above solutions by number or skip, retry or cancel"
@@ -6432,8 +6580,9 @@ msgstr "解決処理のテスト出力中にエラーが発生しました。"
 msgid ""
 "Explicitly selecting DownloadAsNeeded also selects the classic_rpmtrans "
 "backend."
-msgstr "明示的に DownloadAsNeeded を指定した場合、 classic_rpmtrans "
-"も同時に選択されます。"
+msgstr ""
+"明示的に DownloadAsNeeded を指定した場合、 classic_rpmtrans も同時に選択され"
+"ます。"
 
 #: src/solve-commit.cc:620
 #, c-format, boost-format
@@ -6456,8 +6605,8 @@ msgid ""
 "latest updates. Run '%1%' to list these programs."
 msgstr ""
 "実行中のプログラムが、直近のアップグレードにより削除もしくは更新されたファイ"
-"ルを使用しています。ご確認の上、これらを再起動してください。 '%1%' "
-"と入力して実行すると、プログラムの一覧を表示することができます。"
+"ルを使用しています。ご確認の上、これらを再起動してください。 '%1%' と入力して"
+"実行すると、プログラムの一覧を表示することができます。"
 
 #: src/solve-commit.cc:657
 msgid "Update notifications were received from the following packages:"
@@ -6488,7 +6637,8 @@ msgstr "パッケージの依存関係を解決しています..."
 msgid ""
 "Some of the dependencies of installed packages are broken. In order to fix "
 "these dependencies, the following actions need to be taken:"
-msgstr "インストール済みのパッケージのうち、いくつかの依存関係が壊れています。依存関"
+msgstr ""
+"インストール済みのパッケージのうち、いくつかの依存関係が壊れています。依存関"
 "係を修復するには、以下の作業を実行する必要があります:"
 
 #: src/solve-commit.cc:795
@@ -6513,9 +6663,9 @@ msgstr "y/n/p/v/a/r/m/d/g"
 #: src/solve-commit.cc:822
 msgid ""
 "Yes, accept the summary and proceed with installation/removal of packages."
-msgstr "はい "
-"(y)、概要に表示されている内容を受け入れ、パッケージのインストール/削除を行い"
-"ます。"
+msgstr ""
+"はい (y)、概要に表示されている内容を受け入れ、パッケージのインストール/削除を"
+"行います。"
 
 #. translators: help text for 'n' option in the 'Continue?' prompt
 #: src/solve-commit.cc:824
@@ -6602,13 +6752,15 @@ msgstr ""
 
 #: src/solve-commit.cc:1045
 msgid "Problem occurred during or after installation or removal of packages:"
-msgstr "インストールまたは削除の際、もしくはそれぞれの作業の後に問題が発生しました:"
+msgstr ""
+"インストールまたは削除の際、もしくはそれぞれの作業の後に問題が発生しました:"
 
 #: src/solve-commit.cc:1084
 msgid ""
 "One of the installed patches requires a reboot of your machine. Reboot as "
 "soon as possible."
-msgstr "インストールされたパッチの中にはコンピュータの再起動を必要とするものがありま"
+msgstr ""
+"インストールされたパッチの中にはコンピュータの再起動を必要とするものがありま"
 "す。できるだけ早めに再起動してください。"
 
 #: src/solve-commit.cc:1097
@@ -6679,7 +6831,7 @@ msgid "Updatestack"
 msgstr "更新スタック"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "パッチ"
 
@@ -6702,7 +6854,7 @@ msgstr "補助カテゴリ"
 msgid "Needed software management updates will be installed first:"
 msgstr "必要なソフトウエア管理の更新を先にインストールします:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "更新が見つかりません。"
 
@@ -6711,54 +6863,56 @@ msgstr "更新が見つかりません。"
 msgid "The following updates are also available:"
 msgstr "以下のソフトウエア更新も利用できます:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "パッケージの更新"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "パターンの更新"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "製品の更新"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "現在のバージョン"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "利用可能なバージョン"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "該当する発信がありません。"
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "発信番号に該当する以下のものが見つかりました:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "以下のパッチの説明に該当するものが見つかりました:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
-msgstr "Bugzilla 発信番号 %s "
-"に対する修正は見つからなかったか、もしくは不要なものです。"
+msgstr ""
+"Bugzilla 発信番号 %s に対する修正は見つからなかったか、もしくは不要なもので"
+"す。"
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "CVE 発信番号 %s に対する修正は見つからなかったか、または不要です。"
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
-msgstr "%s 発信番号 %s に対する修正は見つからなかったか、もしくは不要なものです。"
+msgstr ""
+"%s 発信番号 %s に対する修正は見つからなかったか、もしくは不要なものです。"
 
 #: src/utils/Augeas.cc:102
 msgid "Cannot initialize configuration file parser."
@@ -6791,7 +6945,8 @@ msgstr "設定ファイル '%1%' が存在していません。"
 #: src/utils/Augeas.cc:635
 #, boost-format
 msgid "%1%: Option '%2%' is defined multiple times. Using the last one."
-msgstr "%1%: オプション '%2%' が複数回指定されています。最後の 1 つのみを使用します。"
+msgstr ""
+"%1%: オプション '%2%' が複数回指定されています。最後の 1 つのみを使用します。"
 
 #: src/utils/Augeas.cc:656
 msgid "No config file is in use."
@@ -6836,8 +6991,9 @@ msgstr "フラグ '%1%' は最大 %2% 回まで指定することができます
 msgid ""
 "Ignoring %s without argument because similar option with an argument has "
 "been specified."
-msgstr "引数が設定された類似オプションが指定されているため、引数のない %s "
-"を無視しています。"
+msgstr ""
+"引数が設定された類似オプションが指定されているため、引数のない %s を無視して"
+"います。"
 
 #: src/utils/flags/flagtypes.cc:235
 msgid "Out of range"
@@ -6951,8 +7107,9 @@ msgstr "これに関するバグ報告を作成してください。"
 #. unless you translate the actual page :)
 #: src/utils/messages.cc:22
 msgid "See http://en.opensuse.org/Zypper/Troubleshooting for instructions."
-msgstr "詳しい手順については https://ja.opensuse.org/SDB:"
-"Zypper_のトラブルシューティング を参照してください。"
+msgstr ""
+"詳しい手順については https://ja.opensuse.org/SDB:Zypper_のトラブルシューティ"
+"ング を参照してください。"
 
 #: src/utils/messages.cc:38
 msgid "Too many arguments."
@@ -6971,34 +7128,38 @@ msgid ""
 "recommended to run '%s' after the operation has finished."
 msgstr ""
 "パッケージのダウンロードやインストールの問題を無視しようとしています。この行"
-"為は他のパッケージの依存関係を壊す可能性があります。操作が完了次第、 '%s' "
-"を実行することをお勧めします。"
+"為は他のパッケージの依存関係を壊す可能性があります。操作が完了次第、 '%s' を"
+"実行することをお勧めします。"
 
 #: src/utils/messages.cc:111
 #, boost-format
 msgid ""
 "Legacy commandline option %1% detected. Please use global option %2% instead."
-msgstr "古い形式のコマンドラインオプション %1% が指定されています。"
-"グローバルオプション %2% をお使いください。"
+msgstr ""
+"古い形式のコマンドラインオプション %1% が指定されています。グローバルオプショ"
+"ン %2% をお使いください。"
 
 #: src/utils/messages.cc:112
 #, boost-format
 msgid "Legacy commandline option %1% detected. Please use %2% instead."
-msgstr "古い形式のコマンドラインオプション %1% が指定されています。%2% "
-"をお使いください。"
+msgstr ""
+"古い形式のコマンドラインオプション %1% が指定されています。%2% をお使いくださ"
+"い。"
 
 #: src/utils/messages.cc:118
 #, boost-format
 msgid "Legacy commandline option %1% detected. This option is ignored."
-msgstr "古い形式のコマンドラインオプション %1% "
-"が指定されています。このオプションは無視されます。"
+msgstr ""
+"古い形式のコマンドラインオプション %1% が指定されています。このオプションは無"
+"視されます。"
 
 #: src/utils/messages.cc:123
 #, boost-format
 msgid ""
 "Abbreviated commandline options will not be supported in future versions. "
 "Please use %2% instead of %1% ."
-msgstr "コマンドラインオプションの省略形は将来バージョンでサポートされなくなる予定で"
+msgstr ""
+"コマンドラインオプションの省略形は将来バージョンでサポートされなくなる予定で"
 "す。 %1% ではなく %2% をお使いください。"
 
 #. translators: %s is "help" or "zypper help" depending on whether
@@ -7006,7 +7167,8 @@ msgstr "コマンドラインオプションの省略形は将来バージョン
 #: src/utils/messages.cc:141
 #, c-format, boost-format
 msgid "Type '%s' to get a list of global options and commands."
-msgstr "グローバルオプションとコマンドの一覧を取得するには '%s' と入力してください。"
+msgstr ""
+"グローバルオプションとコマンドの一覧を取得するには '%s' と入力してください。"
 
 #. translators: %1% is the name of an (unknown) command
 #. translators: %2% something providing more info (like 'zypper help subcommand')
@@ -7017,9 +7179,9 @@ msgid ""
 "In case '%1%' is not a typo it's probably not a built-in command, but "
 "provided as a subcommand or plug-in (see '%2%')."
 msgstr ""
-"'%1%' が入力ミスではない場合、これは内蔵されているコマンドではなく、"
-"サブコマンドやプラグインとして提供されているものである可能性があります ("
-"詳しくは '%2%' をお読みください) 。"
+"'%1%' が入力ミスではない場合、これは内蔵されているコマンドではなく、サブコマ"
+"ンドやプラグインとして提供されているものである可能性があります (詳しくは "
+"'%2%' をお読みください) 。"
 
 #. translators: %1% and %2% are plug-in packages which might provide it.
 #. translators: The word 'subcommand' also refers to a zypper command and should not be translated.
@@ -7030,8 +7192,8 @@ msgid ""
 "installed first. Those packages are often named '%1%' or '%2%'."
 msgstr ""
 "この場合、あらかじめサブコマンドに対応するパッケージをインストールしておく必"
-"要があります。これらのパッケージは '%1%' や '%2%' "
-"のような名前になっています。"
+"要があります。これらのパッケージは '%1%' や '%2%' のような名前になっていま"
+"す。"
 
 #: src/utils/misc.cc:93
 msgid "package"
@@ -7156,8 +7318,9 @@ msgstr "正しい形式はobs://<project>/[platform]です"
 
 #: src/utils/misc.cc:647
 msgid "Problem copying the specified RPM file to the cache directory."
-msgstr "指定した RPM "
-"ファイルをキャッシュディレクトリにコピーする際に問題が発生しました。"
+msgstr ""
+"指定した RPM ファイルをキャッシュディレクトリにコピーする際に問題が発生しまし"
+"た。"
 
 #: src/utils/misc.cc:648
 msgid "Perhaps you are running out of disk space."
@@ -7227,8 +7390,9 @@ msgstr "決して行わない"
 
 #: src/utils/prompt.cc:188
 msgid "Cannot read input: bad stream or EOF."
-msgstr "入力を読み込むことができません: ストリームが正しくないか、 EOF "
-"が検出されました。"
+msgstr ""
+"入力を読み込むことができません: ストリームが正しくないか、 EOF が検出されまし"
+"た。"
 
 #: src/utils/prompt.cc:189
 #, c-format, boost-format
@@ -7237,8 +7401,8 @@ msgid ""
 "option to make zypper use default answers to prompts."
 msgstr ""
 "zypperを端末無しで実行する場合、 '%s' のグローバルオプションを\n"
-"指定することで、 "
-"zypperに対して問い合わせへの既定の応答を設定することができます。"
+"指定することで、 zypperに対して問い合わせへの既定の応答を設定することができま"
+"す。"
 
 #: src/utils/prompt.cc:278
 #, c-format, boost-format
@@ -7254,16 +7418,17 @@ msgstr "回答 '%s' が不正確です。"
 #: src/utils/prompt.cc:289
 #, c-format, boost-format
 msgid "Enter '%s' for '%s' or '%s' for '%s' if nothing else works for you."
-msgstr "うまく動作しない場合、 「%s」(「%s」の場合)、 "
-"「%s」(「%s」の場合)を入力してください。"
+msgstr ""
+"うまく動作しない場合、 「%s」(「%s」の場合)、 「%s」(「%s」の場合)を入力して"
+"ください。"
 
 #: src/utils/prompt.cc:294
 msgid ""
 "If nothing else works enter '#1' to select the 1st option, '#2' for the 2nd "
 "one, ..."
 msgstr ""
-"いずれも動作しない場合は、 '#1' と入力すると最初の選択肢を、 '#2' "
-"と入力すると 2 番目の選択肢・・・のように選択することもできます。"
+"いずれも動作しない場合は、 '#1' と入力すると最初の選択肢を、 '#2' と入力する"
+"と 2 番目の選択肢・・・のように選択することもできます。"
 
 #. TranslatorExplanation These are reasons for various failures.
 #: src/utils/prompt.h:95

--- a/po/ka.po
+++ b/po/ka.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Georgian <https://l10n.opensuse.org/projects/zypper/master/ka/"
@@ -822,7 +822,8 @@ msgstr[0] "შემდეგი %d რეკომენდებული პ�
 msgid "The following recommended source package was automatically selected:"
 msgid_plural ""
 "The following %d recommended source packages were automatically selected:"
-msgstr[0] "შემდეგი %d რეკომენდებული საწყისი კოდის პაკეტი ავტომატურად იქნა არჩეული:"
+msgstr[0] ""
+"შემდეგი %d რეკომენდებული საწყისი კოდის პაკეტი ავტომატურად იქნა არჩეული:"
 
 #: src/Summary.cc:1100
 #, c-format, boost-format
@@ -886,14 +887,16 @@ msgstr[0] "შემდეგი %d ნიმუში რეკომენდ�
 msgid "The following product is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d products are recommended, but will not be installed:"
-msgstr[0] "შემდეგი %d პროდუქტი რეკომენდებულია, მაგრამ მათი დაყენება არ მოხდება:"
+msgstr[0] ""
+"შემდეგი %d პროდუქტი რეკომენდებულია, მაგრამ მათი დაყენება არ მოხდება:"
 
 #: src/Summary.cc:1195
 #, c-format, boost-format
 msgid "The following application is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d applications are recommended, but will not be installed:"
-msgstr[0] "შემდეგი %d აპლიკაცია რეკომენდებულია, მაგრამ მათი დაყენება არ მოხდება:"
+msgstr[0] ""
+"შემდეგი %d აპლიკაცია რეკომენდებულია, მაგრამ მათი დაყენება არ მოხდება:"
 
 #: src/Summary.cc:1228
 #, c-format, boost-format
@@ -995,7 +998,8 @@ msgstr[0] "%d აპლიკაცია მომწოდებელს შ�
 msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
-msgstr[0] "%d პაკეტს მათი მომწოდებლის მხარდაჭერის შესახებ ინფორმაცია არ გააჩნია:"
+msgstr[0] ""
+"%d პაკეტს მათი მომწოდებლის მხარდაჭერის შესახებ ინფორმაცია არ გააჩნია:"
 
 #: src/Summary.cc:1382
 #, c-format, boost-format
@@ -1275,7 +1279,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "კიდევ სცადეთ?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr ""
 
@@ -1303,12 +1307,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -1988,24 +1992,30 @@ msgid "Commands:"
 msgstr "ბრძანებები:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "პაკეტის ტიპი (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2075,7 +2085,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2256,22 +2266,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2322,49 +2332,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2464,11 +2478,11 @@ msgstr[0] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "სახელი"
 
@@ -2478,8 +2492,8 @@ msgstr "დამთხვევები"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "ტიპი"
@@ -2487,7 +2501,7 @@ msgstr "ტიპი"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "საცავი"
@@ -2901,7 +2915,7 @@ msgid "Command"
 msgstr "ბრძანება"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "სერვისი"
 
@@ -3062,120 +3076,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3214,12 +3228,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3261,111 +3275,115 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "სინონიმი"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "ჩართული"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "GPG შემოწმება"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "პრიორიტეტი"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "ავტოგანახლება"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "ჩართ"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "გამორთ"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "პაკეტების შენარჩუნება"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "მშობელი სერვისი"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "საკვანძო სიტყვები"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "შეცდომა რეპოზიტორების წაკითხვისას:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr ""
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3373,20 +3391,20 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "განახლება"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "შენარჩუნება"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr ""
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3487,7 +3505,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "მითითებული რეპოზიტორიები: "
 
@@ -3496,7 +3514,7 @@ msgstr "მითითებული რეპოზიტორიები: 
 msgid "Refreshing repository '%s'."
 msgstr "რეპოზიტორიის ('%s') განახლება."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr ""
@@ -3506,7 +3524,7 @@ msgstr ""
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3533,7 +3551,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3586,12 +3604,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr ""
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr ""
 
@@ -4017,25 +4035,25 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "მითითებული რეპოზიტორიa '%s' გამორთულია."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "შედეგის გარეშე."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4125,7 +4143,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr ""
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4144,21 +4162,25 @@ msgstr ""
 msgid "Service '%s' has been removed."
 msgstr ""
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5024,15 +5046,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "ვერსია"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "არქიტექტურა"
 
@@ -5165,13 +5187,13 @@ msgstr "(ცარიელი)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "ს"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "დამოკიდებულება"
 
@@ -5208,7 +5230,7 @@ msgid "Flavor"
 msgstr "ტიპი"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5461,94 +5483,94 @@ msgstr[0] ""
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr ""
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr ""
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr ""
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr ""
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr ""
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr ""
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr ""
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr ""
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr ""
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr ""
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5556,41 +5578,41 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr ""
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr ""
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr ""
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr ""
@@ -5598,294 +5620,294 @@ msgstr ""
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr ""
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr ""
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr ""
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr ""
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr ""
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr ""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr ""
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr ""
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr ""
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr ""
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr ""
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr ""
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr ""
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr ""
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "რეპოზიტორიის მონაცემების ჩატვირთვა..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "'%s' რეპოზიტორიის მონაცემების მიღება..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -5893,30 +5915,30 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr ""
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr ""
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -5924,25 +5946,25 @@ msgstr ""
 msgid "System Packages"
 msgstr "სისტემური პაკეტები"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr ""
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr ""
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr ""
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr ""
 
@@ -6304,7 +6326,7 @@ msgid "Updatestack"
 msgstr "განახლებების სტეკი"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "პაჩები"
 
@@ -6327,7 +6349,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "ჯერ მოხდება პროგრამების მართვის განახლებების დაყენება:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr ""
 
@@ -6336,50 +6358,50 @@ msgstr ""
 msgid "The following updates are also available:"
 msgstr ""
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr ""
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr ""
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "მიმდინარე ვერსია"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "ხელმისაწვდომი ვერსია"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr ""
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/kab.po
+++ b/po/kab.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Kabyle <https://l10n.opensuse.org/projects/zypper/master/kab/>"
-"\n"
+"Language-Team: Kabyle <https://l10n.opensuse.org/projects/zypper/master/kab/"
+">\n"
 "Language: kab\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1353,7 +1353,7 @@ msgstr ""
 msgid "Try again?"
 msgstr ""
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr ""
 
@@ -1381,12 +1381,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2066,24 +2066,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2153,7 +2159,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2334,22 +2340,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2400,49 +2406,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2543,11 +2553,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Isem"
 
@@ -2557,8 +2567,8 @@ msgstr ""
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Anaw"
@@ -2566,7 +2576,7 @@ msgstr "Anaw"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Akufi"
@@ -2980,7 +2990,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Amezlu"
 
@@ -3140,120 +3150,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3292,12 +3302,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3339,111 +3349,115 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Yermed"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr ""
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr ""
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr ""
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr ""
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr ""
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3451,20 +3465,20 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Smiren"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr ""
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3565,7 +3579,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr ""
 
@@ -3574,7 +3588,7 @@ msgstr ""
 msgid "Refreshing repository '%s'."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr ""
@@ -3584,7 +3598,7 @@ msgstr ""
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3611,7 +3625,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3664,12 +3678,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr ""
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr ""
 
@@ -4095,25 +4109,25 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr ""
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr ""
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4203,7 +4217,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr ""
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4222,21 +4236,25 @@ msgstr ""
 msgid "Service '%s' has been removed."
 msgstr ""
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5106,15 +5124,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Lqem"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr ""
 
@@ -5248,13 +5266,13 @@ msgstr "(d ilem)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr ""
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -5291,7 +5309,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5545,94 +5563,94 @@ msgstr[1] ""
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr ""
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr ""
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr ""
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr ""
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr ""
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr ""
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr ""
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr ""
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr ""
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr ""
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5640,41 +5658,41 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr ""
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr ""
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr ""
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr ""
@@ -5682,294 +5700,294 @@ msgstr ""
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr ""
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr ""
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr ""
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr ""
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr ""
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr ""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr ""
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr ""
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr ""
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr ""
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr ""
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr ""
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr ""
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr ""
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr ""
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr ""
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -5977,30 +5995,30 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr ""
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr ""
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6008,25 +6026,25 @@ msgstr ""
 msgid "System Packages"
 msgstr ""
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr ""
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr ""
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr ""
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr ""
 
@@ -6397,7 +6415,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr ""
 
@@ -6420,7 +6438,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr ""
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr ""
 
@@ -6429,50 +6447,50 @@ msgstr ""
 msgid "The following updates are also available:"
 msgstr ""
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr ""
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr ""
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr ""
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr ""
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr ""
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/km.po
+++ b/po/km.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper.km\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Khmer (Central) <https://l10n.opensuse.org/projects/zypper/"
@@ -191,8 +191,7 @@ msgstr ""
 msgid ""
 "Patches having the flag rebootSuggested set will not be treated as "
 "interactive."
-msgstr ""
-"បំណះ​ដែល​មាន​សំណុំ flag rebootSuggested នឹង​មិន​ត្រូវ​បាន​ចាត់​ទុក​ជា​អន្តរសកម្ម​ទេ ។"
+msgstr "បំណះ​ដែល​មាន​សំណុំ flag rebootSuggested នឹង​មិន​ត្រូវ​បាន​ចាត់​ទុក​ជា​អន្តរសកម្ម​ទេ ។"
 
 #. translators: --non-interactive-include-reboot-patches
 #: src/Config.cc:347
@@ -258,8 +257,7 @@ msgstr ""
 #, c-format, boost-format
 msgid ""
 "Turning on '%s'. New repository signing keys will be automatically imported!"
-msgstr ""
-"បើក '%s' ។ សោ​ចុះហត្ថលេខា​ឃ្លាំង​ថ្មី​នឹង​ត្រូវ​បាននាំចូល​ដោយ​ស្វ័យ​ប្រវត្តិ !"
+msgstr "បើក '%s' ។ សោ​ចុះហត្ថលេខា​ឃ្លាំង​ថ្មី​នឹង​ត្រូវ​បាននាំចូល​ដោយ​ស្វ័យ​ប្រវត្តិ !"
 
 #. translators: --gpg-auto-import-keys
 #: src/Config.cc:477
@@ -280,8 +278,7 @@ msgstr ""
 
 #: src/Config.cc:491
 msgid "Repositories disabled, using the database of installed packages only."
-msgstr ""
-"បានបិទឃ្លាំង ប្រើ​មូលដ្ឋាន​ទិន្នន័យ​របស់​តែ​កញ្ចប់​ដែល​បាន​ដំឡើង​ប៉ុណ្ណោះ ។"
+msgstr "បានបិទឃ្លាំង ប្រើ​មូលដ្ឋាន​ទិន្នន័យ​របស់​តែ​កញ្ចប់​ដែល​បាន​ដំឡើង​ប៉ុណ្ណោះ ។"
 
 #. translators: --disable-repositories
 #: src/Config.cc:495
@@ -525,8 +522,7 @@ msgstr ""
 msgid ""
 "There is an update candidate for '%s', but it is locked. Use '%s' to unlock "
 "it."
-msgstr ""
-"មានបច្ចុប្បន្នភាព​​សម្រាប់ '%s' ប៉ុន្តែ​វា​ជាប់​សោ ។ ប្រើ '%s' ដើម្បីដោះសោ​វា ។"
+msgstr "មានបច្ចុប្បន្នភាព​​សម្រាប់ '%s' ប៉ុន្តែ​វា​ជាប់​សោ ។ ប្រើ '%s' ដើម្បីដោះសោ​វា ។"
 
 #: src/RequestFeedback.cc:149
 #, c-format, boost-format
@@ -541,8 +537,7 @@ msgstr ""
 msgid ""
 "The selected package '%s' from repository '%s' has lower version than the "
 "installed one."
-msgstr ""
-"កញ្ចប់​ '%s' ដែល​បាន​ជ្រើស​ពី​ឃ្លាំង '%s' មានកំណែ​ទាបជាង​កញ្ចប់​មួយ​ដែល​បានដមឡើង ។"
+msgstr "កញ្ចប់​ '%s' ដែល​បាន​ជ្រើស​ពី​ឃ្លាំង '%s' មានកំណែ​ទាបជាង​កញ្ចប់​មួយ​ដែល​បានដមឡើង ។"
 
 #. translators: %s = "zypper install --oldpackage package-version.arch"
 #: src/RequestFeedback.cc:163
@@ -570,8 +565,7 @@ msgstr "បំណះ '%s' ត្រូវ​បាន​ចាក់​សោ �
 #: src/RequestFeedback.cc:193
 #, c-format, boost-format
 msgid "Patch '%s' is locked. Use '%s' to install it, or unlock it using '%s'."
-msgstr ""
-"បំណះ '%s' ត្រូវ​បាន​ចាក់​សោ ។ ប្រើ​ '%s' ដើម្បី​ដំឡើង​វា ឬ​ដោះ​សោ​វា​ដោយ​ប្រើ​ '%s' ។"
+msgstr "បំណះ '%s' ត្រូវ​បាន​ចាក់​សោ ។ ប្រើ​ '%s' ដើម្បី​ដំឡើង​វា ឬ​ដោះ​សោ​វា​ដោយ​ប្រើ​ '%s' ។"
 
 #: src/RequestFeedback.cc:200
 #, c-format, boost-format
@@ -1266,8 +1260,8 @@ msgid ""
 "PackageKit is blocking zypper. This happens if you have an updater applet or "
 "other software management application using PackageKit running."
 msgstr ""
-"PackageKit កំពុង​ទប់ស្កាត់ zypper ។ វា​កើត​ឡើង ប្រសិនបើ​អ្នក​មាន​អាប់ភ្លេត​ធ្វើបច្ចុប្បន្នភាព "
-"ឬ​កម្មវិធី​គ្រប់គ្រង​កម្មវិធី​ផ្សេងៗ​ទៀត ដោយ​ប្រើ​ការរត់របស់ PackageKit ។"
+"PackageKit កំពុង​ទប់ស្កាត់ zypper ។ វា​កើត​ឡើង ប្រសិនបើ​អ្នក​មាន​អាប់ភ្លេត​ធ្វើបច្ចុប្បន្នភាព ឬ​"
+"កម្មវិធី​គ្រប់គ្រង​កម្មវិធី​ផ្សេងៗ​ទៀត ដោយ​ប្រើ​ការរត់របស់ PackageKit ។"
 
 #: src/Zypper.cc:93
 msgid ""
@@ -1287,7 +1281,7 @@ msgstr "PackageKit នៅតែ​កំពុង​រត់ (ប្រហែ�
 msgid "Try again?"
 msgstr "​ព្យាយាម​ម្ដងទៀត ?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "ករណី​លើកលែង​ដែល​មិនបាន​រំពឹង​ទុក ។"
 
@@ -1315,12 +1309,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "ជម្រើស %s មិនមានបែបផែន​នៅ​ទីនេះ​ទេ មិនអើពើ ។"
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "អាគុយម៉ង់​កម្មវិធី​មិនមែន​ជម្រើស ៖ "
 
@@ -1450,8 +1444,7 @@ msgstr "ព្រម​ទទួល​ឯកសារ '%s' ដែល​បាន
 #, c-format, boost-format
 msgid ""
 "Accepting file '%s' from repository '%s' signed with an unknown key '%s'."
-msgstr ""
-"ព្រម​ទទួល​ឯកសារ '%s' ពី​ឃ្លាំង '%s' ដែល​​បាន​ចុះហត្ថលេខា​ជាមួយ​សោ​មិនស្គាល់ '%s' ។"
+msgstr "ព្រម​ទទួល​ឯកសារ '%s' ពី​ឃ្លាំង '%s' ដែល​​បាន​ចុះហត្ថលេខា​ជាមួយ​សោ​មិនស្គាល់ '%s' ។"
 
 #. translator: %1% is a file name, %2% is a gpg key ID
 #: src/callbacks/keyring.h:214
@@ -1539,8 +1532,7 @@ msgstr "មិន​អើពើ​ការ​ផ្ទៀងផ្ទាត់
 
 #: src/callbacks/keyring.h:376
 msgid "Double-check this is not caused by some malicious changes in the file!"
-msgstr ""
-"ពិនិត្យ​ទ្វេដង វា​មិនបណ្ដាល​មក​ពី​ការ​ផ្លាស់ប្ដូរ​ដែល​ព្យាបាទ​មួយ​ចំនួន​នៅ​ក្នុង​ឯកសារ​ទេ !"
+msgstr "ពិនិត្យ​ទ្វេដង វា​មិនបណ្ដាល​មក​ពី​ការ​ផ្លាស់ប្ដូរ​ដែល​ព្យាបាទ​មួយ​ចំនួន​នៅ​ក្នុង​ឯកសារ​ទេ !"
 
 #. translator: %1% is a file name
 #: src/callbacks/keyring.h:386
@@ -1552,8 +1544,7 @@ msgstr "បាន​បរាជ័យ​ក្នុង​ការ​ផ្ទ
 #: src/callbacks/keyring.h:389
 #, boost-format
 msgid "Signature verification failed for file '%1%' from repository '%2%'."
-msgstr ""
-"បាន​បរាជ័យ​ក្នុងកា​រផ្ទៀងផ្ទាត់​ហត្ថលេខា​សម្រាប់​ឯកសារ '%1%' ពី​ឃ្លាំង '%2%' ។"
+msgstr "បាន​បរាជ័យ​ក្នុងកា​រផ្ទៀងផ្ទាត់​ហត្ថលេខា​សម្រាប់​ឯកសារ '%1%' ពី​ឃ្លាំង '%2%' ។"
 
 #: src/callbacks/keyring.h:438
 msgid ""
@@ -1658,8 +1649,7 @@ msgstr ""
 #: src/callbacks/locks.h:27
 msgid ""
 "The following query locks the same objects as the one you want to remove:"
-msgstr ""
-"សំណួរ​ដូច​ខាងក្រោម ចាក់សោ​វត្ថុ​មួយ​ចំនួន ដូច​វត្ថុ​មួយ​ដែល​អ្នក​ចង់​យក​ចេញ​អញ្ចឹង ៖"
+msgstr "សំណួរ​ដូច​ខាងក្រោម ចាក់សោ​វត្ថុ​មួយ​ចំនួន ដូច​វត្ថុ​មួយ​ដែល​អ្នក​ចង់​យក​ចេញ​អញ្ចឹង ៖"
 
 #: src/callbacks/locks.h:30
 msgid "The following query locks some of the objects you want to unlock:"
@@ -1689,8 +1679,7 @@ msgstr "ព្យាយាម​​ប្រមូលយក​ឯកសារ​
 msgid ""
 "Skip retrieval of the file and try to continue with the operation without "
 "the file."
-msgstr ""
-"រំលង​ការ​ទៅ​ប្រមូលយក​​​ឯកសារ និង​ព្យាយាម​បន្ត​ប្រតិបត្តិការ​ដោយ​គ្មាន​ឯកសារ ។"
+msgstr "រំលង​ការ​ទៅ​ប្រមូលយក​​​ឯកសារ និង​ព្យាយាម​បន្ត​ប្រតិបត្តិការ​ដោយ​គ្មាន​ឯកសារ ។"
 
 #. help text for the "Abort, retry, ignore?" prompt for media errors
 #: src/callbacks/media.cc:34
@@ -1780,8 +1769,8 @@ msgid ""
 "Please insert medium [%s] #%d and type 'y' to continue or 'n' to cancel the "
 "operation."
 msgstr ""
-"សូម​បញ្ចូលឧបករណ៍​ផ្ទុក [%s] #%d ហើយ​វាយ​អក្សរ 'y' ដើម្បី​បន្ត ឬ​វាយ​អក្សរ 'n' ដើម្បី​បោះបង់​ប្រតិបត្តិកា"
-"រ ។"
+"សូម​បញ្ចូលឧបករណ៍​ផ្ទុក [%s] #%d ហើយ​វាយ​អក្សរ 'y' ដើម្បី​បន្ត ឬ​វាយ​អក្សរ 'n' ដើម្បី​បោះបង់​"
+"ប្រតិបត្តិការ ។"
 
 #. translators: a/r/i/u are replies to the "Abort, retry, ignore?" prompt
 #. Translate the a/r/i part exactly as you did the a/r/i string.
@@ -1796,8 +1785,8 @@ msgid ""
 "Authentication required to access %s. You need to be root to be able to read "
 "the credentials from %s."
 msgstr ""
-"ទាមទារ​ឲ្យ​ផ្ទៀងផ្ទាត់​ភាព​ត្រឹមត្រូវ​ក្នុង​ការ​ចូល​ប្រើ​ %s ។  ដើម្បី​អាច​អាន​លិខិត​សម្គាល់​ពី​ %s បាន "
-"អ្នក​ចាំបាច់​ត្រូវ​តែ​ជា root ។"
+"ទាមទារ​ឲ្យ​ផ្ទៀងផ្ទាត់​ភាព​ត្រឹមត្រូវ​ក្នុង​ការ​ចូល​ប្រើ​ %s ។  ដើម្បី​អាច​អាន​លិខិត​សម្គាល់​ពី​ %s បាន អ្នក​"
+"ចាំបាច់​ត្រូវ​តែ​ជា root ។"
 
 #: src/callbacks/media.cc:314 src/callbacks/media.cc:321
 msgid "User Name"
@@ -2022,26 +2011,32 @@ msgid "Commands:"
 msgstr "ពាក្យ​បញ្ជា ៖"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "ប្រភេទ​កញ្ចប់ (%1%) ។"
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
-"ធ្វើ​ 'ឲ្យ​អស់​ពី​សមត្ថភាព' ដើម្បី​ឈាន​ដល់​បច្ចុប្បន្នភាព ។ កា​រធ្វើ​​បច្ចុប្បន្នភាព​ "
-"ទៅ​កំណែ​ទាបជាង​កំណែ​ចុងក្រោយ​បំផុត ក៏​ទទួល​យក​ដែរ ​​​។"
+"ធ្វើ​ 'ឲ្យ​អស់​ពី​សមត្ថភាព' ដើម្បី​ឈាន​ដល់​បច្ចុប្បន្នភាព ។ កា​រធ្វើ​​បច្ចុប្បន្នភាព​ ទៅ​កំណែ​ទាបជាង​កំណែ​"
+"ចុងក្រោយ​បំផុត ក៏​ទទួល​យក​ដែរ ​​​។"
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2100,8 +2095,8 @@ msgid ""
 "Make sure these repositories are compatible before you continue. See '%s' "
 "for more information about this command."
 msgstr ""
-"អ្នករៀប​នឹង​ធ្វើ​ឲ្យ​​ការ​ចែកចាយ​ប្រសើរ​ឡើង​ជា​មួយ​នឹង​ឃ្លាំង​ដែលបាន​បើក​ទាំងអស់ ។ សូម​ប្រាកដថា "
-"ឃ្លាំង​ទាំង​នេះ​ឆប​គ្នា មុន​នឹង​អ្នក​បន្ត ។ ចំពោះ​ព័ត៌មាន​បន្ថែម​អំពី​ពាក្យ​បញ្ជា​នេះ​ សូម​មើល '%s' ។"
+"អ្នករៀប​នឹង​ធ្វើ​ឲ្យ​​ការ​ចែកចាយ​ប្រសើរ​ឡើង​ជា​មួយ​នឹង​ឃ្លាំង​ដែលបាន​បើក​ទាំងអស់ ។ សូម​ប្រាកដថា ឃ្លាំង​ទាំង​នេះ​"
+"ឆប​គ្នា មុន​នឹង​អ្នក​បន្ត ។ ចំពោះ​ព័ត៌មាន​បន្ថែម​អំពី​ពាក្យ​បញ្ជា​នេះ​ សូម​មើល '%s' ។"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/help.cc:22
@@ -2113,7 +2108,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "បង្ហាញ​ជំនួយ ។"
 
@@ -2130,8 +2125,7 @@ msgstr ""
 #. translators: command summary: install-new-recommends, inr
 #: src/commands/inrverify.cc:81
 msgid "Install newly added packages recommended by installed packages."
-msgstr ""
-"ដំឡើង​កញ្ចប់​ដែល​បាន​បន្ថែម​ថ្មីៗ​ដែល​បានផ្ដល់​អនុសាសន៍ ដោយ​កញ្ចប់​ដែល​បាន​ដំឡើង ។"
+msgstr "ដំឡើង​កញ្ចប់​ដែល​បាន​បន្ថែម​ថ្មីៗ​ដែល​បានផ្ដល់​អនុសាសន៍ ដោយ​កញ្ចប់​ដែល​បាន​ដំឡើង ។"
 
 #. translators: command summary: verify, ve
 #: src/commands/inrverify.cc:84
@@ -2299,22 +2293,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2338,8 +2332,7 @@ msgstr "រាយបច្ចុប្បន្នភាព​​ដែល​ម
 msgid ""
 "List all packages for which newer versions are available, regardless whether "
 "they are installable or not."
-msgstr ""
-"រាយ​កញ្ចប់​ទាំងអស់​សម្រាប់កំណែ​ថ្មីៗ​គឺ អាច​ប្រើ​ ដោយ​ទាក់ទង​​ថាតើ​ពួកវា អាច​ដំឡើង​បាន ឬ​ក៏​អត់ ។"
+msgstr "រាយ​កញ្ចប់​ទាំងអស់​សម្រាប់កំណែ​ថ្មីៗ​គឺ អាច​ប្រើ​ ដោយ​ទាក់ទង​​ថាតើ​ពួកវា អាច​ដំឡើង​បាន ឬ​ក៏​អត់ ។"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/locale/addlocalecmd.cc:20
@@ -2366,49 +2359,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2508,11 +2505,11 @@ msgstr[0] "សោ %lu ដែលបាន​យកចេញ ។"
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "ឈ្មោះ"
 
@@ -2523,8 +2520,8 @@ msgstr "បំណះ"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "ប្រភេទ"
@@ -2532,7 +2529,7 @@ msgstr "ប្រភេទ"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "ឃ្លាំង"
@@ -2959,7 +2956,7 @@ msgid "Command"
 msgstr "ពាក្យ​បញ្ជា"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "សេវា"
 
@@ -2985,8 +2982,7 @@ msgstr "អ្នក​ចង់​ចាប់ផ្ដើម​ដំណើរ
 #, c-format, boost-format
 msgid ""
 "See '%s' for information about the meaning of values in the above table."
-msgstr ""
-"ចំពោះ​ព័ត៌មាន​អំពី​អត្ថន័យ​របស់​តម្លៃ​នៅ​ក្នុងតារាង​ខាង​លើ​ សូម​មើល '%s' ។"
+msgstr "ចំពោះ​ព័ត៌មាន​អំពី​អត្ថន័យ​របស់​តម្លៃ​នៅ​ក្នុងតារាង​ខាង​លើ​ សូម​មើល '%s' ។"
 
 #: src/commands/ps.cc:208
 msgid ""
@@ -2994,8 +2990,8 @@ msgid ""
 "permission to examine with the system stat(2) function. The result might be "
 "incomplete."
 msgstr ""
-"ចំណាំ ៖ មិន​ដំណើរ​ការ​ជា root អ្នក​ត្រូវ​បាន​កំណត់​ក្នុង​ស្វែងរក​ឯកសារ ដែល​អ្នក​មាន​សិទ្ធិ​ "
-"ដើម្បីពិនិត្យ​មើល​មុខងារ stat(2) របស់​ប្រព័ន្ធ ។ លទ្ធផល​អាច​មិន​ពេញ​លេញ ។"
+"ចំណាំ ៖ មិន​ដំណើរ​ការ​ជា root អ្នក​ត្រូវ​បាន​កំណត់​ក្នុង​ស្វែងរក​ឯកសារ ដែល​អ្នក​មាន​សិទ្ធិ​ ដើម្បីពិនិត្យ​មើល​"
+"មុខងារ stat(2) របស់​ប្រព័ន្ធ ។ លទ្ធផល​អាច​មិន​ពេញ​លេញ ។"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/query/info.cc:19
@@ -3123,120 +3119,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "រាយ​កញ្ចប់​ដែល​អាច​ប្រើ​បានទាំងអស់ ។"
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "រាយ​បំណះ​ដែល​អាច​ប្រើបាន​ទាំងអស់ ។"
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "រាយ​បំណះ​ដែលមាន​ទាំងអស់​នៅ​ក្នុង​ឃ្លាំង​ដែល​បាន​បញ្ជាក់ ។"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "រាយ​លំនាំ​ដែល​អាច​ប្រើ​បានទាំងអស់ ។"
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "រាយ​លំនាំ​ទាំងអស់​ដែល​មាន​នៅ​ក្នុងឃ្លាំង​ដែល​បានបញ្ជាក់ ។"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "រាយ​ផលិតផល​ដែល​អាច​ប្រើបានទាំងអស់ ។"
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "រាយ​ផលិត​ទាំងអស់​ដែល​មាននៅ​ក្នុងឃ្លាំង​ដែល​បានបញ្ជាក់ ។"
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3275,16 +3271,15 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "មិនអាច​ប្រើ %s ជាមួយ​នឹង %s បានទេ ។ ប្រើ​ការ​កំណត់ %s ។"
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
-msgstr ""
-"ប្រសិន​បើ​ប្រើ​តែ​អាគុយម៉ង់​តែ​មួយ គឺ​វា​ត្រូវតែ​ជា URI ដែល​ចង្អុល​ទៅកាន់​ឯកសារ .repo ។"
+msgstr "ប្រសិន​បើ​ប្រើ​តែ​អាគុយម៉ង់​តែ​មួយ គឺ​វា​ត្រូវតែ​ជា URI ដែល​ចង្អុល​ទៅកាន់​ឯកសារ .repo ។"
 
 #: src/commands/repos/add.cc:130
 msgid "Specified type is not a valid repository type:"
@@ -3323,111 +3318,115 @@ msgstr "ជម្រះ​ឃ្លាំង​សម្ងាត់​ទិន
 msgid "Clean both metadata and package caches."
 msgstr "ជម្រះ​ទាំង​ឃ្លាំង​សម្ងាត់​កញ្ចប់ និង​ទិន្នន័យ​មេតា ។"
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "ឈ្មោះ​ក្លែងក្លាយ"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "អនុញ្ញាត"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "ពិនិត្យ​មើល GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "អទិភាព"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "ធ្វើ​ឲ្យ​ស្រស់​ដោយ​ស្វ័យ​ប្រវត្តិ"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "បើក"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "បិទ"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "រក្សា​កញ្ចប់"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "សោ GPG URI"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "បុព្វបទ​​ផ្លូវ"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "សេវា​មេ"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "ផ្លូវ​ឃ្លាំង​សម្ងាត់ MD"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "រាយ​ឃ្លាំង​ដែល​បានកំណត់​ទាំងអស់ ។"
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "កំហុស​ខណៈពេល​អាន​ឃ្លាំង ៖"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "មិនអាច​បើក​សរសេរ %s បានទេ ។"
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "ប្រហែល​ជា​អ្នក​មិនមាន​សិទ្ធិ​សរសេរ ?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "ឃ្លាំង​ត្រូវ​បាន​នាំចេញ​ដោយ​ជោគជ័យទៅ %s ។"
@@ -3435,21 +3434,21 @@ msgstr "ឃ្លាំង​ត្រូវ​បាន​នាំចេញ​
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "ធ្វើ​ឲ្យ​ស្រស់"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "រក​មិន​ឃើញ​ឃ្លាំង ។"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 #, fuzzy
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr "គ្មាន​ឃ្លាំង​បាន​កំណត់ ។ ប្រើ​ពាក្យ​បញ្ជា 'zypper addrepo' ដើម្បី​បន្ថែម​ឃ្លាំង​មួយ ឬ​ច្រើន ។"
@@ -3498,8 +3497,8 @@ msgid ""
 "Refresh repositories specified by their alias, number or URI. If none are "
 "specified, all enabled repositories will be refreshed."
 msgstr ""
-"ធ្វើ​ឲ្យ​ឃ្លាំង​ស្រស់​ដែល​បាន​បញ្ជាក់​ដោយ​ឈ្មោះ​ក្លែងក្លាយ​ លេខ ឬ URI របស់​វា ។ "
-"ប្រសិនបើ​គ្មាន​អ្វី​ត្រូវ​បាន​បញ្ជាក់ ឃ្លាំង​ដែល​បា​ន​បើក​ទាំងអស់​នឹង​ត្រូវបាន​ធ្វើ​ឲ្យ​ស្រស់ ។"
+"ធ្វើ​ឲ្យ​ឃ្លាំង​ស្រស់​ដែល​បាន​បញ្ជាក់​ដោយ​ឈ្មោះ​ក្លែងក្លាយ​ លេខ ឬ URI របស់​វា ។ ប្រសិនបើ​គ្មាន​អ្វី​ត្រូវ​បាន​"
+"បញ្ជាក់ ឃ្លាំង​ដែល​បា​ន​បើក​ទាំងអស់​នឹង​ត្រូវបាន​ធ្វើ​ឲ្យ​ស្រស់ ។"
 
 #. translators: -f, --force
 #: src/commands/repos/refresh.cc:80 src/commands/services/refresh.cc:113
@@ -3553,7 +3552,7 @@ msgstr "ជម្រើស​សកល '%s' មិនមាន​បែបផែ
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "អាគុយម៉ង់​មិន​ត្រូវ​បាន​អនុញ្ញាត​ប្រសិន​បើ '%s' ត្រូវ​បានប្រើ ។"
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "ឃ្លាំង​ដែលបាន​បញ្ជាក់ ៖ "
 
@@ -3562,7 +3561,7 @@ msgstr "ឃ្លាំង​ដែលបាន​បញ្ជាក់ ៖ "
 msgid "Refreshing repository '%s'."
 msgstr "បិទ​ឃ្លាំង '%s' ។"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "មិនអើពើ​ឃ្លាំង​ដែលបាន​បិទ '%s'"
@@ -3572,7 +3571,7 @@ msgstr "មិនអើពើ​ឃ្លាំង​ដែលបាន​បិ
 msgid "Skipping disabled repository '%s'"
 msgstr "កំពុង​រំលង​ឃ្លាំង '%s' ដែល​បាន​បិទ"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "រំលង​ឃ្លាំង '%s' ដោយ​សាង​តែ​កំហុស​ខាង​លើ ។"
@@ -3600,10 +3599,9 @@ msgstr "ប្រើ​ពាក្យ​បញ្ជា '%s' ឬ '%s' ដើម
 msgid "Could not refresh the repositories because of errors."
 msgstr "មិន​អាច​ធ្វើ​ឲ្យ​ឃ្លាំង​ស្រស់​ដោយ​សារ​តែ​មាន​កំហុស ។"
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
-msgstr ""
-"ឃ្លាំង​មួយ​ចំនួន​មិន​ត្រូវ​បាន​​ធ្វើ​ឲ្យ​ស្រស់​ទេ ដោយ​សារ​តែ​មាន​កំហុស ។"
+msgstr "ឃ្លាំង​មួយ​ចំនួន​មិន​ត្រូវ​បាន​​ធ្វើ​ឲ្យ​ស្រស់​ទេ ដោយ​សារ​តែ​មាន​កំហុស ។"
 
 #: src/commands/repos/refresh.cc:346
 msgid "Specified repositories have been refreshed."
@@ -3648,20 +3646,20 @@ msgid ""
 "Cannot change alias of '%s' repository. The repository belongs to service "
 "'%s' which is responsible for setting its alias."
 msgstr ""
-"មិនអាច​ផ្លាស់ប្ដូរ​ឈ្មោះ​ក្លែងក្លាយ​របស់​ឃ្លាំង '%s' បាន​ទេ ។ ឃ្លាំង​ជា​កម្មសិទ្ធិ​របស់​សេវា '%s' "
-"ដែល​ទទួល​ខុសត្រូវ​ចំពោះ​ការ​កំណត់​ឈ្មោះ​ក្លែងក្លាយ​​របស់​វា ។"
+"មិនអាច​ផ្លាស់ប្ដូរ​ឈ្មោះ​ក្លែងក្លាយ​របស់​ឃ្លាំង '%s' បាន​ទេ ។ ឃ្លាំង​ជា​កម្មសិទ្ធិ​របស់​សេវា '%s' ដែល​ទទួល​"
+"ខុសត្រូវ​ចំពោះ​ការ​កំណត់​ឈ្មោះ​ក្លែងក្លាយ​​របស់​វា ។"
 
 #: src/commands/repos/rename.cc:43
 #, c-format, boost-format
 msgid "Repository '%s' renamed to '%s'."
 msgstr "ឃ្លាំង '%s' បាន​ប្ដូរ​ឈ្មោះ​ទៅ '%s' ។"
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "មាន​ឃ្លាំង​ដែល​មាន​ឈ្មោះ '%s' រួចហើយ ។ សូម​ប្រើ​ឈ្មោះ​ផ្សេងទៀត ។"
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "កំហុស​ខណៈពេល​កែប្រែ​ឃ្លាំង ៖"
 
@@ -3682,8 +3680,7 @@ msgstr "ប្ដូរ​ឃ្លាំង​ដែល​បានកំណត
 #. translators: command description
 #: src/commands/repos/rename.cc:67
 msgid "Assign new alias to the repository specified by alias, number or URI."
-msgstr ""
-"ផ្ដល់ឈ្មោះ​ក្លែងក្លាយ​ថ្មី​ទៅ​ឃ្លាំង​ដែល​បានបញ្ជាក់​ដោយ​ឈ្មោះ​ក្លែងក្លាយ លេខ ឬ URI ។"
+msgstr "ផ្ដល់ឈ្មោះ​ក្លែងក្លាយ​ថ្មី​ទៅ​ឃ្លាំង​ដែល​បានបញ្ជាក់​ដោយ​ឈ្មោះ​ក្លែងក្លាយ លេខ ឬ URI ។"
 
 #: src/commands/repos/rename.cc:92
 msgid "Too few arguments. At least URI and alias are required."
@@ -3699,8 +3696,7 @@ msgstr "រក​មិន​ឃើញ​ឃ្លាំង '%s' ទេ ។"
 msgid ""
 "Invalid priority '%s'. Use a positive integer number. The greater the "
 "number, the lower the priority."
-msgstr ""
-"អាទិភាព​មិន​ត្រឹមត្រូវ '%s' ។ ប្រើ​លេខ​វិជ្ជមាន ។ លេខ​កាន់តែ​ធំ​ អាទិភាព​កាន់​តែ​ទាប ។"
+msgstr "អាទិភាព​មិន​ត្រឹមត្រូវ '%s' ។ ប្រើ​លេខ​វិជ្ជមាន ។ លេខ​កាន់តែ​ធំ​ អាទិភាព​កាន់​តែ​ទាប ។"
 
 #: src/commands/reposerviceoptionsets.cc:72
 msgid "Set a descriptive name for the service."
@@ -4092,26 +4088,26 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "ឃ្លាំង​ដែល​បាន​បញ្ជាក់​ '%s' ត្រូវ​បាន​បិទ ។"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "រក​មិនឃើញ​ការ​ចេញផ្សាយ​​ដែល​ផ្គូផ្គង ។​"
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "មាន​បញ្ហា​កើតឡើង​​នៅពេល​ចាប់ផ្ដើម ឬ​ប្រតិបត្តិ​សំណួរ​ស្វែងរក"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "មើល​សារ​ខាងលើ​សម្រាប់​ព័ត៌មាន​ជំនួយ ។"
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "ការ​រត់ 'zypper refresh' ជា root គឺ​អាច​ដោះស្រាយ​បញ្ហា​បាន ។"
 
@@ -4201,7 +4197,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "បញ្ហា​ក្នុងការ​ទៅ​យក​ឯកសារ​លិបិក្រម​ឃ្លាំង​សម្រាប់​សេវា '%s' ៖"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "រំលង​សេវា '%s' ដោយ​សារ​តែ​កំហុស​ខាង​លើ ។"
@@ -4220,23 +4216,26 @@ msgstr "យក​សេវា '%s' ចេញ ៖"
 msgid "Service '%s' has been removed."
 msgstr "សេវា '%s' ត្រូវ​បាន​យក​ចេញ ។"
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "រាយ​សេវា​ដែល​បានកំណត់​ទាំងអស់ ។"
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr "គ្មាន​សេវា​បាន​កំណត់ ។ ប្រើ​ពាក្យ​បញ្ជា '%s' ដើម្បី​បន្ថែម​សេវា​មួយ ឬ​ច្រើន ។"
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
-"គ្មាន​សេវា​បាន​កំណត់ ។ ប្រើ​ពាក្យ​បញ្ជា '%s' ដើម្បី​បន្ថែម​សេវា​មួយ ឬ​ច្រើន ។"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4331,8 +4330,7 @@ msgstr "ឈ្មោះ​សេវា '%s' ត្រូវ​បាន​កំ
 msgid "Repository '%s' has been added to enabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been added to enabled repositories of service '%s'"
-msgstr[0] ""
-"ឃ្លាំង '%s' ត្រូវ​បាន​បន្ថែម​ដើម្បី​​ទៅឃ្លាំង​ដែល​បានបើក​​របស់​សេវា '%s'"
+msgstr[0] "ឃ្លាំង '%s' ត្រូវ​បាន​បន្ថែម​ដើម្បី​​ទៅឃ្លាំង​ដែល​បានបើក​​របស់​សេវា '%s'"
 
 #: src/commands/services/modify.cc:262
 #, c-format, boost-format
@@ -4762,14 +4760,13 @@ msgid ""
 "Zypper does not keep track of installed source packages. To install the "
 "latest source package and its build dependencies, use '%s'."
 msgstr ""
-"Zypper មិន​រក្សាទុក​ដាន​របស់​កញ្ចប់​ប្រភព​ដែល​បាន​ដំឡើង​ទេ ។ ដើម្បី​ដំឡើង​កញ្ចប់​ប្រភព​ចុងក្រោយ "
-"និង​ភាព​អាស្រ័យ​ស្ថាបនា​របស់​វា ប្រើ '%s' ។"
+"Zypper មិន​រក្សាទុក​ដាន​របស់​កញ្ចប់​ប្រភព​ដែល​បាន​ដំឡើង​ទេ ។ ដើម្បី​ដំឡើង​កញ្ចប់​ប្រភព​ចុងក្រោយ និង​ភាព​អាស្រ័យ​"
+"ស្ថាបនា​របស់​វា ប្រើ '%s' ។"
 
 #: src/commands/update.cc:83
 msgid ""
 "Cannot use multiple types when specific packages are given as arguments."
-msgstr ""
-"មិនអាច​ប្រើ​ប្រភេទ​ច្រើន​ នៅពេល​កញ្ចប់​ជាក់លាក់​ត្រូ​វបាន​ផ្ដល់​ជា​អាគុយម៉ង់​នោះ​ទេ ។"
+msgstr "មិនអាច​ប្រើ​ប្រភេទ​ច្រើន​ នៅពេល​កញ្ចប់​ជាក់លាក់​ត្រូ​វបាន​ផ្ដល់​ជា​អាគុយម៉ង់​នោះ​ទេ ។"
 
 #: src/commands/utils/download.cc:129 src/commands/utils/source-download.cc:212
 #, c-format, boost-format
@@ -4856,8 +4853,7 @@ msgstr ""
 #. translators: command description
 #: src/commands/utils/licenses.cc:23
 msgid "Report licenses and EULAs of currently installed software packages."
-msgstr ""
-"រាយការណ៍​អាជ្ញាប័ណ្ណ និង​ EULA របស់​កញ្ចប់​កម្មវិធី​ដែល​បានដំឡើង​ថ្មីៗ ។"
+msgstr "រាយការណ៍​អាជ្ញាប័ណ្ណ និង​ EULA របស់​កញ្ចប់​កម្មវិធី​ដែល​បានដំឡើង​ថ្មីៗ ។"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/utils/purge-kernels.cc:26
@@ -5117,15 +5113,15 @@ msgstr "%s គឺ​ចាស់​ជាង %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "កំណែ"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "ស្ថាបត្យកម្ម"
 
@@ -5259,13 +5255,13 @@ msgstr "(ទទេ)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "ស"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "ភាព​អាស្រ័យ"
 
@@ -5303,7 +5299,7 @@ msgid "Flavor"
 msgstr "លក្ខណៈ"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "ជា​មូលដ្ឋាន"
 
@@ -5428,8 +5424,7 @@ msgstr "យល់​ព្រម​ជា​អាជ្ញាបណ្ណ​ %s
 msgid ""
 "In order to install '%s'%s, you must agree to terms of the following license "
 "agreement:"
-msgstr ""
-"ដើម្បី​ដំឡើង '%s'%s អ្នក​ត្រូវ​តែ​យល់ព្រម​នឹង​លក្ខខណ្ឌ​របស់​កិច្ចព្រមព្រៀង​អាជ្ញាប័ណ្ណ​ដូច​ខាង​ក្រោម ៖"
+msgstr "ដើម្បី​ដំឡើង '%s'%s អ្នក​ត្រូវ​តែ​យល់ព្រម​នឹង​លក្ខខណ្ឌ​របស់​កិច្ចព្រមព្រៀង​អាជ្ញាប័ណ្ណ​ដូច​ខាង​ក្រោម ៖"
 
 #. lincense prompt
 #: src/misc.cc:187
@@ -5447,15 +5442,14 @@ msgid ""
 "Please restart the operation in interactive mode and confirm your agreement "
 "with required licenses, or use the %s option."
 msgstr ""
-"សូម​ចាប់ផ្ដើម​ប្រតិបត្តិការ​ឡើងវិញ​ជា​របៀប​អន្តរកម្ម និង​អះអាង​ការ​យល់ព្រម​របស់​អ្នក​នឹង​អាជ្ញាប័ណ្ណ​ដែល​ត្រូវកា"
-"រ ឬ​ប្រើ​ជម្រើស %s ។"
+"សូម​ចាប់ផ្ដើម​ប្រតិបត្តិការ​ឡើងវិញ​ជា​របៀប​អន្តរកម្ម និង​អះអាង​ការ​យល់ព្រម​របស់​អ្នក​នឹង​អាជ្ញាប័ណ្ណ​ដែល​"
+"ត្រូវការ ឬ​ប្រើ​ជម្រើស %s ។"
 
 #. translators: e.g. "... with flash package license."
 #: src/misc.cc:209
 #, c-format, boost-format
 msgid "Aborting installation due to user disagreement with %s %s license."
-msgstr ""
-"បោះបង់​ការ​ដំឡើង ដោយ​សារ​តែ​ការ​មិន​ព្រមព្រៀង​របស់​អ្នក​ប្រើ​ជា​មួយ​អាជ្ញាបណ្ណ %s %s ។"
+msgstr "បោះបង់​ការ​ដំឡើង ដោយ​សារ​តែ​ការ​មិន​ព្រមព្រៀង​របស់​អ្នក​ប្រើ​ជា​មួយ​អាជ្ញាបណ្ណ %s %s ។"
 
 #: src/misc.cc:248
 msgid "License"
@@ -5568,97 +5562,95 @@ msgstr[0] "ឃ្លាំង"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "ពិនិត្យ​មើល​ថាតើ​ត្រូវ​ធ្វើ​ឲ្យ​ទិន្នន័យ​មេតាស្រស់​សម្រាប់ %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "ឃ្លាំង '%s' ទាន់សម័យ ។"
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "ការ​ពិនិត្យ​ភាព​ហួសសម័យ​របស់ '%s' ត្រូវបាន​ពន្យារពេល ។"
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "បង្ខំ​ធ្វើ​ឲ្យ​ទិន្នន័យ​មេតា​ដើម​ស្រស់"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "ទៅ​យក​ឃ្លាំង​ទិន្នន័យ​មេតា​របស់ '%s'"
 
 # power-off message
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "តើ​អ្នក​ចង់​ទទួល​យក​ហត្ថលេខា​របស់​ឃ្លាំង​នេះ​ឬ ?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "បិទ​ឃ្លាំង '%s' ។"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "បញ្ហា​ក្នុងការ​ទៅ​យក​ឯកសារ​ពី '%s' ។"
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "សូម​មើល​សារ​កំហុស​ខាងលើ សម្រាប់​ព័ត៌មាន​ជំនួយ ។"
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "គ្មាន URI ដែល​បាន​កំណត់​សម្រាប់ '%s' ទេ ។"
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
-msgstr ""
-"សូម​បន្ថែម​ធាតុ URI មូលដ្ឋាន (url មូលដ្ឋាន=URI) ​មួយ ឬ​ច្រើន​ទៅ %s សម្រាប់​ឃ្លាំង '%s' ។"
+msgstr "សូម​បន្ថែម​ធាតុ URI មូលដ្ឋាន (url មូលដ្ឋាន=URI) ​មួយ ឬ​ច្រើន​ទៅ %s សម្រាប់​ឃ្លាំង '%s' ។"
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "គ្មាន​ឈ្មោះ​ក្លែងក្លាយ​ដែល​បាន​កំណត់​សម្រាប់​ឃ្លាំង​នេះ​ទេ ។"
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "ឃ្លាំង '%s' មិន​ត្រឹមត្រូវ ។"
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
-msgstr ""
-"សូម​ពិនិត្យ​មើល ប្រសិន​បើ URI ដែល​បាន​កំណត់​សម្រាប់​ឃ្លាំង​គឺ​ចង្អុល​ទៅ​ឃ្លាំង​ដែល​ត្រឹមត្រូវ ។"
+msgstr "សូម​ពិនិត្យ​មើល ប្រសិន​បើ URI ដែល​បាន​កំណត់​សម្រាប់​ឃ្លាំង​គឺ​ចង្អុល​ទៅ​ឃ្លាំង​ដែល​ត្រឹមត្រូវ ។"
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "កំហុស​ក្នុង​ការ​ទៅ​យក​ទិន្នន័យ​មេតា​សម្រាប់ '%s' ៖"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "បង្ខំ​ស្ថាបនា​ឃ្លាំង​សម្ងាត់​ឃ្លាំង"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "កំហុស​ក្នុង​ការ​ញែក​ទិន្នន័យ​មេតា​សម្រាប់ '%s' ៖"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5669,42 +5661,41 @@ msgstr ""
 "ពេលក្រោយ បើ​មាន​ចម្ងល់ សូម​ផ្ញើ​របាយការណ៍​កំហុស​តាម​សេចក្ដី​ណែនាំ​ដូច​ខាង​ក្រោម​នៅ http://"
 "en.opensuse.org/Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
-msgstr ""
-"រក​មិន​ឃើញ​ទិន្នន័យ​មេតា​ឃ្លាំង​សម្រាប់ '%s' នៅ​ក្នុង​ឃ្លាំង​សម្ងាត់​មូលដ្ឋាន ។"
+msgstr "រក​មិន​ឃើញ​ទិន្នន័យ​មេតា​ឃ្លាំង​សម្រាប់ '%s' នៅ​ក្នុង​ឃ្លាំង​សម្ងាត់​មូលដ្ឋាន ។"
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "កំហុស​ក្នុងការ​ស្ថាបនា​ឃ្លាំង​សម្ងាត់ ៖"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "រក​មិនឃើញ​ឃ្លាំង '%s' តាម​ឈ្មោះ​ក្លែងក្លាយ លេខ ឬ URI របស់​វា​ទេ ។"
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "ប្រើ '%s' ដើម្បី​ទទួល​បញ្ជី​របស់​ឃ្លាំង​ដែល​បានកំណត់ ។"
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "មិនអើពើ​ឃ្លាំង​ដែលបាន​បិទ '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, fuzzy, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr "ប្រើ​ពាក្យ​បញ្ជា '%s' ឬ '%s' ដើម្បី​បន្ថែម ឬ​បើក​ឃ្លាំង ។"
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "មិនអើពើ​នឹង​ឃ្លាំង '%s' ដោយសារ​ជម្រើស '%s' ។"
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "បិទ​ឃ្លាំង '%s' ។"
@@ -5712,7 +5703,7 @@ msgstr "បិទ​ឃ្លាំង '%s' ។"
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -5720,7 +5711,7 @@ msgid ""
 msgstr ""
 "ឃ្លាំង '%s' ផុត​កំណត់ ។ អ្នក​អាច​រត់ 'zypper refresh' ជា​ root ដើម្បី​ធ្វើបច្ចុប្បន្នភាព ។"
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -5729,244 +5720,240 @@ msgstr ""
 "ឃ្លាំង​សម្ងាត់​ទិន្នន័យ​មេតា តម្រូវ​ឲ្យ​ស្ថាបនា​សម្រាប់​ឃ្លាំង '%s' ។ អ្នក​អាច​រត់ 'zypper refresh' ជា "
 "root ដើម្បី​ធ្វើវា ។"
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "ឃ្លាំង '%s' មិន​ត្រឹមត្រូវ ។"
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "ចាប់ផ្ដើម​គោលដៅ"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "ការ​ចាប់ផ្ដើម​គោលដៅ​បាន​បរាជ័យ ៖"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "ជម្រះ​ឃ្លាំង​សម្ងាត់​ទិន្នន័យ​មេតា​សម្រាប់ '%s' ។"
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "ជម្រះ​ឃ្លាំង​សម្ងាត់​ទិន្នន័យ​មេតា​ដើម​សម្រាប់ '%s' ។"
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "រក្សា​ឃ្លាំង​ទិន្នន័យ​មេតា​ដើម​សម្រាប់ %s '%s' ។"
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "ជម្រះ​កញ្ចប់​សម្រាប់ '%s' ។"
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "មិនអាច​ជម្រះ​ឃ្លាំង '%s' បានទេ ព្រោះ​មាន​កំហុស ។"
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "ជម្រះ​ឃ្លាំង​សម្ងាត់​របស់​កញ្ចប់​ដែល​បាន​ដំឡើង ។"
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
-msgstr ""
-"មិនអាច​ជម្រះ​ឃ្លាំង​សម្ងាត់​របស់​កញ្ចប់​ដែល​បាន​ដំឡើង​បាន​ទេ ព្រោះ​មាន​កំហុស ។"
+msgstr "មិនអាច​ជម្រះ​ឃ្លាំង​សម្ងាត់​របស់​កញ្ចប់​ដែល​បាន​ដំឡើង​បាន​ទេ ព្រោះ​មាន​កំហុស ។"
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "មិនអាច​ជម្រះ​ឃ្លាំង​បានទេ ព្រោះ​មាន​កំហុស ។"
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "ឃ្លាំង​មួយ​ចំនួន​មិនត្រូវបាន​ជម្រះ​ទេ ព្រោះ​មាន​កំហុស ។"
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "ឃ្លាំង​ដែល​បាន​បញ្ជាក់​ត្រូវបាន​ជម្រះ ។"
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "ឃ្លាំង​ទាំងអស់​ត្រូវបាន​ជម្រះ ។"
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
-msgstr ""
-"នេះ​ជា​មេឌៀ​ដែល​បានតែ​អាន​ដែល​អាច​ផ្លាស់ប្ដូរ​បាន (ស៊ីឌី/ឌីវីឌី) កា​របិទ​ធ្វើ​ឲ្យ​ស្រស់​ស្វ័យ​ប្រវត្តិ ។"
+msgstr "នេះ​ជា​មេឌៀ​ដែល​បានតែ​អាន​ដែល​អាច​ផ្លាស់ប្ដូរ​បាន (ស៊ីឌី/ឌីវីឌី) កា​របិទ​ធ្វើ​ឲ្យ​ស្រស់​ស្វ័យ​ប្រវត្តិ ។"
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "ឈ្មោះក្លែងក្លាយ​ឃ្លាំង​មិន​ត្រឹមត្រូវ ៖ '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
-"មិនអាច​កំណត់​ប្រភេទ​ឃ្លាំង​បានទេ ។ សូម​ពិនិត្យ​មើល ប្រសិន​បើ​បាន​កំណត់ URI (សូម​មើល​ខាងក្រោម) "
-"ដែល​ចង្អុល​ទៅ​ឃ្លាំង​ត្រឹមត្រូវ ៖"
+"មិនអាច​កំណត់​ប្រភេទ​ឃ្លាំង​បានទេ ។ សូម​ពិនិត្យ​មើល ប្រសិន​បើ​បាន​កំណត់ URI (សូម​មើល​ខាងក្រោម) ដែល​ចង្អុល​ទៅ​"
+"ឃ្លាំង​ត្រឹមត្រូវ ៖"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "មិន​អាច​រក​ឃ្លាំង​ដែល​ត្រឹមត្រូវ​នៅ​ទីតាំង​ដែល​បានផ្ដល់ ៖"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "មាន​បញ្ហា​ក្នុងការ​ផ្ទេរ​ទិន្នន័យ​ឃ្លាំង​ពី URI ដែល​បាន​បញ្ជាក់ ៖"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "សូម​ពិនិត្យ​មើល ថាតើ URI ដែលបាន​បញ្ជាក់​គឺ​អាច​ចូលដំណើរការ​បាន ។"
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "មាន​បញ្ហា​ដែល​មិន​ស្គាល់ នៅ​ពេល​បន្ថែម​ឃ្លាំង ៖"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "បាន​បន្ថែម​ឃ្លាំង '%s' ដោយ​ជោគជ័យ"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "អាន​ទិន្នន័យ​ពី​មេឌៀ '%s'"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "បញ្ហា​ក្នុង​ការ​អាន​ទិន្នន័យ​ពី​មេឌៀ '%s'"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-"សូម​ពិនិត្យ​មើល ថាតើ​ឧបករណ៍​ផ្ទុក​ការ​ដំឡើង​របស់​អ្នក​គឺ​ត្រឹមត្រូវ ហើយ​អាច​អានបាន ។"
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, fuzzy, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "អាន​ទិន្នន័យ​ពី​មេឌៀ '%s'"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "អាន​ទិន្នន័យ​ពី​មេឌៀ '%s'"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "បញ្ហា​ក្នុង​ការ​អាន​ទិន្នន័យ​ពី​មេឌៀ '%s'"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "សូម​ពិនិត្យ​មើល ថាតើ​ឧបករណ៍​ផ្ទុក​ការ​ដំឡើង​របស់​អ្នក​គឺ​ត្រឹមត្រូវ ហើយ​អាច​អានបាន ។"
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "មាន​បញ្ហា​ក្នុងការ​ចូលដំណើរការ​ឯកសារ​នៅ URI ដែល​បាន​បញ្ជាក់"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "សូម​ពិនិត្យ​មើល ថាតើ URI ត្រឹមត្រូវ ហើយ​អាច​ចូលដំណើរការ​បាន ។"
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "មាន​បញ្ហា​ក្នុងការ​ញែក​​ឯកសារ​នៅ URI ដែលបាន​បញ្ជាក់"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "តើ​វា​ជា​ឯកសារ .repo ? ចំពោះ?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "ជួប​បញ្ហា​នៅពេល​អាន​ឯកសារ​នៅ URI ដែល​បាន​បញ្ជាក់"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
-msgstr ""
-"បាន​រកឃើញ​ឃ្លាំង​ដែល​មិន​មាន​ឈ្មោះ​ក្លែងក្លាយ​ត្រូវបាន​កំណត់​នៅ​ក្នុង​ឯកសារ ដូច្នេះ​រំលង ។"
+msgstr "បាន​រកឃើញ​ឃ្លាំង​ដែល​មិន​មាន​ឈ្មោះ​ក្លែងក្លាយ​ត្រូវបាន​កំណត់​នៅ​ក្នុង​ឯកសារ ដូច្នេះ​រំលង ។"
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "ឃ្លាំង '%s' មិនមាន URI ដែល​បាន​កំណត់​ទេ ដូច្នេះ​រំលង​។"
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "ឃ្លាំង '%s' ត្រូវបាន​យកចេញ ។"
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "អាទិភាព​ឃ្លាំង '%s' ត្រូវ​បាន​ទុក​ឲ្យ​នៅ​ដដែល (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "បាន​បើក​ឃ្លាំង '%s' ដោយ​ជោគជ័យ ។"
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "បាន​បិទ​ឃ្លាំង '%s' ដោយ​ជោគជ័យ ។"
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "បាន​បើក​ការ​ធ្វើ​ឲ្យ​ស្រស់​ដោយ​ស្វ័យប្រវត្តិ សម្រាប់​ឃ្លាំង '%s' ។"
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "បាន​បិទ​ការ​ធ្វើ​ឲ្យ​ស្រស់​ដោយ​ស្វ័យប្រវត្តិ​សម្រាប់​ឃ្លាំង '%s' ។"
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "ឃ្លាំង​សម្ងាត់​ឯកសារ RPM ត្រូវ​បាន​បើក​សម្រាប់​ឃ្លាំង '%s' ។"
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "ឃ្លាំង​ឯកសារ RPM ត្រូវ​បានបិទ​សម្រាប់​ឃ្លាំង '%s' ។"
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "ការ​ពិនិត្យ​មើល GPG ត្រូវ​បាន​បើក​សម្រាប់​ឃ្លាំង '%s' ។"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "ការ​ពិនិត្យ​មើល GPG ត្រូវ​បាន​បិទ​សម្រាប់​ឃ្លាំង '%s' ។"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "អាទិភាព​ឃ្លាំង '%s' ត្រូវបាន​កំណត់​ទៅ %d ។"
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "ឈ្មោះ​របស់​ឃ្លាំង '%s' ត្រូវ​បានកំណត់​ទៅ '%s' ។"
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "គ្មាន​អ្វី​ត្រូវប្ដូរ​សម្រាប់​ឃ្លាំង '%s' ទេ ។"
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "មិន​ប៉ះពាល់​ឃ្លាំង %s ។"
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "កំពុង​ទុក​ទិន្នន័យ​ឃ្លាំង..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 #, fuzzy
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
@@ -5975,45 +5962,43 @@ msgstr ""
 "ការ​ព្រមាន ៖ មិន​បាន​កំណត់​ឃ្លាំង ។ ប្រតិបត្តិការ​តែ​ជា​មួយ​អ្វី​ដែល​អាច​ដោះស្រាយ​បាន​ដែល​បាន​ដំឡើង​ប៉ុណ្ណោះ ។ "
 "គ្មាន​អ្វី​ត្រូវ​បាន​ដំឡើង​ទេ ។"
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "កំពុង​ទៅ​យក​ទិន្នន័យ​ឃ្លាំង '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
-msgstr ""
-"ឃ្លាំង '%s' មិនបាន​ដាក់​ជា​ឃ្លាំង​សម្ងាត់ ។ កំពុង​ដាក់​ជា​ឃ្លាំង​សម្ងាត់..."
+msgstr "ឃ្លាំង '%s' មិនបាន​ដាក់​ជា​ឃ្លាំង​សម្ងាត់ ។ កំពុង​ដាក់​ជា​ឃ្លាំង​សម្ងាត់..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "បញ្ហា​ក្នុង​កា​រផ្ទុក​ទិន្នន័យ​ពី '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
-msgstr ""
-"ឃ្លាំង​ '%s' មិន​អាច​ត្រូវ​ធ្វើ​ឲ្យ​ស្រស់​បានទេ ។ ប្រើ​ឃ្លាំង​សម្ងាត់​ចាស់ៗ ។"
+msgstr "ឃ្លាំង​ '%s' មិន​អាច​ត្រូវ​ធ្វើ​ឲ្យ​ស្រស់​បានទេ ។ ប្រើ​ឃ្លាំង​សម្ងាត់​ចាស់ៗ ។"
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "អ្វី​ដែលអាច​ដោះស្រាយ​ពី '%s' មិន​ត្រូវ​បាន​ផ្ទុក​ ដោយ​សារ​តែ​កំហុស ។"
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "សាកល្បង '%s' ឬ '%s' មុនពេល​ធ្វើ​ដូច្នេះ ។"
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6021,31 +6006,31 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "កំពុង​អាច​កញ្ចប់​ដែល​បាន​ដំឡើង..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "មាន​បញ្ហា​នៅពេល​អាន​កញ្ចប់​ដែល​បាន​ដំឡើង ៖"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' ដូចជា​ឯកសារ RPM ។ ព្យាយាម​ទាញយក​វា ។"
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "មាន​បញ្ហា​ជាមួយ​ឯកសារ RPM ដែល​បាន​បញ្ជាក់​ជា '%s' ដូច្នេះ​រំលង ។"
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "មាន​បញ្ហា​ក្នុងការ​អាន​បឋមកថា RPM របស់ %s ។ តើ​វា​ជា​ឯកសារ RPM ឬ ?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "ឃ្លាំង​សម្ងាត់​ឯកសារ RPM ធម្មតា"
 
@@ -6053,25 +6038,25 @@ msgstr "ឃ្លាំង​សម្ងាត់​ឯកសារ RPM ធម�
 msgid "System Packages"
 msgstr "កញ្ចប់​ប្រព័ន្ធ"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "រក​មិន​ឃើញ​បំណះ​ដែល​ត្រូវការ ។"
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "រក​មិនឃើញ​លំនាំ​ទេ ។"
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "រកមិនឃើញ​កញ្ចប់​ទេ ។"
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "ឈ្មោះ​ខាង​ក្នុង"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "រកមិនឃើញ​ផលិតផល​ទេ ។"
 
@@ -6230,8 +6215,7 @@ msgstr ""
 
 #: src/solve-commit.cc:657
 msgid "Update notifications were received from the following packages:"
-msgstr ""
-"ធ្វើ​បច្ចុប្បន្នភាព​​​ការ​ជូនដំណឹង​ដែល​ត្រូវបានទទួល​ពី​កញ្ចប់​ដូច​ខាងក្រោម ៖"
+msgstr "ធ្វើ​បច្ចុប្បន្នភាព​​​ការ​ជូនដំណឹង​ដែល​ត្រូវបានទទួល​ពី​កញ្ចប់​ដូច​ខាងក្រោម ៖"
 
 #: src/solve-commit.cc:666
 #, c-format, boost-format
@@ -6259,8 +6243,8 @@ msgid ""
 "Some of the dependencies of installed packages are broken. In order to fix "
 "these dependencies, the following actions need to be taken:"
 msgstr ""
-"ភាព​អាស្រ័យ​មួយ​ចំនួន​នៃ​កញ្ចប់​ដែលបាន​ដំឡើង គឺ​ខូច ។ ដើម្បី​ជួសជុល​ភាព​អាស្រ័យ​ទាំងនេះ "
-"ដែល​អំពើ​ខាងក្រោម​ត្រូវ​ជ្រើស ៖"
+"ភាព​អាស្រ័យ​មួយ​ចំនួន​នៃ​កញ្ចប់​ដែលបាន​ដំឡើង គឺ​ខូច ។ ដើម្បី​ជួសជុល​ភាព​អាស្រ័យ​ទាំងនេះ ដែល​អំពើ​ខាងក្រោម​ត្រូវ​"
+"ជ្រើស ៖"
 
 #: src/solve-commit.cc:795
 msgid "Root privileges are required to fix broken package dependencies."
@@ -6296,8 +6280,7 @@ msgstr "ទេ បោះបង់​ប្រតិបត្តិការ ។
 msgid ""
 "Restart solver in no-force-resolution mode in order to show dependency "
 "problems."
-msgstr ""
-"ចាប់ផ្ដើម​កម្មវិធី​ដោះស្រាយ​នៅ​ក្នុង​របៀប​គ្មាន​កា​របង្ខំ ដើម្បី​បង្ហាញ​បញ្ហា​ភាព​អាស្រ័យ ។"
+msgstr "ចាប់ផ្ដើម​កម្មវិធី​ដោះស្រាយ​នៅ​ក្នុង​របៀប​គ្មាន​កា​របង្ខំ ដើម្បី​បង្ហាញ​បញ្ហា​ភាព​អាស្រ័យ ។"
 
 #. translators: help text for 'v' option in the 'Continue?' prompt
 #: src/solve-commit.cc:828
@@ -6323,8 +6306,7 @@ msgstr "បិទ​បើក​ការ​បង្ហាញ​ឈ្មោះ
 #. translators: help text for 'd' option in the 'Continue?' prompt
 #: src/solve-commit.cc:836
 msgid "Toggle between showing all details and as few details as possible."
-msgstr ""
-"បិទបើក​ការ​បង្ហាញ​សេចក្ដី​លម្អិតទាំង​អស់ និង​សេចក្ដី​លម្អិត​មួយ​ចំនួន​ដែល​អាច​បង្ហាញ​បាន ។"
+msgstr "បិទបើក​ការ​បង្ហាញ​សេចក្ដី​លម្អិតទាំង​អស់ និង​សេចក្ដី​លម្អិត​មួយ​ចំនួន​ដែល​អាច​បង្ហាញ​បាន ។"
 
 #. translators: help text for 'g' option in the 'Continue?' prompt
 #: src/solve-commit.cc:838
@@ -6363,8 +6345,8 @@ msgid ""
 "- use another installation medium (if e.g. damaged)\n"
 "- use another repository"
 msgstr ""
-"ការ​ពិនិត្យ​ភាព​ត្រឹមត្រូវ​របស់​កញ្ចប់​បាន​បរាជ័យ ។ វា​អាច​ជា​បញ្ហា​ជា​មួយ​ឃ្លាំង​ ឬ​មេឌៀ ។ "
-"ព្យាយាម​ធ្វើ​វា​មួយ​ដូច​ខាង​ក្រោម ៖\n"
+"ការ​ពិនិត្យ​ភាព​ត្រឹមត្រូវ​របស់​កញ្ចប់​បាន​បរាជ័យ ។ វា​អាច​ជា​បញ្ហា​ជា​មួយ​ឃ្លាំង​ ឬ​មេឌៀ ។ ព្យាយាម​ធ្វើ​វា​មួយ​ដូច​"
+"ខាង​ក្រោម ៖\n"
 "\n"
 "- ព្យាយាម​ពាក្យ​បញ្ជា​ពីមុន\n"
 "- ធ្វើ​ឲ្យ​ឃ្លាំង​ស្រស់​ដោយ​ប្រើ 'zypper refresh'\n"
@@ -6380,16 +6362,16 @@ msgid ""
 "One of the installed patches requires a reboot of your machine. Reboot as "
 "soon as possible."
 msgstr ""
-"បំណះ​ដែល​បាន​ដំឡើង​មួយ តម្រូវ​ឲ្យ​ចាប់ផ្ដើម​ម៉ាស៊ីន​របស់​អ្នក​ឡើងវិញ ។ "
-"ចាប់ផ្ដើម​ឡើងវិញ​ឲ្យ​លឿន​តាម​ដែល​អាច​ធ្វើ​ទៅបាន ។"
+"បំណះ​ដែល​បាន​ដំឡើង​មួយ តម្រូវ​ឲ្យ​ចាប់ផ្ដើម​ម៉ាស៊ីន​របស់​អ្នក​ឡើងវិញ ។ ចាប់ផ្ដើម​ឡើងវិញ​ឲ្យ​លឿន​តាម​ដែល​អាច​ធ្វើ​"
+"ទៅបាន ។"
 
 #: src/solve-commit.cc:1097
 msgid ""
 "One of the installed patches affects the package manager itself. Run this "
 "command once more to install any other needed patches."
 msgstr ""
-"បំណះ​មួយ​ក្នុង​ចំណោម​បំណះ​ដូច​ខាងក្រោម​ប៉ះពាល់​ដល់​កម្មវិធី​គ្រប់គ្រង​​កញ្ចប់​ខ្លួន​ឯង ។ "
-"រត់​ពាក្យ​បញ្ជា​ម្ដង​ទៀត​ដើម្បី​ដំឡើង​បំណះ​ដែល​ត្រូវការ​ផ្សេងៗ​ទៀត ។"
+"បំណះ​មួយ​ក្នុង​ចំណោម​បំណះ​ដូច​ខាងក្រោម​ប៉ះពាល់​ដល់​កម្មវិធី​គ្រប់គ្រង​​កញ្ចប់​ខ្លួន​ឯង ។ រត់​ពាក្យ​បញ្ជា​ម្ដង​ទៀត​ដើម្បី​"
+"ដំឡើង​បំណះ​ដែល​ត្រូវការ​ផ្សេងៗ​ទៀត ។"
 
 #: src/solve-commit.cc:1119
 msgid "Dependencies of all installed packages are satisfied."
@@ -6450,7 +6432,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "បំណះ"
 
@@ -6474,7 +6456,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "ត្រូវ​ដំឡើងបច្ចុប្បន្នភាព​​នៃ​ការ​គ្រប់គ្រង​កម្មវិធីដូច​ខាងក្រោម​សិន ។"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "រក​មិន​ឃើញ​បច្ចុប្បន្នភាព ។"
 
@@ -6483,51 +6465,50 @@ msgstr "រក​មិន​ឃើញ​បច្ចុប្បន្នភា
 msgid "The following updates are also available:"
 msgstr "បច្ចុប្បន្នភាព​​ដូច​ខាងក្រោម​អាច​ប្រើ​បាន​ដែរ ៖"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "បច្ចុប្បន្នភាព​​របស់​កញ្ចប់​"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "បច្ចុប្បន្នភាព​​របស់​លំនាំ"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "បច្ចុប្បន្នភាព​​របស់​ផលិតផល"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "កំណែ​បច្ចុប្បន្ន"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "កំណែ​ដែល​មាន"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "រក​មិនឃើញ​ការ​ចេញផ្សាយ​​ដែល​ផ្គូផ្គង ។​"
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "រក​ឃើញ​កា​រផ្គូផ្គង​ដូច​ខាងក្រោម​នៅ​ក្នុង​លេខ​ចេញ​ផ្សាយ ៖"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
-msgstr ""
-"ផ្គូផ្គង​នៅ​ក្នុង​សេចក្ដី​ពិពណ៌នា​បំណះ​នៃ​បំណះ​ដូច​ខាងក្រោម​ដែល​បានរកឃើញ ៖"
+msgstr "ផ្គូផ្គង​នៅ​ក្នុង​សេចក្ដី​ពិពណ៌នា​បំណះ​នៃ​បំណះ​ដូច​ខាងក្រោម​ដែល​បានរកឃើញ ៖"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr "ជួសជុល​លេខ​ចេញផ្សាយ bugzilla %s ដែល​រក​មិនឃើញ​ ឬ​មិន​ត្រូវ​ការ ។"
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "ជួសជុល​លេខ​ចេញ​ផ្សាយ​របស់ CVE  %s ដែល​រក​មិនឃើញ​ ឬ​មិន​ត្រូវការ ។"
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, fuzzy, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "ជួសជុល​លេខ​ចេញ​ផ្សាយ​របស់ CVE  %s ដែល​រក​មិនឃើញ​ ឬ​មិន​ត្រូវការ ។"
@@ -6608,8 +6589,7 @@ msgstr ""
 msgid ""
 "Ignoring %s without argument because similar option with an argument has "
 "been specified."
-msgstr ""
-"មិនអើពើ %s ដោយ​មិនមានអាគុយម៉ង់ទេ ពីព្រោះ​ជម្រើស​ដូច​គ្នា​នឹង​អាគុយម៉ង់​ត្រូវ​បាន​បញ្ជាក់ ។"
+msgstr "មិនអើពើ %s ដោយ​មិនមានអាគុយម៉ង់ទេ ពីព្រោះ​ជម្រើស​ដូច​គ្នា​នឹង​អាគុយម៉ង់​ត្រូវ​បាន​បញ្ជាក់ ។"
 
 #: src/utils/flags/flagtypes.cc:235
 msgid "Out of range"
@@ -6723,8 +6703,7 @@ msgstr "សូម​រៀបចំ​របាយការណ៍​កំហុ
 #. unless you translate the actual page :)
 #: src/utils/messages.cc:22
 msgid "See http://en.opensuse.org/Zypper/Troubleshooting for instructions."
-msgstr ""
-"ចំពោះ​សេចក្ដី​ណែនាំ សូម​មើល http://en.opensuse.org/Zypper/Troubleshooting ។"
+msgstr "ចំពោះ​សេចក្ដី​ណែនាំ សូម​មើល http://en.opensuse.org/Zypper/Troubleshooting ។"
 
 #: src/utils/messages.cc:38
 msgid "Too many arguments."
@@ -6742,9 +6721,8 @@ msgid ""
 "package which might lead to broken dependencies of other packages. It is "
 "recommended to run '%s' after the operation has finished."
 msgstr ""
-"អ្នក​បាន​​មិន​អើពើ​នឹង​បញ្ហា​ដែល​ទាក់ទង​នឹង​ការ​ទាញយក ឬ​ការ​ដំឡើង​កញ្ចប់ "
-"ដែល​អាច​បង្ក​ឲ្យ​ខូចខាត​ដល់​ភាព​អាស្រ័យ​របស់​កញ្ចប់​ផ្សេង ។ វា​ត្រូវ​បាន​ផ្ដល់​អានុសាសន៍​ឲ្យ​ដំណើរការ '%s' "
-"បន្ទាប់​ពី​បាន​បញ្ចប់​ប្រតិបត្តិការ ។"
+"អ្នក​បាន​​មិន​អើពើ​នឹង​បញ្ហា​ដែល​ទាក់ទង​នឹង​ការ​ទាញយក ឬ​ការ​ដំឡើង​កញ្ចប់ ដែល​អាច​បង្ក​ឲ្យ​ខូចខាត​ដល់​ភាព​អាស្រ័យ​"
+"របស់​កញ្ចប់​ផ្សេង ។ វា​ត្រូវ​បាន​ផ្ដល់​អានុសាសន៍​ឲ្យ​ដំណើរការ '%s' បន្ទាប់​ពី​បាន​បញ្ចប់​ប្រតិបត្តិការ ។"
 
 #: src/utils/messages.cc:111
 #, boost-format
@@ -6919,8 +6897,7 @@ msgstr "ទម្រង់​ត្រឹមត្រូវ​គឺ obs://<proj
 
 #: src/utils/misc.cc:647
 msgid "Problem copying the specified RPM file to the cache directory."
-msgstr ""
-"មាន​បញ្ហា​ក្នុង​ការ​ចម្លង​ឯកសារ RPM ដែល​បាន​បញ្ជាក់​ទៅ​ថត​ឃ្លាំង​សម្ងាត់ ។"
+msgstr "មាន​បញ្ហា​ក្នុង​ការ​ចម្លង​ឯកសារ RPM ដែល​បាន​បញ្ជាក់​ទៅ​ថត​ឃ្លាំង​សម្ងាត់ ។"
 
 #: src/utils/misc.cc:648
 msgid "Perhaps you are running out of disk space."
@@ -6941,13 +6918,11 @@ msgstr "ចុច '%c' ដើម្បី​ចេញ​ពី​ភេយ័រ
 
 #: src/utils/pager.cc:42
 msgid "Use arrows or pgUp/pgDown keys to scroll the text by lines or pages."
-msgstr ""
-"ប្រើ​គ្រាប់ចុច​ព្រួញ ឬ​ទំព័រលើ/ទំព័រ​ក្រោម​ដើម្បី​រមូរ​អត្ថបទ​តាម​បន្ទាត់ ឬ​ទំព័រ ។"
+msgstr "ប្រើ​គ្រាប់ចុច​ព្រួញ ឬ​ទំព័រលើ/ទំព័រ​ក្រោម​ដើម្បី​រមូរ​អត្ថបទ​តាម​បន្ទាត់ ឬ​ទំព័រ ។"
 
 #: src/utils/pager.cc:44
 msgid "Use the Enter or Space key to scroll the text by lines or pages."
-msgstr ""
-"ប្រើ​​គ្រាប់ចុច​បញ្ចូល ឬ​ចន្លោះ​មិនឃើញ​ដើម្បី​រមូរ​អត្ថបទ​ដោយ​បន្ទាត់ ឬ​ទំព័រ ។"
+msgstr "ប្រើ​​គ្រាប់ចុច​បញ្ចូល ឬ​ចន្លោះ​មិនឃើញ​ដើម្បី​រមូរ​អត្ថបទ​ដោយ​បន្ទាត់ ឬ​ទំព័រ ។"
 
 #: src/utils/prompt.cc:43 src/utils/prompt.cc:94
 #, c-format, boost-format

--- a/po/ko.po
+++ b/po/ko.po
@@ -5,11 +5,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper.ko\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Korean <https://l10n.opensuse.org/projects/zypper/master/ko/>"
-"\n"
+"Language-Team: Korean <https://l10n.opensuse.org/projects/zypper/master/ko/"
+">\n"
 "Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -141,8 +141,9 @@ msgstr "기본 파일 대신 지정된 구성 파일을 사용합니다."
 
 #: src/Config.cc:277
 msgid "User data string must not contain nonprintable or newline characters!"
-msgstr "사용자 데이터 스트링에 인쇄할 수 없는 문자나 줄바꿈 문자를 포함하면 안 "
-"됩니다!"
+msgstr ""
+"사용자 데이터 스트링에 인쇄할 수 없는 문자나 줄바꿈 문자를 포함하면 안 됩니"
+"다!"
 
 #. translators: --userdata <STRING>
 #: src/Config.cc:283
@@ -210,7 +211,8 @@ msgstr "알 수 없는 패키지를 무시합니다."
 #: src/Config.cc:373
 msgid ""
 "Terse output for machine consumption. Implies --no-abbrev and --no-color."
-msgstr "시스템 사용에 대한 간단한 출력입니다. --no-abbrev 및 --no-color를 의미합니다."
+msgstr ""
+"시스템 사용에 대한 간단한 출력입니다. --no-abbrev 및 --no-color를 의미합니다."
 
 #. translators: --reposd-dir, -D <DIR>
 #: src/Config.cc:397
@@ -254,7 +256,8 @@ msgstr "GPG 확인 오류를 무시하고 계속합니다."
 #, c-format, boost-format
 msgid ""
 "Turning on '%s'. New repository signing keys will be automatically imported!"
-msgstr "'%s'을(를) 설정 중입니다. 새 리포지토리 서명 키가 자동으로 임포트됩니다."
+msgstr ""
+"'%s'을(를) 설정 중입니다. 새 리포지토리 서명 키가 자동으로 임포트됩니다."
 
 #. translators: --gpg-auto-import-keys
 #: src/Config.cc:477
@@ -272,13 +275,14 @@ msgid ""
 "Additionally use disabled repositories providing a specific keyword. Try '--"
 "plus-content debug' to enable repos indicating to provide debug packages."
 msgstr ""
-"비활성화된 리포지토리를 추가로 사용하고 구체적인 키워드를 제공합니다. "
-"'--plus-content debug'를 사용하여 디버그 패키지 제공을 나타내는 리포지토리를 "
-"활성화합니다."
+"비활성화된 리포지토리를 추가로 사용하고 구체적인 키워드를 제공합니다. '--"
+"plus-content debug'를 사용하여 디버그 패키지 제공을 나타내는 리포지토리를 활"
+"성화합니다."
 
 #: src/Config.cc:491
 msgid "Repositories disabled, using the database of installed packages only."
-msgstr "리포지토리가 비활성화되었습니다. 설치된 패키지의 데이터베이스만 사용합니다."
+msgstr ""
+"리포지토리가 비활성화되었습니다. 설치된 패키지의 데이터베이스만 사용합니다."
 
 #. translators: --disable-repositories
 #: src/Config.cc:495
@@ -360,18 +364,21 @@ msgstr "옵션을 저장하지 못했습니다."
 #, c-format, boost-format
 msgid ""
 "'%s' install modifier must not be used without a package name or capability."
-msgstr "'%s' 설치 옵션은 패키지 이름 또는 기능을 명시하지 않고 사용해서는 안 됩니다."
+msgstr ""
+"'%s' 설치 옵션은 패키지 이름 또는 기능을 명시하지 않고 사용해서는 안 됩니다."
 
 #: src/PackageArgs.cc:167
 #, c-format, boost-format
 msgid ""
 "'%s' remove modifier must not be used without a package name or capability."
-msgstr "'%s' 제거 옵션은 패키지 이름 또는 기능을 명시하지 않고 사용해서는 안 됩니다."
+msgstr ""
+"'%s' 제거 옵션은 패키지 이름 또는 기능을 명시하지 않고 사용해서는 안 됩니다."
 
 #: src/PackageArgs.cc:219
 #, c-format, boost-format
 msgid "'%s' not found in package names. Trying '%s'."
-msgstr "패키지 이름에서 '%s'을(를) 찾을 수 없습니다. '%s'을(를) 시도하는 중입니다."
+msgstr ""
+"패키지 이름에서 '%s'을(를) 찾을 수 없습니다. '%s'을(를) 시도하는 중입니다."
 
 #: src/PackageArgs.cc:229
 #, c-format, boost-format
@@ -484,8 +491,9 @@ msgstr "'%s'을(를) 제공하는 '%s'이(가) 이미 설치되어 있습니다.
 msgid ""
 "No update candidate for '%s'. The highest available version is already "
 "installed."
-msgstr "'%s'에 대한 업데이트 후보가 없습니다. 사용할 수 있는 최상위 버전이 이미 "
-"설치되었습니다."
+msgstr ""
+"'%s'에 대한 업데이트 후보가 없습니다. 사용할 수 있는 최상위 버전이 이미 설치"
+"되었습니다."
 
 #: src/RequestFeedback.cc:109
 #, c-format, boost-format
@@ -497,8 +505,9 @@ msgstr "'%s'에 대한 업데이트 후보가 없습니다."
 msgid ""
 "There is an update candidate '%s' for '%s', but it does not match the "
 "specified version, architecture, or repository."
-msgstr "업데이트 후보 '%s'('%s')이(가) 있지만 지정된 버전, 아키텍처 또는 "
-"리포지토리와 일치하지 않습니다."
+msgstr ""
+"업데이트 후보 '%s'('%s')이(가) 있지만 지정된 버전, 아키텍처 또는 리포지토리"
+"와 일치하지 않습니다."
 
 #: src/RequestFeedback.cc:124
 #, c-format, boost-format
@@ -523,7 +532,8 @@ msgstr ""
 msgid ""
 "There is an update candidate for '%s', but it is locked. Use '%s' to unlock "
 "it."
-msgstr "'%s'에 대한 업데이트 후보가 있지만 잠겨 있습니다. 잠금 해제하려면 '%s'을(를) "
+msgstr ""
+"'%s'에 대한 업데이트 후보가 있지만 잠겨 있습니다. 잠금 해제하려면 '%s'을(를) "
 "사용하십시오."
 
 #: src/RequestFeedback.cc:149
@@ -531,7 +541,8 @@ msgstr "'%s'에 대한 업데이트 후보가 있지만 잠겨 있습니다. 잠
 msgid ""
 "Package '%s' is not available in your repositories. Cannot reinstall, "
 "upgrade, or downgrade."
-msgstr "리포지토리에서 '%s' 패키지를 사용할 수 없습니다. 다시 설치하거나 업그레이드 "
+msgstr ""
+"리포지토리에서 '%s' 패키지를 사용할 수 없습니다. 다시 설치하거나 업그레이드 "
 "또는 다운그레이드할 수 없습니다."
 
 #: src/RequestFeedback.cc:159
@@ -539,8 +550,9 @@ msgstr "리포지토리에서 '%s' 패키지를 사용할 수 없습니다. 다�
 msgid ""
 "The selected package '%s' from repository '%s' has lower version than the "
 "installed one."
-msgstr "선택한 패키지 '%s'(리포지토리: '%s')의 버전이 설치된 패키지 버전보다 "
-"낮습니다."
+msgstr ""
+"선택한 패키지 '%s'(리포지토리: '%s')의 버전이 설치된 패키지 버전보다 낮습니"
+"다."
 
 #. translators: %s = "zypper install --oldpackage package-version.arch"
 #: src/RequestFeedback.cc:163
@@ -564,14 +576,15 @@ msgid ""
 "Patch '%1%' is optional. Use '%2%' to install it, or '%3%' to include all "
 "optional patches."
 msgstr ""
-"'%1%' 패치는 선택 사항입니다. '%2%'을(를) 사용하여 설치하거나 '%3%'을(를) "
-"사용하여 선택할 수 있는 모든 패치를 포함합니다."
+"'%1%' 패치는 선택 사항입니다. '%2%'을(를) 사용하여 설치하거나 '%3%'을(를) 사"
+"용하여 선택할 수 있는 모든 패치를 포함합니다."
 
 #: src/RequestFeedback.cc:193
 #, c-format, boost-format
 msgid "Patch '%s' is locked. Use '%s' to install it, or unlock it using '%s'."
-msgstr "'%s' 패치가 잠겼습니다. '%s'을(를) 사용하여 설치하거나 '%s'을(를) 사용하여 "
-"잠금 해제하십시오."
+msgstr ""
+"'%s' 패치가 잠겼습니다. '%s'을(를) 사용하여 설치하거나 '%s'을(를) 사용하여 잠"
+"금 해제하십시오."
 
 #: src/RequestFeedback.cc:200
 #, c-format, boost-format
@@ -863,8 +876,9 @@ msgid ""
 msgid_plural ""
 "The following %d packages are recommended, but will not be installed because "
 "they are unwanted (were manually removed before):"
-msgstr[0] "다음 패키지는 권장되지만 불필요하므로 설치되지 않습니다(이전에 수동으로 "
-"제거됨)."
+msgstr[0] ""
+"다음 패키지는 권장되지만 불필요하므로 설치되지 않습니다(이전에 수동으로 제거"
+"됨)."
 
 #: src/Summary.cc:1169
 #, c-format, boost-format
@@ -874,7 +888,8 @@ msgid ""
 msgid_plural ""
 "The following %d packages are recommended, but will not be installed due to "
 "conflicts or dependency issues:"
-msgstr[0] "다음 패키지는 권장되지만 충돌 또는 종속성 문제 때문에 설치되지 않습니다."
+msgstr[0] ""
+"다음 패키지는 권장되지만 충돌 또는 종속성 문제 때문에 설치되지 않습니다."
 
 #: src/Summary.cc:1182
 #, c-format, boost-format
@@ -1236,7 +1251,8 @@ msgstr[0] "설치할 소스 패키지"
 msgid ""
 "Package manager restart required. (Run this command once again after the "
 "update stack got updated)"
-msgstr "패키지 관리자 재시작이 필요합니다. (업데이트 스택이 업데이트된 후 이 명령을 "
+msgstr ""
+"패키지 관리자 재시작이 필요합니다. (업데이트 스택이 업데이트된 후 이 명령을 "
 "다시 실행하십시오.)"
 
 #. translator: %1% is an option string like  "--dry-run"
@@ -1266,17 +1282,16 @@ msgid ""
 "PackageKit is blocking zypper. This happens if you have an updater applet or "
 "other software management application using PackageKit running."
 msgstr ""
-"PackageKit는 zypper를 차단합니다. 이것은 PackageKit를 사용하는 업데이터 "
-"애플릿 또는 기타 소프트웨어 관리 응용 프로그램이 실행되고 있는 경우 "
-"발생합니다."
+"PackageKit는 zypper를 차단합니다. 이것은 PackageKit를 사용하는 업데이터 애플"
+"릿 또는 기타 소프트웨어 관리 응용 프로그램이 실행되고 있는 경우 발생합니다."
 
 #: src/Zypper.cc:93
 msgid ""
 "We can ask PackageKit to interrupt the current action as soon as possible, "
 "but it depends on PackageKit how fast it will respond to this request."
 msgstr ""
-"가능한 빨리 현재 작업을 중단하도록 PackageKit에 요청할 수 있지만 "
-"PackageKit에서 이 요청에 얼마나 빨리 응답할 것인가에 달려 있습니다."
+"가능한 빨리 현재 작업을 중단하도록 PackageKit에 요청할 수 있지만 PackageKit에"
+"서 이 요청에 얼마나 빨리 응답할 것인가에 달려 있습니다."
 
 #: src/Zypper.cc:96
 msgid "Ask PackageKit to quit?"
@@ -1290,7 +1305,7 @@ msgstr "PackageKit가 여전히 실행 중입니다(사용 중일 수 있음)."
 msgid "Try again?"
 msgstr "다시 해보시겠습니까?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "예상치 못한 예외가 발생했습니다."
 
@@ -1320,12 +1335,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "%s 옵션은 여기서 아무런 의미가 없습니다. 무시 중입니다."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "비옵션 프로그램 인수: "
 
@@ -1336,10 +1351,10 @@ msgid ""
 "the repository provider or check their web site. Many providers maintain a "
 "web page showing the fingerprints of the GPG keys they are using."
 msgstr ""
-"GPG pubkey는 지문으로 명확하게 식별됩니다. 키 이름에 의존하지 마십시오. "
-"제시된 키가 정상인지 확실하지 않은 경우 저장소 제공자에게 문의하거나 웹 "
-"사이트를 확인하십시오. 많은 공급자가 사용 중인 GPG 키의 지문을 보여주는 웹 "
-"페이지를 유지 관리합니다."
+"GPG pubkey는 지문으로 명확하게 식별됩니다. 키 이름에 의존하지 마십시오. 제시"
+"된 키가 정상인지 확실하지 않은 경우 저장소 제공자에게 문의하거나 웹 사이트를 "
+"확인하십시오. 많은 공급자가 사용 중인 GPG 키의 지문을 보여주는 웹 페이지를 유"
+"지 관리합니다."
 
 #: src/callbacks/keyring.h:38
 msgid ""
@@ -1348,9 +1363,9 @@ msgid ""
 "signature can lead to a corrupted system and in extreme cases even to a "
 "system compromise."
 msgstr ""
-"데이터에 서명하면 수신자는 데이터가 서명된 후에 수정이 발생하지 않았음을 "
-"확인할 수 있습니다. 서명이 없거나 잘못되었거나 알 수 없는 데이터를 수락하면 "
-"시스템이 손상되고 극단적인 경우 시스템이 손상될 수 있습니다."
+"데이터에 서명하면 수신자는 데이터가 서명된 후에 수정이 발생하지 않았음을 확인"
+"할 수 있습니다. 서명이 없거나 잘못되었거나 알 수 없는 데이터를 수락하면 시스"
+"템이 손상되고 극단적인 경우 시스템이 손상될 수 있습니다."
 
 #. translator: %1% is a file name
 #: src/callbacks/keyring.h:46
@@ -1358,16 +1373,17 @@ msgstr ""
 msgid ""
 "File '%1%' is the repositories master index file. It ensures the integrity "
 "of the whole repo."
-msgstr "'%1%' 파일은 리포지토리 마스터 인덱스 파일입니다. 전체 repo의 무결성을 "
-"보장합니다."
+msgstr ""
+"'%1%' 파일은 리포지토리 마스터 인덱스 파일입니다. 전체 repo의 무결성을 보장합"
+"니다."
 
 #: src/callbacks/keyring.h:52
 msgid ""
 "We can't verify that no one meddled with this file, so it might not be "
 "trustworthy anymore! You should not continue unless you know it's safe."
 msgstr ""
-"아무도이 파일에 간섭하지 않았음을 확인할 수 없으므로 더 이상 신뢰할 수 "
-"없습니다! 안전하다고 판단되지 않는 경우 계속해서는 안됩니다."
+"아무도이 파일에 간섭하지 않았음을 확인할 수 없으므로 더 이상 신뢰할 수 없습니"
+"다! 안전하다고 판단되지 않는 경우 계속해서는 안됩니다."
 
 #: src/callbacks/keyring.h:57
 msgid ""
@@ -1461,8 +1477,9 @@ msgstr "알 수 없는 키 '%s'(으)로 서명된 '%s' 파일을 승인 중입�
 #, c-format, boost-format
 msgid ""
 "Accepting file '%s' from repository '%s' signed with an unknown key '%s'."
-msgstr "리포지토리 '%s'에서 알 수 없는 키 '%s'(으)로 서명된 '%s' 파일을 승인 "
-"중입니다."
+msgstr ""
+"리포지토리 '%s'에서 알 수 없는 키 '%s'(으)로 서명된 '%s' 파일을 승인 중입니"
+"다."
 
 #. translator: %1% is a file name, %2% is a gpg key ID
 #: src/callbacks/keyring.h:214
@@ -1474,7 +1491,8 @@ msgstr "'%1%' 파일이 알 수 없는 키 '%2%'(으)로 서명되었습니다."
 #: src/callbacks/keyring.h:217
 #, boost-format
 msgid "File '%1%' from repository '%3%' is signed with an unknown key '%2%'."
-msgstr "리포지토리 '%3%'의 '%1%' 파일이 알 수 없는 키 '%2%'(으)로 서명되었습니다."
+msgstr ""
+"리포지토리 '%3%'의 '%1%' 파일이 알 수 없는 키 '%2%'(으)로 서명되었습니다."
 
 #: src/callbacks/keyring.h:246
 msgid "Automatically importing the following key:"
@@ -1491,8 +1509,9 @@ msgstr "새 리포지토리 또는 패키지 서명 키 수신:"
 #. translators: this message is shown after showing description of the key
 #: src/callbacks/keyring.h:284
 msgid "Do you want to reject the key, trust temporarily, or trust always?"
-msgstr "키를 거부(r)하시겠습니까, 아니면 임시로 신뢰(t)하거나 항상 "
-"신뢰(a)하시겠습니까?"
+msgstr ""
+"키를 거부(r)하시겠습니까, 아니면 임시로 신뢰(t)하거나 항상 신뢰(a)하시겠습니"
+"까?"
 
 #. translators: this message is shown after showing description of the key
 #: src/callbacks/keyring.h:287
@@ -1568,8 +1587,9 @@ msgstr "리포지토리 '%1%'의 '%2%' 파일에 대한 서명 확인에 실패�
 msgid ""
 "The rpm database seems to contain old V3 version gpg keys which are "
 "meanwhile obsolete and considered insecure:"
-msgstr "rpm 데이터베이스에 오래되고 안전하지 않은 것으로 간주되는 이전 V3 버전 gpg "
-"키가 있는 것 같습니다."
+msgstr ""
+"rpm 데이터베이스에 오래되고 안전하지 않은 것으로 간주되는 이전 V3 버전 gpg 키"
+"가 있는 것 같습니다."
 
 #: src/callbacks/keyring.h:445
 #, boost-format
@@ -1581,8 +1601,9 @@ msgstr "키에 대한 세부 정보를 보려면 '%1%'을(를) 호출합니다."
 msgid ""
 "Unless you believe the key in question is still in use, you can remove it "
 "from the rpm database calling '%1%'."
-msgstr "문제의 키가 여전히 사용되는 것이 아니면 '%1%'을(를) 호출하여 rpm "
-"데이터베이스에서 해당 키를 제거할 수 있습니다."
+msgstr ""
+"문제의 키가 여전히 사용되는 것이 아니면 '%1%'을(를) 호출하여 rpm 데이터베이스"
+"에서 해당 키를 제거할 수 있습니다."
 
 #. translator: %1% is the number of keys, %2% the name of a repository
 #: src/callbacks/keyring.h:468
@@ -1597,9 +1618,9 @@ msgid ""
 "repository. In order to validate those packages upon download and "
 "installation the new keys will be imported into the rpm database."
 msgstr ""
-"이러한 추가 키는 일반적으로 저장소에서 제공하는 패키지에 서명하는 데 "
-"사용됩니다. 다운로드 및 설치 시 해당 패키지의 유효성을 검사하기 위해 새 키를 "
-"rpm 데이터베이스로 가져옵니다."
+"이러한 추가 키는 일반적으로 저장소에서 제공하는 패키지에 서명하는 데 사용됩니"
+"다. 다운로드 및 설치 시 해당 패키지의 유효성을 검사하기 위해 새 키를 rpm 데이"
+"터베이스로 가져옵니다."
 
 #: src/callbacks/keyring.h:474
 msgid "New:"
@@ -1640,8 +1661,9 @@ msgstr ""
 msgid ""
 "Accepting packages with wrong checksums can lead to a corrupted system and "
 "in extreme cases even to a system compromise."
-msgstr "잘못된 체크섬을 포함한 패키지를 승인하면 시스템이 손상될 수 있으며, 심각한 "
-"경우 보안 위험이 발생할 수도 있습니다."
+msgstr ""
+"잘못된 체크섬을 포함한 패키지를 승인하면 시스템이 손상될 수 있으며, 심각한 경"
+"우 보안 위험이 발생할 수도 있습니다."
 
 #: src/callbacks/keyring.h:548
 #, boost-format
@@ -1656,8 +1678,8 @@ msgstr ""
 "하지만 '%1%..' 체크섬을 포함한 파일이 안전하고 올바르며\n"
 "이 작업에서 사용해야 하는 것이 확실하면 본인이 위험을 부담하고 체크섬의 처음 "
 "4글자를\n"
-"입력하여 이 파일의 사용 차단을 해제하십시오. 입력하지 않으면 파일이 "
-"폐기됩니다.\n"
+"입력하여 이 파일의 사용 차단을 해제하십시오. 입력하지 않으면 파일이 폐기됩니"
+"다.\n"
 
 #. translators: A prompt option
 #: src/callbacks/keyring.h:555
@@ -1799,8 +1821,9 @@ msgstr "매체를 꺼내십시오."
 msgid ""
 "Please insert medium [%s] #%d and type 'y' to continue or 'n' to cancel the "
 "operation."
-msgstr "매체 [%s] #%d을(를) 삽입하고 'y'를 입력하여 계속하거나, 'n'을 입력하여 "
-"작업을 취소하십시오."
+msgstr ""
+"매체 [%s] #%d을(를) 삽입하고 'y'를 입력하여 계속하거나, 'n'을 입력하여 작업"
+"을 취소하십시오."
 
 #. translators: a/r/i/u are replies to the "Abort, retry, ignore?" prompt
 #. Translate the a/r/i part exactly as you did the a/r/i string.
@@ -1814,8 +1837,9 @@ msgstr "중단/재시도/무시/URI 변경"
 msgid ""
 "Authentication required to access %s. You need to be root to be able to read "
 "the credentials from %s."
-msgstr "%s에 액세스하려면 인증이 필요합니다. %s에서 인증서를 읽을 수 있으려면 루트 "
-"사용자여야 합니다."
+msgstr ""
+"%s에 액세스하려면 인증이 필요합니다. %s에서 인증서를 읽을 수 있으려면 루트 사"
+"용자여야 합니다."
 
 #: src/callbacks/media.cc:314 src/callbacks/media.cc:321
 msgid "User Name"
@@ -1943,9 +1967,9 @@ msgid ""
 "in advance in order to access their file lists. See option '%1%' in the "
 "zypper manual page for details."
 msgstr ""
-"파일 충돌을 확인하려면 파일 목록에 액세스하기 위해 설치되지 않은 패키지를 "
-"미리 다운로드해야 합니다. 자세한 내용은 zypper 매뉴얼 페이지의 '%1%' 옵션을 "
-"참조하십시오."
+"파일 충돌을 확인하려면 파일 목록에 액세스하기 위해 설치되지 않은 패키지를 미"
+"리 다운로드해야 합니다. 자세한 내용은 zypper 매뉴얼 페이지의 '%1%' 옵션을 참"
+"조하십시오."
 
 #. TranslatorExplanation %1%(number of conflicts); detailed list follows
 #: src/callbacks/rpm.h:523
@@ -1965,8 +1989,8 @@ msgid ""
 "same name but different contents. If you continue, conflicting files will be "
 "replaced losing the previous content."
 msgstr ""
-"파일 충돌은 두 패키지가 이름은 같지만 내용이 다른 파일을 설치하려고 할 때 "
-"발생합니다. 계속하면 충돌하는 파일이 바뀌고 이전 내용이 손실됩니다."
+"파일 충돌은 두 패키지가 이름은 같지만 내용이 다른 파일을 설치하려고 할 때 발"
+"생합니다. 계속하면 충돌하는 파일이 바뀌고 이전 내용이 손실됩니다."
 
 #. TranslatorExplanation This text is a progress display label e.g. "Installing: foo-1.1.2 [42%]"
 #: src/callbacks/rpm.h:760 src/callbacks/rpm.h:767
@@ -2039,26 +2063,33 @@ msgid "Commands:"
 msgstr "명령:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "자세한 설치 요약을 표시합니다."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "패키지 유형(%1%)입니다."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
-msgstr "'best effort' 방식으로 업데이트합니다. 최신 버전이 아닌 이전 버전의 "
-"업데이트도 허용합니다."
+msgstr ""
+"'best effort' 방식으로 업데이트합니다. 최신 버전이 아닌 이전 버전의 업데이트"
+"도 허용합니다."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "패키지 관리 자체에 영향을 미치는 패치만 고려합니다."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2068,15 +2099,17 @@ msgstr "이 명령을 실행하려면 루트 권한이 필요합니다."
 msgid ""
 "This is a transactional-server, please use transactional-update to update or "
 "modify the system."
-msgstr "트랜잭션 서버이므로 트랜잭션 업데이트를 사용하여 시스템을 업데이트하거나 "
-"수정하십시오."
+msgstr ""
+"트랜잭션 서버이므로 트랜잭션 업데이트를 사용하여 시스템을 업데이트하거나 수정"
+"하십시오."
 
 #: src/commands/conditions.cc:49
 msgid ""
 "The target filesystem is mounted as read-only. Please make sure the target "
 "filesystem is writeable."
-msgstr "대상 파일 시스템이 읽기 전용으로 마운트되었습니다. 대상 파일 시스템이 쓰기 "
-"가능한지 확인하십시오."
+msgstr ""
+"대상 파일 시스템이 읽기 전용으로 마운트되었습니다. 대상 파일 시스템이 쓰기 가"
+"능한지 확인하십시오."
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/distupgrade.cc:20
@@ -2118,9 +2151,9 @@ msgid ""
 "Make sure these repositories are compatible before you continue. See '%s' "
 "for more information about this command."
 msgstr ""
-"모든 활성화된 리포지토리를 사용하여 배포판 업그레이드를 수행하려고 합니다. "
-"계속하기 전에 이 리포지토리가 호환되는지 확인하십시오. 이 명령에 대한 자세한 "
-"내용은 '%s'을(를) 확인하십시오."
+"모든 활성화된 리포지토리를 사용하여 배포판 업그레이드를 수행하려고 합니다. 계"
+"속하기 전에 이 리포지토리가 호환되는지 확인하십시오. 이 명령에 대한 자세한 내"
+"용은 '%s'을(를) 확인하십시오."
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/help.cc:22
@@ -2132,7 +2165,7 @@ msgstr "zypper [--글로벌 옵션] <명령> [--명령-옵션] [인수]"
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <하위 명령> [--명령-옵션] [인수]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "도움말을 인쇄합니다."
 
@@ -2165,10 +2198,10 @@ msgid ""
 "unconditionally on small or minimal systems, as it may easily add a large "
 "number of packages."
 msgstr ""
-"이미 설치된 패키지에서 권장하는 새로 추가된 패키지를 설치합니다. 이 명령은 "
-"기본적으로 설치된 모든 패키지 권장 사항을 다시 평가하고 그에 따라 시스템을 "
-"채웁니다. 많은 패키지를 쉽게 추가할 수 있으므로 작은 시스템 또는 MSYS에서 이 "
-"명령을 무조건 호출하지 않는 것이 좋습니다."
+"이미 설치된 패키지에서 권장하는 새로 추가된 패키지를 설치합니다. 이 명령은 기"
+"본적으로 설치된 모든 패키지 권장 사항을 다시 평가하고 그에 따라 시스템을 채웁"
+"니다. 많은 패키지를 쉽게 추가할 수 있으므로 작은 시스템 또는 MSYS에서 이 명령"
+"을 무조건 호출하지 않는 것이 좋습니다."
 
 #. translators: command description, %1% is a zypper command
 #: src/commands/inrverify.cc:98
@@ -2178,17 +2211,18 @@ msgid ""
 "supporting available hardware, languages or filesystems. Useful after having "
 "added e.g. new hardware or driver repos."
 msgstr ""
-"'%1%'(으)로 호출되었으므로 사용 가능한 하드웨어, 언어 또는 파일 시스템을 "
-"지원하는 패키지만 찾도록 명령을 제한합니다. 새 하드웨어 또는 드라이버 "
-"리포지토리 등을 추가했을 때 유용합니다."
+"'%1%'(으)로 호출되었으므로 사용 가능한 하드웨어, 언어 또는 파일 시스템을 지원"
+"하는 패키지만 찾도록 명령을 제한합니다. 새 하드웨어 또는 드라이버 리포지토리 "
+"등을 추가했을 때 유용합니다."
 
 #. translators: command description
 #: src/commands/inrverify.cc:101
 msgid ""
 "Check whether dependencies of installed packages are satisfied and suggest "
 "to install or remove packages in order to repair the dependency problems."
-msgstr "설치된 패키지의 종속성을 만족하는지 확인하고 종속성 문제를 해결하려면 "
-"패키지를 설치하거나 제거합니다."
+msgstr ""
+"설치된 패키지의 종속성을 만족하는지 확인하고 종속성 문제를 해결하려면 패키지"
+"를 설치하거나 제거합니다."
 
 #: src/commands/installremove.cc:62
 msgid "Select packages by plain name, not by capability."
@@ -2214,8 +2248,8 @@ msgid ""
 "Remove packages with specified capabilities. A capability is NAME[.ARCH]"
 "[OP<VERSION>], where OP is one of <, <=, =, >=, >."
 msgstr ""
-"지정된 기능을 포함한 패키지를 제거합니다. 기능은 NAME[.ARCH][OP<VERSION>]"
-"입니다. 여기서 OP는 <, <=, =, >=, > 중 하나입니다."
+"지정된 기능을 포함한 패키지를 제거합니다. 기능은 NAME[.ARCH][OP<VERSION>]입니"
+"다. 여기서 OP는 <, <=, =, >=, > 중 하나입니다."
 
 #: src/commands/installremove.cc:104 src/commands/installremove.cc:234
 #: src/utils/messages.cc:53
@@ -2261,9 +2295,9 @@ msgid ""
 "location. A capability is NAME[.ARCH][OP<VERSION>], where OP is one of <, "
 "<=, =, >=, >."
 msgstr ""
-"지정된 기능으로 패키지를 설치하거나 지정된 위치에서 RPM 파일을 설치합니다. "
-"기능은 NAME[.ARCH][OP<VERSION>]입니다. 여기서 OP는 <, <=, =, >=, > 중 "
-"하나입니다."
+"지정된 기능으로 패키지를 설치하거나 지정된 위치에서 RPM 파일을 설치합니다. 기"
+"능은 NAME[.ARCH][OP<VERSION>]입니다. 여기서 OP는 <, <=, =, >=, > 중 하나입니"
+"다."
 
 #. translators: --from <ALIAS|#|URI>
 #: src/commands/installremove.cc:195 src/commands/utils/download.cc:170
@@ -2275,19 +2309,22 @@ msgstr "지정된 리포지토리에서 패키지를 선택합니다."
 msgid ""
 "Allows one to replace a newer item with an older one. Handy if you are doing "
 "a rollback. Unlike --force it will not enforce a reinstall."
-msgstr "최신 항목을 오래된 항목으로 바꿀 수 있습니다. 롤백을 할 경우 편리합니다. --"
+msgstr ""
+"최신 항목을 오래된 항목으로 바꿀 수 있습니다. 롤백을 할 경우 편리합니다. --"
 "force와 달리 재설치를 수행하지 않습니다."
 
 #: src/commands/installremove.cc:203
 msgid "Silently install unsigned rpm packages given as commandline parameters."
-msgstr "명령줄 매개변수로 주어진 서명되지 않은 rpm 패키지를 자동으로 설치하십시오."
+msgstr ""
+"명령줄 매개변수로 주어진 서명되지 않은 rpm 패키지를 자동으로 설치하십시오."
 
 #. translators: -f, --force
 #: src/commands/installremove.cc:208
 msgid ""
 "Install even if the item is already installed (reinstall), downgraded or "
 "changes vendor or architecture."
-msgstr "항목이 이미 설치(재설치)되었거나 다운그레이드되었거나, 벤더 또는 아키텍처를 "
+msgstr ""
+"항목이 이미 설치(재설치)되었거나 다운그레이드되었거나, 벤더 또는 아키텍처를 "
 "변경하는 경우에도 설치합니다."
 
 #. translators: rug related message, shown if
@@ -2331,22 +2368,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [OPTIONS]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "해당하는 모든 패치를 나열합니다."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "해당하는 패치뿐 아니라 모든 패치를 나열합니다."
 
@@ -2370,7 +2407,8 @@ msgstr "사용 가능한 모든 업데이트를 나열합니다."
 msgid ""
 "List all packages for which newer versions are available, regardless whether "
 "they are installable or not."
-msgstr "사용 가능한 새 버전의 모든 패키지를 설치 가능 여부에 상관 없이 나열합니다."
+msgstr ""
+"사용 가능한 새 버전의 모든 패키지를 설치 가능 여부에 상관 없이 나열합니다."
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/locale/addlocalecmd.cc:20
@@ -2394,54 +2432,61 @@ msgstr "제공된 로케일에 해당하는 패키지를 설치하지 않습니�
 msgid ""
 "Specify locale which shall be supported by the language code. Get a list of "
 "all available locales by calling '%s'."
-msgstr "언어 코드에서 지원할 로케일을 지정합니다. '%s'을(를) 호출하여 사용 가능한 "
-"모든 로케일 목록을 가져옵니다."
+msgstr ""
+"언어 코드에서 지원할 로케일을 지정합니다. '%s'을(를) 호출하여 사용 가능한 모"
+"든 로케일 목록을 가져옵니다."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [옵션] [로케일] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "요청한 로케일(언어 코드)을 나열합니다."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "요청한 로케일 및 해당 패키지를 나열합니다."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "해당 패키지를 표시합니다."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "사용 가능한 로케일을 모두 나열합니다."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr "모든 인수를 제공했기 때문에 위치 인수를 무시합니다."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "정보를 인쇄할 로케일입니다."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
-msgstr "대체 'en'을 제외하고 언어 코드 'en'과 함께 고유한 국가 코드가 있는 모든 "
-"로케일 가져오기:"
+msgstr ""
+"대체 'en'을 제외하고 언어 코드 'en'과 함께 고유한 국가 코드가 있는 모든 로케"
+"일 가져오기:"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
-msgstr "언어 코드 'en'과 함께 다음 국가 코드가 있거나 없는 모든 로케일 가져오기:"
+msgstr ""
+"언어 코드 'en'과 함께 다음 국가 코드가 있거나 없는 모든 로케일 가져오기:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "다음 인수와 정확히 일치하는 로케일 가져오기: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "'de' 및 'en'에 사용할 수 있는 패키지 목록 가져오기:"
 
@@ -2463,7 +2508,8 @@ msgstr "지원 언어 목록에서 제공된 로케일을 제거합니다."
 msgid ""
 "Specify locales which shall be removed by the language code. Get the list of "
 "requested locales by calling '%s'."
-msgstr "언어 코드에서 제거할 로케일을 지정합니다. '%s'을(를) 호출하여 요청한 로케일 "
+msgstr ""
+"언어 코드에서 제거할 로케일을 지정합니다. '%s'을(를) 호출하여 요청한 로케일 "
 "목록을 가져옵니다."
 
 #: src/commands/locale/removelocalecmd.cc:46
@@ -2545,11 +2591,11 @@ msgstr[0] "%lu 잠금이 제거되었습니다."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "이름"
 
@@ -2559,8 +2605,8 @@ msgstr "일치 항목"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "유형"
@@ -2568,7 +2614,7 @@ msgstr "유형"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "리포지토리"
@@ -2637,8 +2683,9 @@ msgstr "패키지 잠금을 제거합니다."
 msgid ""
 "Remove a package lock. Specify the lock to remove by its number obtained "
 "with '%1%' or by package name."
-msgstr "패키지 잠금을 제거합니다. '%1%'에서 가져온 번호나 패키지 이름별로 제거할 "
-"잠금을 지정합니다."
+msgstr ""
+"패키지 잠금을 제거합니다. '%1%'에서 가져온 번호나 패키지 이름별로 제거할 잠금"
+"을 지정합니다."
 
 #: src/commands/locks/remove.cc:45
 msgid "Remove only locks with specified repository."
@@ -2675,10 +2722,10 @@ msgid ""
 "Exit code ZYPPER_EXIT_INF_REBOOT_NEEDED indicates that a reboot is "
 "suggested, otherwise the exit code is set to ZYPPER_EXIT_OK."
 msgstr ""
-"코어 라이브러리 또는 서비스의 이전 업데이트 또는 설치에서 needs-reboot "
-"플래그를 설정했는지 확인합니다.\n"
-"종료 코드 ZYPPER_EXIT_INF_REBOOT_NEEDED는 재부팅이 필요함을 나타냅니다. "
-"그렇지 않은 경우 종료 코드가 ZYPPER_EXIT_OK로 설정됩니다."
+"코어 라이브러리 또는 서비스의 이전 업데이트 또는 설치에서 needs-reboot 플래그"
+"를 설정했는지 확인합니다.\n"
+"종료 코드 ZYPPER_EXIT_INF_REBOOT_NEEDED는 재부팅이 필요함을 나타냅니다. 그렇"
+"지 않은 경우 종료 코드가 ZYPPER_EXIT_OK로 설정됩니다."
 
 #: src/commands/needs-rebooting.cc:26
 msgid ""
@@ -2815,15 +2862,17 @@ msgstr "설치되지 않은 패키지만 표시합니다."
 msgid ""
 "Automatically say 'yes' to third party license confirmation prompt. See 'man "
 "zypper' for more details."
-msgstr "제3자 라이센스 확인 프롬프트에 자동으로 '예'라고 말하십시오. 자세한 내용은 "
+msgstr ""
+"제3자 라이센스 확인 프롬프트에 자동으로 '예'라고 말하십시오. 자세한 내용은 "
 "'man zypper'를 참조하십시오."
 
 #: src/commands/optionsets.cc:244
 msgid ""
 "Automatically accept product licenses only. See 'man zypper' for more "
 "details."
-msgstr "제품 라이센스만 자동으로 수락합니다. 자세한 내용은 'man zypper'를 "
-"참조하십시오."
+msgstr ""
+"제품 라이센스만 자동으로 수락합니다. 자세한 내용은 'man zypper'를 참조하십시"
+"오."
 
 #. translators: --replacefiles
 #: src/commands/optionsets.cc:264
@@ -2832,16 +2881,17 @@ msgid ""
 "installed, packages. Default is to treat file conflicts as an error. --"
 "download-as-needed disables the fileconflict check."
 msgstr ""
-"이미 설치된 다른 패키지의 파일을 바꾸는 경우에도, 패키지를 설치합니다. "
-"기본값은 파일 충돌을 오류로 처리하는 것입니다. --download-as-needed는 파일 "
-"충돌 확인을 비활성화합니다."
+"이미 설치된 다른 패키지의 파일을 바꾸는 경우에도, 패키지를 설치합니다. 기본값"
+"은 파일 충돌을 오류로 처리하는 것입니다. --download-as-needed는 파일 충돌 확"
+"인을 비활성화합니다."
 
 #. translators: -y, --no-confirm
 #: src/commands/optionsets.cc:291
 msgid ""
 "Don't require user interaction. Alias for the --non-interactive global "
 "option."
-msgstr "사용자의 작업을 요청하지 마십시오. --non-interactive 전역 옵션의 별칭입니다."
+msgstr ""
+"사용자의 작업을 요청하지 마십시오. --non-interactive 전역 옵션의 별칭입니다."
 
 #: src/commands/optionsets.cc:309
 msgid ""
@@ -2909,8 +2959,8 @@ msgid ""
 "is ignored, if the patch command must update the update stack first. Can not "
 "be combined with --updatestack-only."
 msgstr ""
-"패치에 포함되지 않는 모든 패키지를 추가로 업데이트해 보십시오. 패치 명령이 "
-"업데이트 스택을 먼저 업데이트해야 하는 경우 옵션이 무시됩니다. --updatestack-"
+"패치에 포함되지 않는 모든 패키지를 추가로 업데이트해 보십시오. 패치 명령이 업"
+"데이트 스택을 먼저 업데이트해야 하는 경우 옵션이 무시됩니다. --updatestack-"
 "only와 함께 사용할 수 없습니다."
 
 #. translators: command synopsis; do not translate lowercase words
@@ -2929,9 +2979,8 @@ msgid ""
 "Display stats about applicable patches. The command returns 100 if needed "
 "patches were found, 101 if there is at least one needed security patch."
 msgstr ""
-"해당하는 패치에 대한 통계를 표시합니다. 이 명령을 실행하여 필요한 패치를 "
-"찾으면 100을 반환하고, 최소 한 개의 필요한 보안 패치를 찾으면 101을 "
-"반환합니다."
+"해당하는 패치에 대한 통계를 표시합니다. 이 명령을 실행하여 필요한 패치를 찾으"
+"면 100을 반환하고, 최소 한 개의 필요한 보안 패치를 찾으면 101을 반환합니다."
 
 #. translators: command synopsis; do not translate the command 'name (abbreviations)' or '-option' names
 #: src/commands/ps.cc:27
@@ -2943,8 +2992,9 @@ msgstr "ps [OPTIONS]"
 msgid ""
 "List running processes which might still use files and libraries deleted by "
 "recent upgrades."
-msgstr "최근 업그레이드에서 삭제된 파일 및 라이브러리를 아직 사용할 수도 있는 실행 "
-"중인 프로세스를 나열합니다."
+msgstr ""
+"최근 업그레이드에서 삭제된 파일 및 라이브러리를 아직 사용할 수도 있는 실행 중"
+"인 프로세스를 나열합니다."
 
 #. translators: -s, --short
 #: src/commands/ps.cc:46
@@ -2953,9 +3003,9 @@ msgid ""
 "processes which are associated with a system service. Given three times, "
 "list the associated system service names only."
 msgstr ""
-"삭제된 파일을 표시하지 않는 짧은 테이블을 생성합니다. 두 번째는 시스템 "
-"서비스와 연결된 프로세스만 표시하고, 세 번째는 연결된 시스템 서비스 이름만 "
-"나열합니다."
+"삭제된 파일을 표시하지 않는 짧은 테이블을 생성합니다. 두 번째는 시스템 서비스"
+"와 연결된 프로세스만 표시하고, 세 번째는 연결된 시스템 서비스 이름만 나열합니"
+"다."
 
 #. translators: --print <format>
 #: src/commands/ps.cc:49
@@ -2965,9 +3015,9 @@ msgid ""
 "followed by a newline. Any '%s' directive in <format> is replaced by the "
 "system service name."
 msgstr ""
-"연관된 각 시스템 서비스에 대해 표준 출력으로 <format>을 인쇄하고 그 뒤에 "
-"줄바꿈 문자를 인쇄합니다. <format>의 '%s' 지시어는 시스템 서비스 이름으로 "
-"대체됩니다."
+"연관된 각 시스템 서비스에 대해 표준 출력으로 <format>을 인쇄하고 그 뒤에 줄바"
+"꿈 문자를 인쇄합니다. <format>의 '%s' 지시어는 시스템 서비스 이름으로 대체됩"
+"니다."
 
 #. translators: -d, --debugFile <path>
 #: src/commands/ps.cc:52
@@ -3009,7 +3059,7 @@ msgid "Command"
 msgstr "명령"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "서비스"
 
@@ -3043,8 +3093,8 @@ msgid ""
 "permission to examine with the system stat(2) function. The result might be "
 "incomplete."
 msgstr ""
-"참고: 루트로 실행하지 않는 경우 system stat(2) 함수로 검사할 권한이 있는 "
-"파일만 검색할 수 있습니다. 결과가 불완전할 수 있습니다."
+"참고: 루트로 실행하지 않는 경우 system stat(2) 함수로 검사할 권한이 있는 파일"
+"만 검색할 수 있습니다. 결과가 불완전할 수 있습니다."
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/query/info.cc:19
@@ -3064,9 +3114,9 @@ msgid ""
 "partially matching use option '--match-substrings' or use wildcards (*?) in "
 "name."
 msgstr ""
-"지정된 패키지에 대한 자세한 정보를 표시합니다. 기본적으로 주어진 이름과 "
-"정확히 일치하는 패키지가 표시됩니다. 부분적으로 일치하는 패키지도 가져오려면 "
-"'--match-substrings' 옵션을 사용하거나 이름에 와일드카드(*?)를 사용하십시오."
+"지정된 패키지에 대한 자세한 정보를 표시합니다. 기본적으로 주어진 이름과 정확"
+"히 일치하는 패키지가 표시됩니다. 부분적으로 일치하는 패키지도 가져오려면 '--"
+"match-substrings' 옵션을 사용하거나 이름에 와일드카드(*?)를 사용하십시오."
 
 #: src/commands/query/info.cc:25
 msgid ""
@@ -3175,120 +3225,120 @@ msgid "Show detailed information for products."
 msgstr "제품에 대한 자세한 정보를 표시합니다."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [옵션] [리포지토리] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "사용 가능한 모든 패키지를 나열합니다."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "지정된 리포지토리에서 사용 가능한 모든 패키지를 나열합니다."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "제안된 패키지를 표시합니다."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "권장 패키지를 표시합니다."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "불필요한 패키지를 표시합니다."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "패키지 이름별로 목록을 정렬합니다."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "리포지토리별로 목록을 정렬합니다."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [리포지토리] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "사용 가능한 모든 패치를 나열합니다."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "지정한 리포지토리에서 사용 가능한 모든 패치를 나열합니다."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [옵션] [리포지토리] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "사용 가능한 모든 패턴을 나열합니다."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "지정한 리포지토리에서 사용 가능한 모든 패턴을 나열합니다."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [옵션] [리포지토리] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "사용 가능한 모든 제품을 나열합니다."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "지정한 리포지토리에서 사용 가능한 모든 제품을 나열합니다."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr "XML 출력만 사용: 산출된 파일에서 검색된 XML tag를 문자 그대로 재전송."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "옵션 %1% 은(는) 전역옵션 %2% (이)가 없는 경우 적용되지 않습니다."
@@ -3310,8 +3360,8 @@ msgid ""
 "Add a repository to the system. The repository can be specified by its URI "
 "or can be read from specified .repo file (even remote)."
 msgstr ""
-"시스템에 리포지토리를 추가합니다. 해당 URI로 리포지토리를 지정하거나 지정된 "
-".repo 파일(원격 포함)에서 리포지토리를 읽을 수 있습니다."
+"시스템에 리포지토리를 추가합니다. 해당 URI로 리포지토리를 지정하거나 지정"
+"된 .repo 파일(원격 포함)에서 리포지토리를 읽을 수 있습니다."
 
 #: src/commands/repos/add.cc:40
 msgid "Just another means to specify a .repo file to read."
@@ -3329,12 +3379,12 @@ msgstr "URI를 검사하지 않고 나중에 새로 고치는 동안 검사합�
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr "리포지토리 유형은 항상 자동 감지됩니다. 이 옵션은 무시됩니다."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "%s과(와) %s을(를) 동시에 사용할 수 없습니다. %s 설정을 사용합니다."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr "한 개의 인수만 사용한 경우 URI가 .repo 파일을 가리켜야 합니다."
@@ -3346,7 +3396,8 @@ msgstr "지정된 유형은 올바른 리포지토리 유형이 아닙니다."
 #: src/commands/repos/add.cc:131
 #, c-format, boost-format
 msgid "See '%s' or '%s' to get a list of known repository types."
-msgstr "'%s' 또는 '%s'을(를) 확인하여 알려진 리포지토리 유형의 목록을 가져옵니다."
+msgstr ""
+"'%s' 또는 '%s'을(를) 확인하여 알려진 리포지토리 유형의 목록을 가져옵니다."
 
 #: src/commands/repos/clean.cc:16
 msgid "clean (cc) [ALIAS|#|URI] ..."
@@ -3377,111 +3428,115 @@ msgid "Clean both metadata and package caches."
 msgstr "메타 데이터와 패키지 캐시를 모두 정리합니다."
 
 #  Translators: table column headings
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "별칭"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "활성화됨"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "GPG 확인"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "우선순위"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "자동 새로 고침"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "켜기"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "끄기"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "패키지 유지"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "GPG 키 URI"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "경로 접두어"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "상위 서비스"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "키워드"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Repo 정보 경로"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "MD 캐시 경로"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [옵션] [리포지토리] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "정의된 모든 리포지토리를 나열합니다."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "정의된 모든 리포지토리를 단일 로컬 .repo 파일로 엑스포트합니다."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "리포지토리를 읽는 중 오류 발생:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "%s을(를) 열어 쓸 수 없습니다."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "쓰기 권한이 없는 것 같습니다."
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "리포지토리가 %s(으)로 엑스포트되었습니다."
@@ -3489,20 +3544,20 @@ msgstr "리포지토리가 %s(으)로 엑스포트되었습니다."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "새로 고침"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "리포지토리가 정의되지 않았습니다."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr "'zypper addrepo' 명령을 사용하여 리포지토리를 하나 이상 추가하십시오."
 
@@ -3528,7 +3583,8 @@ msgstr "지정된 리포지토리를 수정합니다."
 msgid ""
 "Modify properties of repositories specified by alias, number, or URI, or by "
 "the '%1%' aggregate options."
-msgstr "별칭, 번호 또는 URI로 지정된 서비스의 속성을 수정하거나 통합 옵션 '%1%'(으)"
+msgstr ""
+"별칭, 번호 또는 URI로 지정된 서비스의 속성을 수정하거나 통합 옵션 '%1%'(으)"
 "로 지정된 서비스의 속성을 수정합니다."
 
 #: src/commands/repos/modify.cc:89
@@ -3551,8 +3607,8 @@ msgid ""
 "Refresh repositories specified by their alias, number or URI. If none are "
 "specified, all enabled repositories will be refreshed."
 msgstr ""
-"별칭, 번호 또는 URI별로 지정한 리포지토리를 새로 고칩니다. 아무 것도 "
-"지정하지 않은 경우 활성화된 모든 리포지토리가 새로 고쳐집니다."
+"별칭, 번호 또는 URI별로 지정한 리포지토리를 새로 고칩니다. 아무 것도 지정하"
+"지 않은 경우 활성화된 모든 리포지토리가 새로 고쳐집니다."
 
 #. translators: -f, --force
 #: src/commands/repos/refresh.cc:80 src/commands/services/refresh.cc:113
@@ -3606,7 +3662,7 @@ msgstr "'%s' 전체 옵션은 여기서 아무런 의미가 없습니다."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "'%s'이(가) 사용될 경우 인수가 허용되지 않습니다."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "지정된 리포지토리: "
 
@@ -3615,7 +3671,7 @@ msgstr "지정된 리포지토리: "
 msgid "Refreshing repository '%s'."
 msgstr "'%s' 리포지토리를 새로 고치는 중입니다."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "비활성화된 '%s' 리포지토리의 컨텐트를 스캔 중입니다."
@@ -3625,7 +3681,7 @@ msgstr "비활성화된 '%s' 리포지토리의 컨텐트를 스캔 중입니다
 msgid "Skipping disabled repository '%s'"
 msgstr "비활성화된 리포지토리 '%s'을(를) 건너뛰는 중"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "위의 오류로 인해 '%s' 리포지토리를 건너뛰고 있습니다."
@@ -3652,7 +3708,7 @@ msgstr "'%s' 또는 '%s' 명령을 사용하여 리포지토리를 추가하거�
 msgid "Could not refresh the repositories because of errors."
 msgstr "오류로 인해 리포지토리를 새로 고칠 수 없습니다."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "오류로 인해 일부 리포지토리가 새로 고쳐지지 않았습니다."
 
@@ -3707,12 +3763,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "'%s' 리포지토리의 이름이 '%s'(으)로 변경되었습니다."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "이름이 '%s'인 리포지토리가 이미 있습니다. 다른 별칭을 사용하십시오."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "리포지토리를 수정하는 중 오류 발생:"
 
@@ -3749,8 +3805,9 @@ msgstr "'%s' 리포지토리를 찾을 수 없습니다."
 msgid ""
 "Invalid priority '%s'. Use a positive integer number. The greater the "
 "number, the lower the priority."
-msgstr "잘못된 우선순위 '%s'입니다. 양의 정수를 사용하십시오. 숫자가 클수록 "
-"우선순위는 낮습니다."
+msgstr ""
+"잘못된 우선순위 '%s'입니다. 양의 정수를 사용하십시오. 숫자가 클수록 우선순위"
+"는 낮습니다."
 
 #: src/commands/reposerviceoptionsets.cc:72
 msgid "Set a descriptive name for the service."
@@ -3851,12 +3908,14 @@ msgstr "'%1%'에 대한 속기입니다."
 
 #: src/commands/reposerviceoptionsets.cc:143
 msgid "Enable GPG check but allow the repository metadata to be unsigned."
-msgstr "GPG 확인을 활성화하지만 리포지토리 메타데이터가 서명되지 않도록 허용합니다."
+msgstr ""
+"GPG 확인을 활성화하지만 리포지토리 메타데이터가 서명되지 않도록 허용합니다."
 
 #: src/commands/reposerviceoptionsets.cc:144
 msgid ""
 "Enable GPG check but allow installing unsigned packages from this repository."
-msgstr "GPG 확인을 활성화하지만 이 리포지토리에서 서명되지 않은 패키지를 설치하도록 "
+msgstr ""
+"GPG 확인을 활성화하지만 이 리포지토리에서 서명되지 않은 패키지를 설치하도록 "
 "허용합니다."
 
 #: src/commands/reposerviceoptionsets.cc:145
@@ -3867,8 +3926,9 @@ msgstr "이 리포지토리에 대해 GPG 확인을 비활성화합니다."
 msgid ""
 "Use the global GPG check setting defined in /etc/zypp/zypp.conf. This is the "
 "default."
-msgstr "/etc/zypp/zypp.conf에 정의된 전역 GPG 검사 설정을 사용하십시오. 이는 "
-"기본값입니다."
+msgstr ""
+"/etc/zypp/zypp.conf에 정의된 전역 GPG 검사 설정을 사용하십시오. 이는 기본값입"
+"니다."
 
 #. translators: -a, --alias
 #: src/commands/reposerviceoptionsets.cc:182
@@ -3942,8 +4002,9 @@ msgstr "리포지토리 우선순위별로 목록을 정렬합니다."
 msgid ""
 "For an extended search including not yet activated remote resources please "
 "use '%1%'."
-msgstr "아직 활성화되지 않은 원격 리소스를 포함한 확장 검색의 경우 '%1%'을(를) "
-"사용하십시오."
+msgstr ""
+"아직 활성화되지 않은 원격 리소스를 포함한 확장 검색의 경우 '%1%'을(를) 사용하"
+"십시오."
 
 #. translator: %1% denotes a zypper command to execute. Like 'zypper search-packages'.
 #: src/commands/search/search-packages-hinthack.cc:74
@@ -3951,16 +4012,18 @@ msgstr "아직 활성화되지 않은 원격 리소스를 포함한 확장 검�
 msgid ""
 "The package providing this subcommand is currently not installed. You can "
 "install it by calling '%1%'."
-msgstr "이 하위 명령을 제공하는 패키지가 현재 설치되지 않았습니다. '%1%'을(를) "
-"호출하여 설치할 수 있습니다."
+msgstr ""
+"이 하위 명령을 제공하는 패키지가 현재 설치되지 않았습니다. '%1%'을(를) 호출하"
+"여 설치할 수 있습니다."
 
 #: src/commands/search/search-packages-hinthack.cc:87
 #, boost-format
 msgid ""
 "For an extended search including not yet activated remote resources you may "
 "run '%1%' at any time."
-msgstr "아직 활성화되지 않은 원격 리소스를 포함한 확장 검색을 위해 언제든지 "
-"'%1%'을(를) 실행할 수 있습니다."
+msgstr ""
+"아직 활성화되지 않은 원격 리소스를 포함한 확장 검색을 위해 언제든지 '%1%'을"
+"(를) 실행할 수 있습니다."
 
 #: src/commands/search/search-packages-hinthack.cc:88
 #, boost-format
@@ -3992,7 +4055,8 @@ msgstr "지정된 검색 문자열과 일치하는 패키지를 검색합니다.
 msgid ""
 "* and ? wildcards can also be used within search strings. If a search string "
 "is enclosed in '/', it's interpreted as a regular expression."
-msgstr "* 및 ? 와일드카드를 검색 문자열에 사용할 수도 있습니다. 검색 문자열이 '/'로 "
+msgstr ""
+"* 및 ? 와일드카드를 검색 문자열에 사용할 수도 있습니다. 검색 문자열이 '/'로 "
 "묶여 있는 경우 정규식으로 해석됩니다."
 
 #. translators: --match-substrings
@@ -4116,8 +4180,9 @@ msgstr "지정된 유형의 패키지만 검색합니다."
 msgid ""
 "Useful together with dependency options, otherwise searching in package name "
 "is default."
-msgstr "종속성 옵션과 함께 사용할 경우 유용합니다. 그렇지 않으면 패키지 이름에서 "
-"검색이 기본값입니다."
+msgstr ""
+"종속성 옵션과 함께 사용할 경우 유용합니다. 그렇지 않으면 패키지 이름에서 검색"
+"이 기본값입니다."
 
 #. translators: -f, --file-list
 #: src/commands/search/search.cc:189
@@ -4146,25 +4211,25 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr "마찬가지로 검색이 일치된 추가 정보를 포함합니다(종속성 검색에 유용)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "지정된 리포지토리 '%s'이(가) 비활성화되었습니다."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "일치하는 항목이 없습니다."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "검색 쿼리를 초기화하거나 실행하는 중 문제가 발생했습니다."
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "자세한 내용은 위의 메시지를 참조하십시오."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "'zypper refresh'를 루트 권한으로 실행하여 문제를 해결할 수 있습니다."
 
@@ -4255,7 +4320,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "'%s' 서비스에 대한 리포지토리 색인 파일을 검색하는 중 문제 발생:"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "위의 오류로 인해 '%s' 서비스를 건너뛰고 있습니다."
@@ -4274,23 +4339,28 @@ msgstr "'%s' 서비스 제거 중:"
 msgid "Service '%s' has been removed."
 msgstr "'%s' 서비스가 제거되었습니다."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [옵션]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "정의된 모든 서비스를 나열합니다."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "정의된 서비스를 나열합니다."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
-msgstr "정의된 서비스가 없습니다. '%s' 명령을 사용하여 서비스를 한 개 이상 "
-"추가하십시오."
+msgstr ""
+"정의된 서비스가 없습니다. '%s' 명령을 사용하여 서비스를 한 개 이상 추가하십시"
+"오."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4312,7 +4382,8 @@ msgstr "지정된 서비스를 수정합니다."
 msgid ""
 "Modify properties of services specified by alias, number, or URI, or by the "
 "'%1%' aggregate options."
-msgstr "별칭, 번호 또는 URI로 지정된 서비스의 속성을 수정하거나 통합 옵션 '%1%'(으)"
+msgstr ""
+"별칭, 번호 또는 URI로 지정된 서비스의 속성을 수정하거나 통합 옵션 '%1%'(으)"
 "로 지정된 서비스의 속성을 수정합니다."
 
 #: src/commands/services/modify.cc:41
@@ -4630,8 +4701,8 @@ msgid ""
 "executing '%2%'."
 msgstr ""
 "RPM에서 소스 패키지를 설치하는 기본 위치는 '%1%'입니다. 하지만 이 값은 로컬 "
-"RPM 구성에 변경할 수 있습니다. 확실하지 않은 경우에는 '%2%'을(를) 실행해 "
-"보십시오."
+"RPM 구성에 변경할 수 있습니다. 확실하지 않은 경우에는 '%2%'을(를) 실행해 보십"
+"시오."
 
 #. translators: -d, --build-deps-only
 #: src/commands/sourceinstall.cc:48
@@ -4732,8 +4803,8 @@ msgstr ""
 "zypper_execdir('%1%')에 상주하는 독립 실행 파일입니다.\n"
 "\n"
 "zypper는 하위 명령을 위해 \n"
-"하위 명령의 상주 위치를 알고 있는 래퍼를 제공하며 명령행 인수를 "
-"전달함으로써\n"
+"하위 명령의 상주 위치를 알고 있는 래퍼를 제공하며 명령행 인수를 전달함으로"
+"써\n"
 "이들을 실행합니다.\n"
 "\n"
 "하위 명령이 zypper_execdir에서 발견되지 않으면 래퍼는\n"
@@ -4813,8 +4884,9 @@ msgstr "설치된 패키지를 새 버전으로 업데이트합니다."
 #: src/commands/update.cc:26
 msgid ""
 "Update all or specified installed packages with newer versions, if possible."
-msgstr "가능한 경우 설치된 모든 패키지나 지정된 패키지를 최신 버전으로 "
-"업데이트합니다."
+msgstr ""
+"가능한 경우 설치된 모든 패키지나 지정된 패키지를 최신 버전으로 업데이트합니"
+"다."
 
 #: src/commands/update.cc:69 src/commands/update.cc:76
 #: src/commands/update.cc:123
@@ -4832,8 +4904,8 @@ msgid ""
 "Zypper does not keep track of installed source packages. To install the "
 "latest source package and its build dependencies, use '%s'."
 msgstr ""
-"Zypper는 설치된 소스 패키지를 추적하지 않습니다. 최신 소스 패키지와 빌드 "
-"종속관계를 설치하려면 '%s'을(를) 사용하십시오."
+"Zypper는 설치된 소스 패키지를 추적하지 않습니다. 최신 소스 패키지와 빌드 종속"
+"관계를 설치하려면 '%s'을(를) 사용하십시오."
 
 #: src/commands/update.cc:83
 msgid ""
@@ -4875,16 +4947,17 @@ msgid ""
 "tried to download. Upon success the local path is is found in 'download-"
 "result/localpath@path'."
 msgstr ""
-"XML 출력에서 <download-result> 노드는 다운로드를 시도한 각 패키지에 대해 "
-"기록됩니다. 성공하면 로컬 경로를 'download-result/localpath@path'에서 찾을 "
-"수 있습니다."
+"XML 출력에서 <download-result> 노드는 다운로드를 시도한 각 패키지에 대해 기록"
+"됩니다. 성공하면 로컬 경로를 'download-result/localpath@path'에서 찾을 수 있"
+"습니다."
 
 #. translators: --all-matches
 #: src/commands/utils/download.cc:166
 msgid ""
 "Download all versions matching the commandline arguments. Otherwise only the "
 "best version of each matching package is downloaded."
-msgstr "명령줄 인수와 일치하는 모든 버전을 다운로드합니다. 그렇지 않으면 일치하는 각 "
+msgstr ""
+"명령줄 인수와 일치하는 모든 버전을 다운로드합니다. 그렇지 않으면 일치하는 각 "
 "패키지의 최고 버전만 다운로드됩니다."
 
 #. translators: Label text; is followed by ': cmdline argument'
@@ -5081,7 +5154,8 @@ msgstr ""
 msgid ""
 "Don't download any source rpms, but show which source rpms are missing or "
 "extraneous."
-msgstr "소스 rpm을 다운로드하지 않지만, 누락되거나 관련 없는 소스 rpm을 표시합니다."
+msgstr ""
+"소스 rpm을 다운로드하지 않지만, 누락되거나 관련 없는 소스 rpm을 표시합니다."
 
 #. translators: command summary: targetos, tos
 #: src/commands/utils/system-architecture.cc:20
@@ -5183,15 +5257,15 @@ msgstr "%s이(가) %s보다 이전입니다."
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "버전"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "아키텍처"
 
@@ -5324,13 +5398,13 @@ msgstr "(비어 있음)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "종속성"
 
@@ -5368,7 +5442,7 @@ msgid "Flavor"
 msgstr "특징"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "기본"
 
@@ -5506,8 +5580,9 @@ msgstr "라이센스를 확인할 필요가 있어서 설치를 중단하고 있
 msgid ""
 "Please restart the operation in interactive mode and confirm your agreement "
 "with required licenses, or use the %s option."
-msgstr "대화형 모드에서 작업을 다시 시작하고 필요한 라이센스에 동의하는지 여부를 "
-"확인하거나 %s 옵션을 사용하십시오."
+msgstr ""
+"대화형 모드에서 작업을 다시 시작하고 필요한 라이센스에 동의하는지 여부를 확인"
+"하거나 %s 옵션을 사용하십시오."
 
 #. translators: e.g. "... with flash package license."
 #: src/misc.cc:209
@@ -5585,7 +5660,8 @@ msgstr "임시"
 msgid ""
 "Repo '%1%' is managed by service '%2%'. Volatile changes are reset by the "
 "next service refresh!"
-msgstr "'%1%' 리포지토리는 '%2%' 서비스에서 관리됩니다. 다음에 서비스를 새로 고치면 "
+msgstr ""
+"'%1%' 리포지토리는 '%2%' 서비스에서 관리됩니다. 다음에 서비스를 새로 고치면 "
 "임시 변경 사항이 재설정됩니다."
 
 #: src/repos.cc:75
@@ -5608,7 +5684,8 @@ msgstr "예"
 msgid ""
 "Repository priorities are without effect. All enabled repositories share the "
 "same priority."
-msgstr "저장소는 우선순위가 없습니다. 모든 저장소는 같은 우선순위를 공유합니다."
+msgstr ""
+"저장소는 우선순위가 없습니다. 모든 저장소는 같은 우선순위를 공유합니다."
 
 #: src/repos.cc:184
 msgid "Repository priorities in effect:"
@@ -5627,142 +5704,144 @@ msgstr[0] "%1% 저장소"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "%s에 대한 메타 데이터를 새로 고칠지 여부 확인 중"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "'%s' 리포지토리가 최신 상태입니다."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "'%s'의 최신 상태 확인이 지연되었습니다."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "원시 메타 데이터를 강제로 새로 고침 중"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "'%s' 리포지토리 메타 데이터를 검색하는 중"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "%s 리포지토리를 영구적으로 비활성화하시겠습니까?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "'%s' 리포지토리를 비활성화하는 중 오류가 발생했습니다."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "'%s'에서 파일을 검색하는 중 문제가 발생했습니다."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "자세한 내용은 위의 오류 메시지를 확인하십시오."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "'%s'에 정의된 URI가 없습니다."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
-msgstr "'%s' 리포지토리에 대한 %s에 기본 URI(baseurl=URI) 항목을 한 개 이상 "
-"추가하십시오."
+msgstr ""
+"'%s' 리포지토리에 대한 %s에 기본 URI(baseurl=URI) 항목을 한 개 이상 추가하십"
+"시오."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "이 리포지토리에 정의된 별칭이 없습니다."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "'%s' 리포지토리가 잘못되었습니다."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
-msgstr "이 리포지토리에 정의된 URI가 올바른 리포지토리를 가리키고 있는지 "
-"확인하십시오."
+msgstr ""
+"이 리포지토리에 정의된 URI가 올바른 리포지토리를 가리키고 있는지 확인하십시"
+"오."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "'%s'에 대한 메타 데이터를 검색하는 중 오류 발생:"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "리포지토리 캐시를 강제로 빌드 중"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "'%s'에 대한 메타 데이터를 구문 분석하는 중 오류 발생:"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
 "report by following instructions at http://en.opensuse.org/Zypper/"
 "Troubleshooting"
 msgstr ""
-"이것은 리포지토리의 잘못된 메타 데이터나 메타 데이터 구문 분석기의 버그로 "
-"인해 발생했을 수 있습니다. 후자 또는 확실하지 않은 경우 http://"
-"en.opensuse.org/Zypper/Troubleshooting에 있는 지침에 따라 버그 보고서를 "
-"파일로 작성하십시오."
+"이것은 리포지토리의 잘못된 메타 데이터나 메타 데이터 구문 분석기의 버그로 인"
+"해 발생했을 수 있습니다. 후자 또는 확실하지 않은 경우 http://en.opensuse.org/"
+"Zypper/Troubleshooting에 있는 지침에 따라 버그 보고서를 파일로 작성하십시오."
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "로컬 캐시에서 '%s'에 대한 리포지토리 메타 데이터를 찾을 수 없습니다."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "캐시 빌드 중 오류:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "별칭, 번호 또는 URI별로 '%s' 리포지토리를 찾을 수 없습니다."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "'%s'을(를) 사용하여 정의된 리포지토리 목록을 가져옵니다."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "비활성화된 리포지토리 '%s'을(를) 무시하는 중"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
-msgstr "'%s' 전역 옵션을 사용하여 리포지토리를 일시적으로 활성화할 수 있습니다."
+msgstr ""
+"'%s' 전역 옵션을 사용하여 리포지토리를 일시적으로 활성화할 수 있습니다."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "'%s' 리포지토리를 '%s' 옵션으로 인해 무시합니다."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "'%s' 리포지토리를 일시적으로 활성화 중입니다."
@@ -5770,15 +5849,16 @@ msgstr "'%s' 리포지토리를 일시적으로 활성화 중입니다."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
-msgstr "'%s' 리포지토리가 오래되었습니다. 루트 권한으로 'zypper refresh'를 실행하면 "
+msgstr ""
+"'%s' 리포지토리가 오래되었습니다. 루트 권한으로 'zypper refresh'를 실행하면 "
 "업데이트할 수 있습니다."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -5787,285 +5867,289 @@ msgstr ""
 "'%s' 리포지토리에 대한 메타 데이터 캐시를 빌드해야 합니다. 루트 권한으로 "
 "'zypper refresh'를 실행하면 이 작업을 수행할 수 있습니다."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "'%s' 리포지토리가 비활성화 상태입니다."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "대상 초기화 중"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "대상 초기화 실패:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "'%s'에 대한 메타 데이터 캐시를 정리하는 중입니다."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "'%s'에 대한 원시 메타 데이터 캐시를 정리하는 중입니다."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "%s '%s'에 대한 원시 메타 데이터 캐시를 유지하고 있습니다."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "'%s'에 대한 패키지를 정리하는 중입니다."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "오류로 인해 '%s' 리포지토리를 정리할 수 없습니다."
 
 #  progress stages
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "설치된 패키지 캐시를 정리하는 중입니다."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "오류로 인해 설치된 패키지 캐시를 정리할 수 없습니다."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "오류로 인해 리포지토리를 정리할 수 없습니다."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "오류로 인해 일부 리포지토리가 정리되지 않았습니다."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "지정된 리포지토리가 정리되었습니다."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "모든 리포지토리가 정리되었습니다."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
-msgstr "변경 가능한 읽기 전용 미디어(CD/DVD)입니다. 자동 새로 고침을 비활성화하고 "
-"있습니다."
+msgstr ""
+"변경 가능한 읽기 전용 미디어(CD/DVD)입니다. 자동 새로 고침을 비활성화하고 있"
+"습니다."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "잘못된 리포지토리 별칭: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
-msgstr "리포지토리 유형을 결정할 수 없습니다. 정의한 URI(아래 참조)가 올바른 "
-"리포지토리를 가리키고 있는지 확인하십시오."
+msgstr ""
+"리포지토리 유형을 결정할 수 없습니다. 정의한 URI(아래 참조)가 올바른 리포지토"
+"리를 가리키고 있는지 확인하십시오."
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "지정된 위치에서 올바른 리포지토리를 찾을 수 없습니다."
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "지정된 URI에서 리포지토리 데이터를 전송하는 중 문제 발생:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "지정한 URI가 액세스 가능한지 확인하십시오."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "리포지토리 추가 중 알 수 없는 문제 발생:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
-msgstr "'%1%' 리포지토리 구성에서 GPG 검사가 비활성화되었습니다. 패키지의 무결성과 "
-"출처를 확인할 수 없습니다."
+msgstr ""
+"'%1%' 리포지토리 구성에서 GPG 검사가 비활성화되었습니다. 패키지의 무결성과 출"
+"처를 확인할 수 없습니다."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "'%s' 리포지토리가 추가되었습니다."
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "'%s' 미디어에서 데이터를 읽는 중"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "'%s' 미디어에서 데이터를 읽는 중 문제가 발생했습니다."
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "설치 미디어가 유효하고 판독 가능한지 확인하십시오."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "다음 새로 고침까지 '%s' 미디어에서 데이터 읽기가 지연됩니다."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "'%s' 미디어에서 데이터를 읽는 중"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "'%s' 미디어에서 데이터를 읽는 중 문제가 발생했습니다."
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "설치 미디어가 유효하고 판독 가능한지 확인하십시오."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "지정한 URI에서 파일에 액세스하는 중 문제가 발생했습니다."
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "URI가 유효하고 액세스 가능한지 확인하십시오."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "지정한 URI에서 파일 구문을 분석하는 중 문제가 발생했습니다."
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "그것은 .repo 파일입니까?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "지정한 URI에서 파일을 읽으려는 중 문제가 발생했습니다."
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "정의된 별칭이 없는 리포지토리가 파일에 있습니다. 건너뛰는 중입니다."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "'%s' 리포지토리에 URI가 정의되어 있지 않습니다. 건너뛰는 중입니다."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "'%s' 리포지토리가 제거되었습니다."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "'%s' 리포지토리의 우선순위가 변경되지 않았습니다(%d)."
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "'%s' 리포지토리가 활성화되었습니다."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "'%s' 리포지토리가 비활성화되었습니다."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "'%s' 리포지토리의 자동 새로 고침이 활성화되었습니다."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "'%s' 리포지토리의 자동 새로 고침이 비활성화되었습니다."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "'%s' 리포지토리의 RPM 파일 캐싱이 활성화되었습니다."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "'%s' 리포지토리의 RPM 파일 캐싱이 비활성화되었습니다."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "'%s' 리포지토리에 대해 GPG 확인이 활성화되었습니다."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "'%s' 리포지토리에 대해 GPG 확인이 비활성화되었습니다."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "'%s' 리포지토리의 우선순위가 %d(으)로 설정되었습니다."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "'%s' 리포지토리의 이름이 '%s'(으)로 설정되었습니다."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "'%s' 리포지토리에 변경할 항목이 없습니다."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "%s 리포지토리를 변경하지 않은 채로 둡니다."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "리포지토리 데이터 로드 중..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
-msgstr "리포지토리가 정의되지 않았습니다. 설치된 resolvable만 작동 중입니다. 다른 "
-"항목은 설치할 수 없습니다."
+msgstr ""
+"리포지토리가 정의되지 않았습니다. 설치된 resolvable만 작동 중입니다. 다른 항"
+"목은 설치할 수 없습니다."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "리포지토리 '%s' 데이터 검색 중..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "'%s' 리포지토리가 캐싱되지 않았습니다. 캐싱 중..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "'%s'에서 데이터를 로드하는 중 문제가 발생했습니다."
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "'%s' 리포지토리를 새로 고칠 수 없습니다. 이전 캐시를 사용합니다."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "오류로 인해 '%s'에서 Resolvable이 로드되지 않았습니다."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "작업을 실행하기 전에 '%s' 또는 '%s'을(를) 시도하십시오."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6074,30 +6158,30 @@ msgid ""
 msgstr ""
 
 #  progress stages
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "설치된 패키지를 읽는 중..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "설치된 패키지를 읽는 동안 문제 발생:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s'은(는) RPM 파일과 유사합니다. 다운로드를 시도합니다."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "'%s'(으)로 지정한 RPM 파일에 문제가 발생했습니다. 건너뛰는 중입니다."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "%s의 RPM 헤더를 읽는 중 문제가 발생했습니다. RPM 파일입니까?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "일반 RPM 파일 캐시"
 
@@ -6105,25 +6189,25 @@ msgstr "일반 RPM 파일 캐시"
 msgid "System Packages"
 msgstr "시스템 패키지"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "필요한 패치가 없습니다."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "패턴이 없습니다."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "패키지가 없습니다."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "내부 이름"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "제품이 없습니다."
 
@@ -6281,8 +6365,8 @@ msgid ""
 "latest updates. Run '%1%' to list these programs."
 msgstr ""
 "최근 업그레이드에서 삭제하거나 업데이트한 파일 및 라이브러리를 아직 사용하는 "
-"프로그램이 실행 중입니다. 최근 업그레이드를 적용하려면 이러한 프로그램을 "
-"다시 시작해야 합니다. 해당 프로그램을 나열하려면 '%1%'을(를) 실행합니다."
+"프로그램이 실행 중입니다. 최근 업그레이드를 적용하려면 이러한 프로그램을 다"
+"시 시작해야 합니다. 해당 프로그램을 나열하려면 '%1%'을(를) 실행합니다."
 
 #: src/solve-commit.cc:657
 msgid "Update notifications were received from the following packages:"
@@ -6313,8 +6397,9 @@ msgstr "패키지 종속성 확인 중..."
 msgid ""
 "Some of the dependencies of installed packages are broken. In order to fix "
 "these dependencies, the following actions need to be taken:"
-msgstr "설치된 패키지 중 일부 종속성이 손상되었습니다. 이 종속성을 복구하려면 다음 "
-"작업을 수행해야 합니다."
+msgstr ""
+"설치된 패키지 중 일부 종속성이 손상되었습니다. 이 종속성을 복구하려면 다음 작"
+"업을 수행해야 합니다."
 
 #: src/solve-commit.cc:795
 msgid "Root privileges are required to fix broken package dependencies."
@@ -6350,8 +6435,9 @@ msgstr "아니요. 작업을 취소합니다."
 msgid ""
 "Restart solver in no-force-resolution mode in order to show dependency "
 "problems."
-msgstr "종속성 문제를 표시하기 위해 no-force-resolution 모드에서 solver를 다시 "
-"시작합니다."
+msgstr ""
+"종속성 문제를 표시하기 위해 no-force-resolution 모드에서 solver를 다시 시작합"
+"니다."
 
 #. translators: help text for 'v' option in the 'Continue?' prompt
 #: src/solve-commit.cc:828
@@ -6404,7 +6490,8 @@ msgstr "리포지토리에서 패키지 파일을 검색하는 중 문제 발생
 #: src/solve-commit.cc:1020
 #, c-format, boost-format
 msgid "Repository '%s' is out of date. Running '%s' might help."
-msgstr "'%s' 리포지토리가 오래되었습니다. '%s'을(를) 실행하면 도움이 될 수 있습니다."
+msgstr ""
+"'%s' 리포지토리가 오래되었습니다. '%s'을(를) 실행하면 도움이 될 수 있습니다."
 
 #: src/solve-commit.cc:1031
 msgid ""
@@ -6416,8 +6503,8 @@ msgid ""
 "- use another installation medium (if e.g. damaged)\n"
 "- use another repository"
 msgstr ""
-"패키지 무결성 확인에 실패했습니다. 리포지토리나 미디어에 문제가 있는 것 "
-"같습니다. 다음 중 하나를 시도하십시오.\n"
+"패키지 무결성 확인에 실패했습니다. 리포지토리나 미디어에 문제가 있는 것 같습"
+"니다. 다음 중 하나를 시도하십시오.\n"
 "\n"
 "- 이전 명령 재시도\n"
 "- 'zypper refresh'를 사용하여 리포지토리 새로 고침\n"
@@ -6432,15 +6519,17 @@ msgstr "패키지 설치 중이나 패키지 설치 또는 제거 후 문제 발
 msgid ""
 "One of the installed patches requires a reboot of your machine. Reboot as "
 "soon as possible."
-msgstr "설치된 패치 중 하나를 사용하려면 컴퓨터 재부팅이 필요합니다. 최대한 빨리 "
-"재부팅하십시오."
+msgstr ""
+"설치된 패치 중 하나를 사용하려면 컴퓨터 재부팅이 필요합니다. 최대한 빨리 재부"
+"팅하십시오."
 
 #: src/solve-commit.cc:1097
 msgid ""
 "One of the installed patches affects the package manager itself. Run this "
 "command once more to install any other needed patches."
-msgstr "설치된 패치 중 하나가 패키지 관리자 자체에 영향을 줍니다. 이 명령을 다시 "
-"실행하여 다른 필요한 패치를 설치하십시오."
+msgstr ""
+"설치된 패치 중 하나가 패키지 관리자 자체에 영향을 줍니다. 이 명령을 다시 실행"
+"하여 다른 필요한 패치를 설치하십시오."
 
 #: src/solve-commit.cc:1119
 msgid "Dependencies of all installed packages are satisfied."
@@ -6501,7 +6590,7 @@ msgid "Updatestack"
 msgstr "업데이트 스택"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "패치"
 
@@ -6524,7 +6613,7 @@ msgstr "포함된 범주"
 msgid "Needed software management updates will be installed first:"
 msgstr "필요한 소프트웨어 관리 업데이트가 먼저 설치됩니다."
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "업데이트가 없습니다."
 
@@ -6533,50 +6622,50 @@ msgstr "업데이트가 없습니다."
 msgid "The following updates are also available:"
 msgstr "다음 업데이트도 사용할 수 있습니다."
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "패키지 업데이트"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "패턴 업데이트"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "제품 업데이트"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "현재 버전"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "사용 가능한 버전"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "일치하는 문제가 없습니다."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "문제 번호에서 다음 일치 항목이 발견되었습니다."
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "다음 패치의 패치 설명과 일치하는 항목이 발견되었습니다."
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr "bugzilla 문제 번호 %s에 대한 수정사항이 없거나 수정할 필요가 없습니다."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "CVE 문제 번호 %s에 대한 수정사항이 없거나 수정할 필요가 없습니다."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "%s 문제 번호 %s에 대한 수정 사항이 없거나 필요하지 않습니다."
@@ -6657,7 +6746,8 @@ msgstr "'%1%' 플래그는 최대 %2% 번만 사용할 수 있습니다."
 msgid ""
 "Ignoring %s without argument because similar option with an argument has "
 "been specified."
-msgstr "인수와 유사한 옵션이 지정되었기 때문에 인수가 없는 %s은(는) 무시됩니다."
+msgstr ""
+"인수와 유사한 옵션이 지정되었기 때문에 인수가 없는 %s은(는) 무시됩니다."
 
 #: src/utils/flags/flagtypes.cc:235
 msgid "Out of range"
@@ -6771,7 +6861,8 @@ msgstr "해당 버그 보고서를 파일로 작성하십시오."
 #. unless you translate the actual page :)
 #: src/utils/messages.cc:22
 msgid "See http://en.opensuse.org/Zypper/Troubleshooting for instructions."
-msgstr "자세한 내용은 http://en.opensuse.org/Zypper/Troubleshooting을 참조하십시오."
+msgstr ""
+"자세한 내용은 http://en.opensuse.org/Zypper/Troubleshooting을 참조하십시오."
 
 #: src/utils/messages.cc:38
 msgid "Too many arguments."
@@ -6789,21 +6880,22 @@ msgid ""
 "package which might lead to broken dependencies of other packages. It is "
 "recommended to run '%s' after the operation has finished."
 msgstr ""
-"기타 패키지의 종속성이 손실될 수 있는 패키지의 설치 또는 다운로드 문제를 "
-"무시하도록 선택했습니다. 작업이 종료된 후에는 '%s'을(를) 실행하는 것이 "
-"좋습니다."
+"기타 패키지의 종속성이 손실될 수 있는 패키지의 설치 또는 다운로드 문제를 무시"
+"하도록 선택했습니다. 작업이 종료된 후에는 '%s'을(를) 실행하는 것이 좋습니다."
 
 #: src/utils/messages.cc:111
 #, boost-format
 msgid ""
 "Legacy commandline option %1% detected. Please use global option %2% instead."
-msgstr "레거시 명령줄 옵션 %1%이(가) 감지되었습니다. 전역 옵션 %2%을(를) 대신 "
-"사용하십시오."
+msgstr ""
+"레거시 명령줄 옵션 %1%이(가) 감지되었습니다. 전역 옵션 %2%을(를) 대신 사용하"
+"십시오."
 
 #: src/utils/messages.cc:112
 #, boost-format
 msgid "Legacy commandline option %1% detected. Please use %2% instead."
-msgstr "레거시 명령줄 옵션 %1%이(가) 감지되었습니다. %2%을(를) 대신 사용하십시오."
+msgstr ""
+"레거시 명령줄 옵션 %1%이(가) 감지되었습니다. %2%을(를) 대신 사용하십시오."
 
 #: src/utils/messages.cc:118
 #, boost-format
@@ -6832,8 +6924,9 @@ msgstr "전체 옵션 및 명령 목록을 가져오려면 '%s'을(를) 입력�
 msgid ""
 "In case '%1%' is not a typo it's probably not a built-in command, but "
 "provided as a subcommand or plug-in (see '%2%')."
-msgstr "'%1%'은(는) 오타가 아닌 경우 기본 제공 명령이 아니지만 하위 명령 또는 "
-"플러그인으로 제공됩니다('%2%' 참조)."
+msgstr ""
+"'%1%'은(는) 오타가 아닌 경우 기본 제공 명령이 아니지만 하위 명령 또는 플러그"
+"인으로 제공됩니다('%2%' 참조)."
 
 #. translators: %1% and %2% are plug-in packages which might provide it.
 #. translators: The word 'subcommand' also refers to a zypper command and should not be translated.
@@ -6843,8 +6936,8 @@ msgid ""
 "In this case a specific package providing the subcommand needs to be "
 "installed first. Those packages are often named '%1%' or '%2%'."
 msgstr ""
-"이 경우 하위 명령을 제공하는 특정 패키지를 먼저 설치해야합니다. 이러한 "
-"패키지는 종종 '%1%' 또는 '%2%'(으)로 명명됩니다."
+"이 경우 하위 명령을 제공하는 특정 패키지를 먼저 설치해야합니다. 이러한 패키지"
+"는 종종 '%1%' 또는 '%2%'(으)로 명명됩니다."
 
 #: src/utils/misc.cc:93
 msgid "package"
@@ -6990,13 +7083,15 @@ msgstr "호출기를 종료하려면 '%c'을(를) 누르십시오."
 
 #: src/utils/pager.cc:42
 msgid "Use arrows or pgUp/pgDown keys to scroll the text by lines or pages."
-msgstr "화살표 또는 <pgUp>/<pgDown> 키를 사용하여 텍스트를 행이나 페이지별로 "
-"스크롤합니다."
+msgstr ""
+"화살표 또는 <pgUp>/<pgDown> 키를 사용하여 텍스트를 행이나 페이지별로 스크롤합"
+"니다."
 
 #: src/utils/pager.cc:44
 msgid "Use the Enter or Space key to scroll the text by lines or pages."
-msgstr "<Enter> 또는 <스페이스> 키를 사용하여 텍스트를 행이나 페이지별로 "
-"스크롤합니다."
+msgstr ""
+"<Enter> 또는 <스페이스> 키를 사용하여 텍스트를 행이나 페이지별로 스크롤합니"
+"다."
 
 #: src/utils/prompt.cc:43 src/utils/prompt.cc:94
 #, c-format, boost-format
@@ -7050,8 +7145,8 @@ msgid ""
 "option to make zypper use default answers to prompts."
 msgstr ""
 "zypper를 터미널 없이 실행할 경우\n"
-"zypper가 프롬프트에 대해 기본 응답을 사용하도록 하려면 '%s' 전역 옵션을 "
-"사용하십시오."
+"zypper가 프롬프트에 대해 기본 응답을 사용하도록 하려면 '%s' 전역 옵션을 사용"
+"하십시오."
 
 #: src/utils/prompt.cc:278
 #, c-format, boost-format
@@ -7067,14 +7162,16 @@ msgstr "'%s' 응답이 모호합니다."
 #: src/utils/prompt.cc:289
 #, c-format, boost-format
 msgid "Enter '%s' for '%s' or '%s' for '%s' if nothing else works for you."
-msgstr "아무것도 실행되지 않는 경우 '%s'('%s'의 경우) 또는 '%s'('%s'의 경우)을(를) "
-"입력하십시오."
+msgstr ""
+"아무것도 실행되지 않는 경우 '%s'('%s'의 경우) 또는 '%s'('%s'의 경우)을(를) 입"
+"력하십시오."
 
 #: src/utils/prompt.cc:294
 msgid ""
 "If nothing else works enter '#1' to select the 1st option, '#2' for the 2nd "
 "one, ..."
-msgstr "아무것도 실행되지 않는 경우 '#1'을 입력하여 첫 번째 옵션을 선택하고, '#2'를 "
+msgstr ""
+"아무것도 실행되지 않는 경우 '#1'을 입력하여 첫 번째 옵션을 선택하고, '#2'를 "
 "입력하여 두 번째 옵션을, ..."
 
 #. TranslatorExplanation These are reasons for various failures.

--- a/po/ku.po
+++ b/po/ku.po
@@ -5,11 +5,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: memory.ku.po\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Kurdish <https://l10n.opensuse.org/projects/zypper/master/ku/>"
-"\n"
+"Language-Team: Kurdish <https://l10n.opensuse.org/projects/zypper/master/ku/"
+">\n"
 "Language: ku\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "Bila dîsa biceribîne?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 #, fuzzy
 msgid "Unexpected exception."
 msgstr "Tikandina Ne li bendê"
@@ -1397,12 +1397,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2103,24 +2103,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2190,7 +2196,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2372,22 +2378,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2438,49 +2444,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2583,11 +2593,11 @@ msgstr[1] "Hemûyan Rake"
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Nav"
 
@@ -2598,8 +2608,8 @@ msgstr "Pîne"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Cure"
@@ -2607,7 +2617,7 @@ msgstr "Cure"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Arşîv"
@@ -3029,7 +3039,7 @@ msgid "Command"
 msgstr "Ferman"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Servîs"
 
@@ -3190,120 +3200,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3343,12 +3353,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3390,16 +3400,16 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 #, fuzzy
 msgid "URI"
@@ -3407,100 +3417,104 @@ msgstr "URL"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Çalak Bû"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr ""
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Pêşanî"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 #, fuzzy
 msgid "Autorefresh"
 msgstr "Bixweber-Nûkirinê Derbas be "
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Vekirî"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Girtî"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Keep Packages"
 msgstr "Pakêt"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "Destpêkirina Servîsê"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 #, fuzzy
 msgid "MD Cache Path"
 msgstr "Riya Cîhazê"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 #, fuzzy
 msgid "Error reading repositories:"
 msgstr "Arşîvan tomar bike..."
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "%s nehat vebûn."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3508,21 +3522,21 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Nû Bike"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "Arşîvan Rake"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3623,7 +3637,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 #, fuzzy
 msgid "Specified repositories: "
 msgstr "Arşîvan Tomar Bike"
@@ -3633,7 +3647,7 @@ msgstr "Arşîvan Tomar Bike"
 msgid "Refreshing repository '%s'."
 msgstr "Çavkaniyê &Neçalak Bike"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Çavkaniyê &Neçalak Bike"
@@ -3643,7 +3657,7 @@ msgstr "Çavkaniyê &Neçalak Bike"
 msgid "Skipping disabled repository '%s'"
 msgstr "Çavkaniyê &Neçalak Bike"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3670,7 +3684,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3723,12 +3737,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr ""
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 #, fuzzy
 msgid "Error while modifying the repository:"
 msgstr "Demê afirandina arşîvê de çewtiyek çêbû."
@@ -4158,26 +4172,26 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Arşîv nederbasdar e."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "Tu nehat dîtin"
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4268,7 +4282,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr ""
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4287,21 +4301,25 @@ msgstr "Servîsa '%1' nayê zanîn "
 msgid "Service '%s' has been removed."
 msgstr ""
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5184,15 +5202,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Guherto"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr ""
 
@@ -5334,13 +5352,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr ""
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 #, fuzzy
 msgid "Dependency"
 msgstr "Girêdayî"
@@ -5379,7 +5397,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5641,94 +5659,94 @@ msgstr[1] "Arşîv"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr ""
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr ""
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Meta-dana ya arşîvê nederbasdar e."
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Tu bi rastî dixwazî vê têketinê jê bibî?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Çavkaniyê &Neçalak Bike"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr ""
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr ""
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr ""
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Meta-dana ya arşîvê nederbasdar e."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr ""
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5736,41 +5754,41 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, fuzzy, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Meta-dana ya arşîvê nederbasdar e."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr ""
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Çavkaniyê &Neçalak Bike"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr ""
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Çavkaniyê &Neçalak Bike"
@@ -5778,297 +5796,297 @@ msgstr "Çavkaniyê &Neçalak Bike"
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Meta-dana ya arşîvê nederbasdar e."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 #, fuzzy
 msgid "Initializing Target"
 msgstr "Tê Amadekirin"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr ""
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr ""
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 #, fuzzy
 msgid "Cleaning installed packages cache."
 msgstr "Pakêtên RPM yên sazkirî kontrol dike..."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr ""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr ""
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr ""
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr ""
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr ""
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr ""
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr ""
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr ""
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, fuzzy, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Arşîv nederbasdar e."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 #, fuzzy
 msgid "Loading repository data..."
 msgstr "Arşîvan tomar bike..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Çavkaniyên nivîsbarî yê nû dike..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6076,32 +6094,32 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "Pakêtên Sazkirî Bixwîne"
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Demê xwendina rojnivîskê de çewtî çêbû."
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6110,29 +6128,29 @@ msgstr ""
 msgid "System Packages"
 msgstr "Pakêtên Tên Pêşniyazkirin"
 
-#: src/search.cc:261
+#: src/search.cc:262
 #, fuzzy
 msgid "No needed patches found."
 msgstr "Pîne yên Hewce"
 
-#: src/search.cc:342
+#: src/search.cc:344
 #, fuzzy
 msgid "No patterns found."
 msgstr "Tu nehat dîtin"
 
-#: src/search.cc:450
+#: src/search.cc:453
 #, fuzzy
 msgid "No packages found."
 msgstr "Pakêta '%s' nehat dîtin."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "Înternet"
 
-#: src/search.cc:544
+#: src/search.cc:549
 #, fuzzy
 msgid "No products found."
 msgstr "berhem"
@@ -6511,7 +6529,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Pîne"
 
@@ -6535,7 +6553,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "Ew pakêt hewce ne ku bên sazkirin:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 #, fuzzy
 msgid "No updates found."
 msgstr "Tu nehat dîtin"
@@ -6546,56 +6564,56 @@ msgstr "Tu nehat dîtin"
 msgid "The following updates are also available:"
 msgstr "Pakêt tune ye."
 
-#: src/update.cc:700
+#: src/update.cc:707
 #, fuzzy
 msgid "Package updates"
 msgstr "Pakêt"
 
-#: src/update.cc:704
+#: src/update.cc:711
 #, fuzzy
 msgid "Pattern updates"
 msgstr "Nîgar"
 
-#: src/update.cc:706
+#: src/update.cc:713
 #, fuzzy
 msgid "Product updates"
 msgstr "Navê Berhemê"
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "Roja Niha"
 
-#: src/update.cc:795
+#: src/update.cc:801
 #, fuzzy
 msgid "Available Version"
 msgstr "Pelên Heyî"
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "Tu nehat dîtin"
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Lithuanian <https://l10n.opensuse.org/projects/zypper/master/"
@@ -1575,7 +1575,7 @@ msgstr "PackageKit vis dar veikia (greičiausiai užimtas)."
 msgid "Try again?"
 msgstr "Bandyti vėl?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Netikėta išimtis."
 
@@ -1603,12 +1603,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Čia parinktis %s yra neveiksni, nepaisoma."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Programos argumentai, nereikalaujantys argumentų: "
 
@@ -2328,17 +2328,17 @@ msgid "Commands:"
 msgstr "Komandos:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Rodyti išsamią diegimo santrauką."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Paketo tipas (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2346,8 +2346,14 @@ msgstr ""
 "Įvykdyti „geriausio bandymo“ atnaujinimą. Taip pat galimi atnaujinimai ne "
 "iki pačios naujausios versijos."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2421,7 +2427,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <pokomandis> [--komandos-parinktys] [argumentai]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Rodyti pagalbą"
 
@@ -2605,22 +2611,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Visų prieinamų pataisų sąrašas."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Visų pritaikomų pataisų sąrašas."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2673,49 +2679,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2821,11 +2831,11 @@ msgstr[3] "Atrakintas %lu."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Pavadinimas"
 
@@ -2835,8 +2845,8 @@ msgstr "Atitinka"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Tipas"
@@ -2844,7 +2854,7 @@ msgstr "Tipas"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Saugykla"
@@ -2901,7 +2911,8 @@ msgstr "Nėra užrakintų paketų."
 # =============================================================================
 #: src/commands/locks/remove.cc:25
 msgid "removelock (rl) [OPTIONS] <LOCK-NUMBER|PACKAGENAME> ..."
-msgstr "removelock (rl) [parinktys] <užrakinimo_numeris|paketo_pavadinimas> ..."
+msgstr ""
+"removelock (rl) [parinktys] <užrakinimo_numeris|paketo_pavadinimas> ..."
 
 #: src/commands/locks/remove.cc:26
 msgid "Remove a package lock."
@@ -3270,7 +3281,7 @@ msgid "Command"
 msgstr "Komanda"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Paslauga"
 
@@ -3435,120 +3446,120 @@ msgid "Show detailed information for products."
 msgstr "Pateikia išsamią informaciją apie produktus."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Rodyti visus prieinamus paketus."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [saugykla] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Rodyti visas prieinamas pataisas."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Pateikti visų pataisų, pasiekiamų konkrečiose saugyklose, sąrašą."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [parinktys] [saugykla] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Rodyti visus prieinamus šablonus."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Pateikti visų šablonų, pasiekiamų nurodytose saugyklose, sąrašą."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [parinktys] [saugykla] .."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Rodyti visus prieinamus produktus."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Pateikti visų produktų, pasiekiamų nurodytose saugyklose, sąrašą."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3587,12 +3598,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "Negalima %s naudoti kartu su %s. Naudojama %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3636,111 +3647,115 @@ msgstr "Išvalyti neapdorotų meta duomenų podėlį."
 msgid "Clean both metadata and package caches."
 msgstr "Išvalyti tiek meta duomenų, tiek ir paketų podėlį."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Pseudonimas"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Įgalinta"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "GPG patikra"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Prioritetas"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Atsinaujinti"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Įjungta"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Išjungta"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Išlaikyti paketus"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "GPG rakto URI"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Kelio pradžia"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Pirminė paslauga"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Raktažodžiai"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Saug Info Kelias"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "MD podėlio kelias"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [parinktys] [saugykla] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Pateikia aprašytų saugyklų sąrašą."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "Visas aprašytas saugyklas eksportuoja į vieną vietinę .repo rinkmeną."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Klaida skaitant saugyklas:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Nepavyksta atidaryti %s rašymui."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Galbūt neturite leidimo įrašyti?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Saugykla sėkmingai eksportuota į %s."
@@ -3748,20 +3763,20 @@ msgstr "Saugykla sėkmingai eksportuota į %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Atnaujinti"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Nenurodyta nė viena saugykla."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 "Norėdami pridėti vieną ar daugiau saugyklų, naudokite komandą „zypper "
@@ -3866,7 +3881,7 @@ msgstr "Čia bendra parinktis „%s“ yra neveiksni."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Argumentai neleiskite, jei naudojama  „%s“."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Nurodytos saugyklos:"
 
@@ -3875,7 +3890,7 @@ msgstr "Nurodytos saugyklos:"
 msgid "Refreshing repository '%s'."
 msgstr "Atnaujinama saugykla „%s“."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Peržvelgiamas uždraustos saugyklos „%s“ turinys."
@@ -3885,7 +3900,7 @@ msgstr "Peržvelgiamas uždraustos saugyklos „%s“ turinys."
 msgid "Skipping disabled repository '%s'"
 msgstr "Praleidžiama uždrausta saugykla „%s“."
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Saugykla „%s“ praleidžiama dėl įvykusios klaidos."
@@ -3913,7 +3928,7 @@ msgstr "Saugyklų pridėjimui ar įgalinimui naudokite komandas „%s“ arba �
 msgid "Could not refresh the repositories because of errors."
 msgstr "Dėl įvykusių klaidų negalima atnaujinti saugyklų."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Dėl įvykusių klaidų kai kurios saugyklos nebuvo atnaujintos."
 
@@ -3969,12 +3984,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Saugyklos „%s“ pavadinimas pakeistas į „%s“"
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "Saugykla pavadinimu „%s“ jau yra. Nurodykite kitą pseudonimą."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Keičiant saugyklą įvyko klaida:"
 
@@ -4406,25 +4421,25 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Nurodyta saugykla „%s“ yra uždrausta."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Atitikmenų nerasta."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Nesklandumai paruošiant ar paiešką"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Žiūrėkite užuominą virš pranešimo."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 "Šią bėdą galite išspręsti prisijungę kaip root naudotojas ir įvykdę „zypper "
@@ -4516,7 +4531,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Nesklandumai gaunant paslaugos „%s“ turinio rinkmeną."
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Dėl įvykusios klaidos praleidžiama paslauga „%s“."
@@ -4535,24 +4550,28 @@ msgstr "Pašalinama paslauga „%s“:"
 msgid "Service '%s' has been removed."
 msgstr "Paslauga „%s“ pašalinta."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [parinktys]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Parodyti visas apibrėžtas paslaugas."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Pateikia aprašytų paslaugų sąrašą."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Nerasta jokių paslaugų. Norėdami pridėti vieną ar daugiau paslaugų, "
 "naudokite komandą „%s“."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4844,7 +4863,8 @@ msgstr "Sukurti priklausomybių sprendimo aprašą derinimui."
 msgid ""
 "Force the solver to find a solution (even an aggressive one) rather than "
 "asking."
-msgstr "Priverstinai rasti priklausomybių sprendimą (leistina net ir agresyvų)."
+msgstr ""
+"Priverstinai rasti priklausomybių sprendimą (leistina net ir agresyvų)."
 
 #: src/commands/solveroptionset.cc:63
 msgid "Do not force the solver to find a solution, let it ask."
@@ -5444,15 +5464,15 @@ msgstr "%s senesnis už %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Versija"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arch"
 
@@ -5588,13 +5608,13 @@ msgstr "(tuščia)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "B"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Priklausomybė"
 
@@ -5631,7 +5651,7 @@ msgid "Flavor"
 msgstr "Atmaina"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Yra pagrindinis"
 
@@ -5896,57 +5916,57 @@ msgstr[3] "%1% saugykla"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Tikrinama, ar atnaujinti %s metaduomenis "
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Saugykla „%s“ atnaujinta."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "„%s“ naujumo patikrinimas atidėtas."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Priverstinai atnaujinami neapdoroti metaduomenys"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Gaunami saugyklos „%s“ metaduomenys"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Norite visam laikui uždrausti „%s“ saugyklą?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Klaida išjungiat saugyklą „%s“."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Nesklandumai gaunant rinkmenas iš „%s“."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Žiūrėkite aukščiau esančią užuominą."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "„%s“ neturi nurodyto URI."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -5955,37 +5975,37 @@ msgstr ""
 "Nurodykite vieną ar kelis pagrindinius URI (baseurl=URI) įrašui %s, "
 "saugyklai „%s“."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Šiai saugyklai nepriskirtas joks pseudonimas."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Saugykla „%s“ yra netinkama."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr "Patikrinkite, ar šiai saugyklai nurodytas URI nurodo tinkamą saugyklą."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Gaunant „%s“ metaduomenis įvyko klaida:"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Priverstinai kuriamas saugyklų podėlis"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Nagrinėjant „%s“ metaduomenis įvyko klaida:"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5997,43 +6017,43 @@ msgstr ""
 "prašytume užpildyti ydos pranešimą naudodamiesi http://en.opensuse.org/"
 "Zypper/Troubleshooting instrukcijomis."
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Vietiniame podėlyje nerasti „%s“ saugyklos metaduomenys."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Kuriant podėlį įvyko klaida:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 "Saugyklos „%s“ nepavyko rasti nei pagal jos pseudonimą, nei pagal numerį, "
 "nei pagal URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Norėdami gauti aprašytų saugyklų sąrašą, naudokite „%s“."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Praleidžiama uždrausta saugykla „%s“"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, fuzzy, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr "Saugyklų pridėjimui ar įgalinimui naudokite komandas „%s“ arba „%s“."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Saugyklos „%s“ nepaisoma, nes yra parinktis „%s“."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Laikinai įgalinama saugykla „%s“."
@@ -6041,7 +6061,7 @@ msgstr "Laikinai įgalinama saugykla „%s“."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6050,7 +6070,7 @@ msgstr ""
 "Saugykla „%s“ yra senstelėjusi. Prisijungę kaip root naudotojas, galite "
 "paleisti „zypper refresh“ ir taip ją atnaujinti."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6059,107 +6079,107 @@ msgstr ""
 "Saugyklai „%s“ reikia sukurti metaduomenų podėlį. Tai galite padaryti "
 "prisijungę kaip root naudotojas ir įvykdę „zypper refresh“."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Saugykla „%s“ ir toliau bus uždrausta."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Ruošiama paskirtis"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Paskirties paruošti nepavyko:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Išvalomas „%s“ metaduomenų podėlis."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Išvalomas „%s“ neapdorotas metaduomenų podėlis."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Išlaikomas %s „%s“ neapdorotų metaduomenų podėlis."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Išvalomi „%s“ paketai."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Dėl įvykusios klaidos negalima išvalyti saugyklos „%s“."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Išvalomas įdiegtų paketų podėlis."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Dėl įvykusios klaidos negalima išvalyti įdiegtų paketų podėlio."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Dėl įvykusių klaidų negalima išvalyti saugyklų."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Dėl įvykusios klaidos nebuvo išvalytos kai kurios saugyklos."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Nurodytos saugyklos buvo išvalytos."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Buvo išvalytos visos saugyklos."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Tai yra keičiama laikmena (CD/DVD), skirta tik rašymui, tad savaiminį "
 "atnaujinimą išjungiame."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Netinkamas saugyklos pseudonimas „%s“."
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
-"Nepavyksta apibrėžti saugyklos tipo. Patikrinkite, ar nurodytas URI ("
-"žiūrėkite žemiau) skirtas tinkamai saugyklai:"
+"Nepavyksta apibrėžti saugyklos tipo. Patikrinkite, ar nurodytas URI "
+"(žiūrėkite žemiau) skirtas tinkamai saugyklai:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Nurodytoje vietoje nepavyksta rasti tinkamos saugyklos:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Nesklandumai perduodant duomenis iš nurodyto URI:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Patikrinkite, ar nurodytas URI yra prieinamas."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Pridedant saugykla įvyko nežinoma klaida:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6168,135 +6188,135 @@ msgstr ""
 "„%1%“ saugyklos konfigūracijoje GPG tikrinimas uždraustas. Negalima "
 "patikrinti paketų vientisumo ir kilmės."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Saugykla „%s“ pridėta sėkmingai"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Skaitomi duomenys iš laikmenos „%s“"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Nesklandumai skaitant duomenis iš laikmenos %s“"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Patikrinkite, ar jūsų diegimo laikmena yra tinkama ir nuskaitoma."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Duomenų skaitymas iš laikmenos „%s“ atidedamas iki kito atnaujinimo."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Skaitomi duomenys iš laikmenos „%s“"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Nesklandumai skaitant duomenis iš laikmenos %s“"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Patikrinkite, ar jūsų diegimo laikmena yra tinkama ir nuskaitoma."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Nesklandumai mėginant nurodytu URI prieiti prie rinkmenos"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Patikrinkite, ar URI yra tinkamas ir prieinamas."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Nesklandumai nagrinėjant rinkmeną duotuoju URI"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Ar tai .repo rinkmena?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Nesklandumų kilo mėginant duotuoju URI nuskaityti rinkmeną"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Praleidžiama saugykla, neturinti rinkmenoje nurodyto pseudonimo."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Saugyklai „%s“ nenurodytas URI, praleidžiama."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Saugykla „%s“ pašalinta."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Saugyklos „%s“ prioritetas nepakeistas (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Saugykla „%s“ sėkmingai įgalinta."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Saugykla „%s“ sėkmingai uždrausta."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Saugyklai „%s“ savaiminis atnaujinimas sėkmingai įjungtas."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Saugyklai „%s“ savaiminis atnaujinimas sėkmingai uždraustas."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Saugyklai „%s“ įgalintas RPM rinkmenų podėlis."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Saugyklai „%s“ uždraustas RPM rinkmenų podėlis."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Saugyklai „%s“ įgalintas GPG tikrinimas."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Saugyklai „%s“ uždraustas GPG tikrinimas."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Saugyklai „%s“ nustatytas prioritetas %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Saugyklai „%s“ nustatytas pavadinimas „%s“."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Saugykla „%s“ nepakeista."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Saugykla „%s“ paliekama nepakeista."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Įkeliami saugyklų duomenys..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6304,43 +6324,43 @@ msgstr ""
 "Dėmesio: neapibrėžta jokia saugykla. Naudojami tik įdiegti paketai. Nieko "
 "negalima įdiegti."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Gaunami saugyklos „%s“ duomenys..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Saugykla „%s“ neturi podėlio. Sukuriamas podėlis..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Nesklandumai įkeliant duomenis iš „%s“"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "Negalima atnaujinti saugyklos „%s“. Naudojamas senas podėlis."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Dėl įvykusios klaidos neįkelti sprendimai iš „%s“."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Prieš tai darydami, pabandykite „%s“ arba net „%s“."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6348,30 +6368,30 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Skaitomi įdiegti paketai..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Skaitant įdiegtus paketus, kilo nesklandumų:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "„%s“ regis yra RPM rinkmena. Bus bandoma ją parsiųsti."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Nesklandumai su RPM rinkmena, nurodyta kaip „%s“, praleidžiama."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Nesklandumai skaitant %s RPM antraštę. Ar tai RPM rinkmena?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Ištisas RPM rinkmenų podėlis"
 
@@ -6379,25 +6399,25 @@ msgstr "Ištisas RPM rinkmenų podėlis"
 msgid "System Packages"
 msgstr "Sistemos paketai"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Nerasta reikalingų pataisų."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Šablonų nerasta."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Paketų nerasta."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Vidinis pavadinimas"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Produktų nerasta."
 
@@ -6812,7 +6832,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Pataisos"
 
@@ -6835,7 +6855,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "Pirmiausia įdiegsimi reikalingiausi programinės įrangos atnaujinimai:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Atnaujinimų nerasta."
 
@@ -6844,50 +6864,50 @@ msgstr "Atnaujinimų nerasta."
 msgid "The following updates are also available:"
 msgstr "Taip pat galimi šie atnaujinimai:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Paketų atnaujinimai"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Šablonų atnaujinimai"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Produkto atnaujinimai"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Dabartinė versija"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Galima versija"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Nerasta atitinkančių ydų"
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Rasti šie atitikmenys tarp ydų numerių:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "Atitikmenys rasti šiuose pataisų aprašuose:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr "Bugzilla ydos Nr. %s ištaisymas nerastas arba jo nereikia."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "CVE ydos Nr. %s ištaisymas nerastas arba jo nereikia."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "%s klaidos Nr. %s ištaisymas nerastas arba jo nereikia."

--- a/po/mk.po
+++ b/po/mk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Macedonian <https://l10n.opensuse.org/projects/zypper/master/"
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Try again?"
 msgstr ""
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr ""
 
@@ -1402,12 +1402,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2087,24 +2087,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2174,7 +2180,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2355,22 +2361,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2421,49 +2427,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2564,11 +2574,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr ""
 
@@ -2578,8 +2588,8 @@ msgstr ""
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr ""
@@ -2587,7 +2597,7 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr ""
@@ -3001,7 +3011,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr ""
 
@@ -3161,120 +3171,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3313,12 +3323,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3360,111 +3370,115 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr ""
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr ""
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr ""
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr ""
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr ""
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr ""
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3472,20 +3486,20 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr ""
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr ""
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3586,7 +3600,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr ""
 
@@ -3595,7 +3609,7 @@ msgstr ""
 msgid "Refreshing repository '%s'."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr ""
@@ -3605,7 +3619,7 @@ msgstr ""
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3632,7 +3646,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3685,12 +3699,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr ""
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr ""
 
@@ -4116,25 +4130,25 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr ""
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr ""
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4224,7 +4238,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr ""
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4243,21 +4257,25 @@ msgstr ""
 msgid "Service '%s' has been removed."
 msgstr ""
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5127,15 +5145,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr ""
 
@@ -5269,13 +5287,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr ""
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -5312,7 +5330,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5566,94 +5584,94 @@ msgstr[1] ""
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr ""
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr ""
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr ""
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr ""
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr ""
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr ""
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr ""
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr ""
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr ""
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr ""
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5661,41 +5679,41 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr ""
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr ""
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr ""
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr ""
@@ -5703,294 +5721,294 @@ msgstr ""
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr ""
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr ""
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr ""
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr ""
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr ""
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr ""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr ""
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr ""
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr ""
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr ""
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr ""
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr ""
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr ""
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr ""
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr ""
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr ""
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -5998,30 +6016,30 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr ""
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr ""
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6029,25 +6047,25 @@ msgstr ""
 msgid "System Packages"
 msgstr ""
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr ""
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr ""
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr ""
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr ""
 
@@ -6418,7 +6436,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr ""
 
@@ -6441,7 +6459,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr ""
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr ""
 
@@ -6450,50 +6468,50 @@ msgstr ""
 msgid "The following updates are also available:"
 msgstr ""
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr ""
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr ""
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr ""
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr ""
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr ""
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -2,11 +2,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Marathi <https://l10n.opensuse.org/projects/zypper/master/mr/>"
-"\n"
+"Language-Team: Marathi <https://l10n.opensuse.org/projects/zypper/master/mr/"
+">\n"
 "Language: mr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "इन्स्टॉलेशन ची तयारी सुरु करत आहे..."
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "अनपेक्षित अपवाद"
 
@@ -1396,12 +1396,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2123,24 +2123,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2210,7 +2216,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2396,22 +2402,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2462,49 +2468,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2608,11 +2618,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "नांव"
 
@@ -2623,8 +2633,8 @@ msgstr "पॅच करा"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "प्रकार"
@@ -2632,7 +2642,7 @@ msgstr "प्रकार"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr ""
@@ -3058,7 +3068,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "सर्व्हर"
@@ -3222,120 +3232,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3375,12 +3385,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3422,118 +3432,122 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "सक्षम केले"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 #, fuzzy
 msgid "GPG Check"
 msgstr "डिएनएस चेक"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 #, fuzzy
 msgid "Autorefresh"
 msgstr "ऑटो रिफ्रेश"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 #, fuzzy
 msgid "On"
 msgstr "नाहीं"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Keep Packages"
 msgstr "प्रणाली एरिया आयटेम्स"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 #, fuzzy
 msgid "Path Prefix"
 msgstr "डायल प्रिफिक्स"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "सर्व्हर"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 #, fuzzy
 msgid "Error reading repositories:"
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "फाईलरायटिंगसाठी उघडू शकत नाही."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3541,21 +3555,21 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "पुन्हा सुरू करा"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "ऑटो रिफ्रेश"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3656,7 +3670,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 #, fuzzy
 msgid "Specified repositories: "
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
@@ -3666,7 +3680,7 @@ msgstr "VPN संपर्क परत मिळविण्यात चू�
 msgid "Refreshing repository '%s'."
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
@@ -3676,7 +3690,7 @@ msgstr "VPN संपर्क परत मिळविण्यात चू�
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3705,7 +3719,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3758,12 +3772,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "सेवा चालू नाही"
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 #, fuzzy
 msgid "Error while modifying the repository:"
 msgstr "नोंदी वाचत असताना चूक सापडली."
@@ -4196,27 +4210,27 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "ऑटो रिफ्रेश"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "सेवा चालू नाही"
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 #, fuzzy
 msgid "See the above message for a hint."
 msgstr "कृपया त्रुटी सुधारा व पुन्हा प्रयत्न करा."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4307,7 +4321,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4327,21 +4341,25 @@ msgstr "एंड रिमूव्ह लिंक"
 msgid "Service '%s' has been removed."
 msgstr "सेवा चालू नाही"
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5233,15 +5251,15 @@ msgstr "%s च्या जागी %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "आवृत्ती"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "शिल्प"
 
@@ -5379,13 +5397,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "एस"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -5423,7 +5441,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5690,97 +5708,97 @@ msgstr[1] "सेवा चालू नाही"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, fuzzy, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "आता आपणास प्रणाली थांबवायची आहे?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, fuzzy, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "%s वरून फाईलसूची वाचत आहे"
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 #, fuzzy
 msgid "Please see the above error message for a hint."
 msgstr "कृपया त्रुटी सुधारा व पुन्हा प्रयत्न करा."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, fuzzy, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "नोंदी वाचत असताना चूक सापडली."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 #, fuzzy
 msgid "No alias defined for this repository."
 msgstr "नोंदी वाचत असताना चूक सापडली."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, fuzzy, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 #, fuzzy
 msgid "Forcing building of repository cache"
 msgstr "फाईल्सचे पार्सिंग चालू आहे....."
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, fuzzy, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5788,42 +5806,42 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, fuzzy, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 #, fuzzy
 msgid "Error building the cache:"
 msgstr "प्रमाणपत्राचा संबंध सांगतांना चूक"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, fuzzy, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
@@ -5831,309 +5849,309 @@ msgstr "VPN संपर्क परत मिळविण्यात चू�
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "टार्गेट सुरु करत आहे"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 #, fuzzy
 msgid "Target initialization failed:"
 msgstr "प्रांभिकीकरण अयशस्वी"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, fuzzy, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, fuzzy, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, fuzzy, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, fuzzy, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "%s वरून पॅकेजेस वाचत आहे"
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 #, fuzzy
 msgid "Cleaning installed packages cache."
 msgstr "आवश्यक पॅकेजेस स्थापन करण्यास अपयश."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 #, fuzzy
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "रिसोर्से प्रतिलिपित करु शकलो नाही (डेटाबेस त्रुटी)"
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 #, fuzzy
 msgid "Could not clean the repositories because of errors."
 msgstr "रिसोर्से प्रतिलिपित करु शकलो नाही (डेटाबेस त्रुटी)"
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 #, fuzzy
 msgid "Specified repositories have been cleaned up."
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 #, fuzzy
 msgid "All repositories have been cleaned up."
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, fuzzy, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 #, fuzzy
 msgid "Problem transferring repository data from specified URI:"
 msgstr "फाईल्सचे पार्सिंग चालू आहे....."
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 #, fuzzy
 msgid "Please check whether the specified URI is accessible."
 msgstr " स्क्रिप्ट फाईल अक्सिसेबल नाही "
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 #, fuzzy
 msgid "Unknown problem when adding repository:"
 msgstr "फाईल्सचे पार्सिंग चालू आहे....."
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, fuzzy, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "%s वरून प्रॉडक्ट वाचत आहे"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, fuzzy, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "%s वरून प्रॉडक्ट वाचत आहे"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, fuzzy, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "%s वरून प्रॉडक्ट वाचत आहे"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 #, fuzzy
 msgid "Problem accessing the file at the specified URI"
 msgstr "फाईल्सचे पार्सिंग चालू आहे....."
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 #, fuzzy
 msgid "Please check if the URI is valid and accessible."
 msgstr " स्क्रिप्ट फाईल अक्सिसेबल नाही "
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 #, fuzzy
 msgid "Problem parsing the file at the specified URI"
 msgstr "फाईल्सचे पार्सिंग चालू आहे....."
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 #, fuzzy
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "फाईल्सचे पार्सिंग चालू आहे....."
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 #, fuzzy
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, fuzzy, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, fuzzy, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, fuzzy, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "फाईल्सचे पार्सिंग चालू आहे....."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 #, fuzzy
 msgid "Loading repository data..."
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "VPN संपर्क परत मिळविण्यात चूक '%s'"
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "सेवा चालू नाही"
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6141,32 +6159,32 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "आवश्यक पॅकेजेस स्थापन करण्यास अपयश."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "स्थापना स्रोतमधून वाचत असताना त्रुटी घडली आहे."
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6175,28 +6193,28 @@ msgstr ""
 msgid "System Packages"
 msgstr "प्रणाली एरिया आयटेम्स"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 #, fuzzy
 msgid "No patterns found."
 msgstr "कोणत्याही चुका आढळल्या नाहीत."
 
-#: src/search.cc:450
+#: src/search.cc:453
 #, fuzzy
 msgid "No packages found."
 msgstr "कोणत्याही चुका आढळल्या नाहीत."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "अंतर्गत चूक"
 
-#: src/search.cc:544
+#: src/search.cc:549
 #, fuzzy
 msgid "No products found."
 msgstr "कोणत्याही चुका आढळल्या नाहीत."
@@ -6586,7 +6604,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 #, fuzzy
 msgid "Patches"
 msgstr "पॅच करा"
@@ -6611,7 +6629,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "ह्या पॅकेजना संस्थापित करण्याची आवश्यकता"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr ""
 
@@ -6621,56 +6639,56 @@ msgstr ""
 msgid "The following updates are also available:"
 msgstr "खाली दिलेले रिसोर्सेस मॉडिफाय केलेले आहेत"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 #, fuzzy
 msgid "Pattern updates"
 msgstr "बॅटरीची स्थिती"
 
-#: src/update.cc:706
+#: src/update.cc:713
 #, fuzzy
 msgid "Product updates"
 msgstr "प्रॉडक्टचे नाव"
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "चालू कनेक्शन"
 
-#: src/update.cc:795
+#: src/update.cc:801
 #, fuzzy
 msgid "Available Version"
 msgstr "उपलब्ध मेमरी"
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "सेवा चालू नाही"
 
-#: src/update.cc:978
+#: src/update.cc:986
 #, fuzzy
 msgid "The following matches in issue numbers have been found:"
 msgstr "ह्या पॅकेजना संस्थापित करण्याची आवश्यकता"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Norwegian Bokmål <https://l10n.opensuse.org/projects/zypper/"
@@ -1398,7 +1398,7 @@ msgstr "PackageKit kjører fremdeles (sannsynligvis opptatt)."
 msgid "Try again?"
 msgstr "Vil du forsøke på nytt?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Uventet unntak."
 
@@ -1426,12 +1426,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Valget %s har ingen effekt her, ignorerer."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Programargumenter som ikke er alternativer: "
 
@@ -2144,17 +2144,17 @@ msgid "Commands:"
 msgstr "Kommandoer:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Pakketype (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2162,8 +2162,14 @@ msgstr ""
 "Bruk en 'så godt som mulig'-tilnærming til oppdateringen. Oppdatering til en "
 "eldre versjon enn den nyeste er også akseptabelt."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2236,7 +2242,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Vis zypper hjelp"
 
@@ -2423,22 +2429,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2491,49 +2497,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2635,11 +2645,11 @@ msgstr[1] "Fjernede %lu lås."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Navn"
 
@@ -2650,8 +2660,8 @@ msgstr "Pakkeoppdateringer"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Type"
@@ -2659,7 +2669,7 @@ msgstr "Type"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Pakkebrønn"
@@ -3089,7 +3099,7 @@ msgid "Command"
 msgstr "Kommando"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Tjeneste"
 
@@ -3253,121 +3263,121 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Vis alle tilgjengelige pakker."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [pakkebrønn] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Vis alle tilgjengelige programrettelser."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 "Vis alle tilgjengeligige programrettelser i de spesifiserte pakkebrønnene."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [valg] [pakkebrønn] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Vis alle tilgjengelig mønstre."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Vis alle tilgjengelige mønstre i de spesifiserte pakkebrønnene."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "produkter (pd) [valg] [pakkebrønn] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Vis alle tilgjengelig produkter."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Vis alle tilgjengelige produkter i de spesifiserte pakkebrønnene."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3407,12 +3417,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "Kan ikke bruke %s sammen med %s. Bruker innstillingen %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3455,111 +3465,115 @@ msgstr "Tøm rådatamellomlager."
 msgid "Clean both metadata and package caches."
 msgstr "Tøm både metadata- og pakkemellomlagre."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "aktivert"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "GPG-kontroll"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Prioritet"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Autooppdater"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "På"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Av"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Behold pakker"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI for GPG-nøkkel"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Adresseprefiks"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Overordnet tjeneste"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Sti til MD-mellomlager"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [valg] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Vis alle definerte pakkebrønner."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "Eksporter alle definerte pakkebrønner som en enkelt lokal .repo-fil."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Feil under lesing av pakkebrønner:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Kan ikke åpne%s for lagring."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Du har kanskje ikke skrivetilgang?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Pakkebrønnene ble eksportert til %s."
@@ -3567,21 +3581,21 @@ msgstr "Pakkebrønnene ble eksportert til %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Oppdater"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "Ingen arkiver ble ikke funnet."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 #, fuzzy
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
@@ -3687,7 +3701,7 @@ msgstr "Det globale valget '%s' har ingen effekt her."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Argumenter er ikke tillatt sammen med '%s'."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Angitte pakkebrønner: "
 
@@ -3696,7 +3710,7 @@ msgstr "Angitte pakkebrønner: "
 msgid "Refreshing repository '%s'."
 msgstr "Deaktiverer pakkebrønnen '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Ignorerer deaktivert pakkebrønn '%s'"
@@ -3706,7 +3720,7 @@ msgstr "Ignorerer deaktivert pakkebrønn '%s'"
 msgid "Skipping disabled repository '%s'"
 msgstr "Hopper over deaktivert pakkebrønn '%s'"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Hopper over pakkebrønn '%s' på grunn av feilen overfor."
@@ -3735,7 +3749,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "Kunne ikke oppdatere pakkebrønnene på grunn av feil."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Noen av pakkebrønnene ble ikke oppdatert på grunn av feil."
 
@@ -3790,12 +3804,13 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Pakkebrønnen '%s' har endret navn til '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
-msgstr "En pakkebrønn med navnet '%s' eksisterer allerede. Velg et annet alias."
+msgstr ""
+"En pakkebrønn med navnet '%s' eksisterer allerede. Velg et annet alias."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Feil ved endring av pakkebrønnen:"
 
@@ -4233,26 +4248,26 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Angitt pakkebrønn '%s' er deaktivert."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "Ingen samsvarende oppføringer funnet."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Det oppstod et problem ved initialisering eller kjøring av søket"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Meldingen over innholder kanskje et hint."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "Å kjøre 'zypper refresh' som rot løser ikke alltid problemet."
 
@@ -4342,7 +4357,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Feil under henting av pakkebrønnindeksfil for tjenesten '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Hopper over tjenesten '%s' på grunn av feilen ovenfor."
@@ -4361,24 +4376,28 @@ msgstr "Fjerner tjenesten '%s':"
 msgid "Service '%s' has been removed."
 msgstr "Tjenesten '%s' er fjernet."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [alternativer]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Vis alle definerte tjenester."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Vis definerte tjenester."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Ingen tjenester definert. Bruk kommandoen %s for å legge til én eller flere "
 "tjenester."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4476,7 +4495,8 @@ msgstr "Navnet på tjenesten '%s' er satt til '%s'."
 msgid "Repository '%s' has been added to enabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been added to enabled repositories of service '%s'"
-msgstr[0] "Pakkebrønnen '%s' er lagt til aktiverte pakkebrønner for tjenesten '%s'"
+msgstr[0] ""
+"Pakkebrønnen '%s' er lagt til aktiverte pakkebrønner for tjenesten '%s'"
 msgstr[1] ""
 "Pakkebrønnene '%s' er lagt til aktiverte pakkebrønner for tjenesten '%s'"
 
@@ -5054,7 +5074,8 @@ msgstr ""
 #: src/commands/utils/source-download.cc:203
 #, c-format, boost-format
 msgid "Can't create or access download directory '%s'."
-msgstr "Kan ikke opprette eller har ikke tilgang til nedlastingskatalogen '%s'."
+msgstr ""
+"Kan ikke opprette eller har ikke tilgang til nedlastingskatalogen '%s'."
 
 #: src/commands/utils/source-download.cc:216
 #, c-format, boost-format
@@ -5146,7 +5167,8 @@ msgstr "Ingen kildepakker å laste ned."
 #: src/commands/utils/source-download.cc:481
 #: src/commands/utils/source-download.cc:483
 msgid "Download source rpms for all installed packages to a local directory."
-msgstr "Last ned kilde-rpm-er for alle installerte pakker til en lokal katalog."
+msgstr ""
+"Last ned kilde-rpm-er for alle installerte pakker til en lokal katalog."
 
 #. translators: -d, --directory <DIR>
 #: src/commands/utils/source-download.cc:495
@@ -5267,15 +5289,15 @@ msgstr "%s er eldre enn %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Versjon"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arkitektur"
 
@@ -5410,13 +5432,13 @@ msgstr "(tom)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Avhengighet"
 
@@ -5454,7 +5476,7 @@ msgid "Flavor"
 msgstr "Variant"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Er grunnvalg"
 
@@ -5720,58 +5742,58 @@ msgstr[1] "Pakkebrønn"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Kontrollerer om metadata bør oppdateres for %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Pakkebrønnen '%s' er oppdatert."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "'Oppdatert'-kontrollen for '%s' er forsinket."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Tvinger rå-metadata-oppdatering"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Henter metadata for pakkebrønnen '%s'"
 
 # power-off message
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Vil du deaktivere bakkebrønnen %s permanent?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Feil under deaktivering av pakkebrønnen «%s»."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Kunne ikke hente filer fra '%s'."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Feilmeldingen ovenfor innholder et hint."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Ingen URI-er definert for '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -5780,16 +5802,16 @@ msgstr ""
 "Legg til én eller flere grunnadresser (baseurl=URI) i %s for pakkebrønnen "
 "'%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Ingen aliaser er definert for denne pakkebrønnen."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Pakkebrønnen '%s' er ugyldig."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -5797,22 +5819,22 @@ msgstr ""
 "Kontroller om nettadressene som er angitt for denne pakkebrønnen, peker på "
 "en gyldig pakkebrønn."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Feil under henting av metadata for '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Tvinger bygging av pakkebrønnmellomlager"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Feil under lesing av metadata for '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5823,42 +5845,42 @@ msgstr ""
 "tolkeren. Om det siste er tilfelle, eller om du er usikker, rapporter feilen "
 "ved å følge instruksene på http://en.opensuse.org/Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Pakkebrønnmetadata for %s ble ikke funnet i lokalt mellomlager."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Feil under bygging av mellomlager:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Pakkebrønnen '%s' ikke funnet ved hjelp av alias, nummer eller URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Bruk %s for å vise listen over definerte akriv."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Ignorerer deaktivert pakkebrønn '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, fuzzy, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "Bruk kommandoene '%s' eller '%s' for å legge til eller aktivere pakkebrønner."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Ignorerer pakkebrønnen '%s' på grunn av valget '%s'."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Deaktiverer pakkebrønnen '%s'."
@@ -5866,7 +5888,7 @@ msgstr "Deaktiverer pakkebrønnen '%s'."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -5875,7 +5897,7 @@ msgstr ""
 "Pakkebrønnen '%s' er utdatert. Du kan kjøre 'zypper refresh' som rotbrukeren "
 "for å oppdatere det."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -5884,81 +5906,81 @@ msgstr ""
 "Metadatamellomlageret må bygges for pakkebrønnen '%s'. Du kan kjøre 'zypper "
 "refresh' som rot for å oppdatere."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Pakkebrønnen '%s' er ugyldig."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Initialiserer mål"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Initialisering av mål mislyktes:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Rydder metadatamellomlager for '%s'."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Rydder rådatamellomlager for '%s'."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Beholder rådatamellomlager for %s '%s'."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Rydder pakker for '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Kan ikke rydde pakkebrønnen '%s' på grunn av en feil."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Rydder mellomlager for installerte pakker."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Kan ikke rydde mellomlager for installerte pakker på grunn av en feil."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Kunne ikke rydde pakkebrønnene på grunn av feil."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Noen av pakkebrønnene ble ikke ryddet på grunn av en feil."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Det er ryddet opp i angitte pakkebrønner."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Det er ryddet opp i alle pakkebrønner."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Dette er et skiftende skrivebeskyttet medium (CD/DVD), deaktiverer "
 "autooppdatering."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Ugyldig pakkebrønnalias '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -5966,160 +5988,160 @@ msgstr ""
 "Kunne ikke avgjøre pakkebrønntypen. Kontroller om angitte URI-er (se under) "
 "peker på en gyldig pakkebrønn:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Fant ingen gyldig pakkebrønn på angitt sted:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Problemer med overføring av pakkebrønndata fra angitt URI:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Kontroller om angitt URI er tilgjengelig."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Problemer med å legge til pakkebrønn:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Pakkebrønnen '%s' ble lagt til"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Leser data fra '%s'-mediumet"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Kunne ikke lese data fra '%s'-mediumet"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Kontroller om installasjonsmediet er gyldig og lesbart."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, fuzzy, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Leser data fra '%s'-mediumet"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Leser data fra '%s'-mediumet"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Kunne ikke lese data fra '%s'-mediumet"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Kontroller om installasjonsmediet er gyldig og lesbart."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Problemer med tilgang til filen på angitt URI"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Kontroller om URI-en er gyldig og tilgjengelig."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Problemer med tolking av filen på angitt URI"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Er det en .repo-fil?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Det oppstod problemer med å lese filen på angitt URI"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Pakkebrønn uten definert alias funnet i filen, hopper over."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Pakkebrønnen '%s' har ingen definert URI, hopper over."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Pakkebrønnen '%s' er fjernet."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Prioriteten for pakkebrønnen '%s' er uendret (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Pakkebrønnen '%s' er aktivert."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Pakkebrønnen '%s' er deaktivert."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Automatisk oppdatering er aktivert for pakkebrønnen '%s'."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Automatisk oppdatering er deaktivert for pakkebrønnen '%s'."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Mellomlagring av RPM-filer er aktivert for pakkebrønnen '%s'."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Mellomlagring av RPM-filer er deaktivert for pakkebrønnen '%s'."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "GPG-kontroll er aktivert for pakkebrønnen '%s'."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "GPG-kontroll er deaktivert for pakkebrønnen '%s'."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Prioriteten for pakkebrønnen '%s' er satt til %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Navnet på pakkebrønnen '%s' er satt til '%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Ingenting å endre for pakkebrønnen '%s'."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Lar pakkebrønnen %s være uendret."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Laster pakkebrønndata..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 #, fuzzy
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
@@ -6128,43 +6150,43 @@ msgstr ""
 "Advarsel: Ingen pakkebrønn angitt. Bruker bare installerte nødvendige "
 "pakker. Ingen nye kan installeres."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Henter data for pakkebrønnen '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Pakkebrønnen '%s' finnes ikke i mellomlager. Mellomlagrer..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Kunne ikke lese data fra '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "Pakkebrønnen '%s' kunne ikke oppdateres. Bruker gammelt mellomlager."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "På grunn av feil, ble ikke nødvendige pakker fra '%s' lastet."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Forsøk '%s' eller '%s' før du gjør dette."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6172,31 +6194,31 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Leser installerte pakker..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Det oppstod en feil ved lesing av installerte pakker:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' ser ut som an RPM-fil. Forsøker å laste den ned."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Problem med RPM-filen '%s', hopper over den."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Problem med å lese RPM-deklarasjonen for %s. Er det en RPM-fil?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Rent RPM-mellomlager"
 
@@ -6204,25 +6226,25 @@ msgstr "Rent RPM-mellomlager"
 msgid "System Packages"
 msgstr "Systempakker"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Ingen programrettelser ble funnet."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Ingen mønstre funnet."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Ingen pakker funnet."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Internt navn"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Ingen produkter funnet."
 
@@ -6251,7 +6273,8 @@ msgstr ""
 #: src/solve-commit.cc:138
 msgid "Choose the above solution using '1' or skip, retry or cancel"
 msgid_plural "Choose from above solutions by number or skip, retry or cancel"
-msgstr[0] "Velg løsningen ovenfor med '1' eller med hopp over, gjenta eller avbryt"
+msgstr[0] ""
+"Velg løsningen ovenfor med '1' eller med hopp over, gjenta eller avbryt"
 msgstr[1] ""
 "Velg løsningen ovenfor med nummeret eller med hopp over, gjenta eller avbryt"
 
@@ -6615,7 +6638,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Programrettelser"
 
@@ -6641,7 +6664,7 @@ msgstr ""
 "Følgende oppdateringer for programvareadministrasjon vil bli installert "
 "først:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Ingen oppdateringer ble funnet."
 
@@ -6650,55 +6673,55 @@ msgstr "Ingen oppdateringer ble funnet."
 msgid "The following updates are also available:"
 msgstr "Følgende oppdateringer er også tilgjengelige:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Pakkeoppgraderinger"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Oppdatering av mønstre"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Produktoppdateringer"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Gjeldende versjon"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Tilgjengelig versjon"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Ingen samsvarende oppføringer funnet."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Følgende samsvarende oppføringsnummer er funnet:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 "Samsvar i programrettelse-beskrivelser for følgende programrettelser er "
 "funnet:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "Retting for bugzilla-oppføringsnummer %s ble ikke funnet eller er ikke "
 "nødvendig."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 "Rettelse for CVE-oppføringsnummer %s ble ikke funnet eller er ikke nødvendig."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, fuzzy, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper.nl\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Dutch <https://l10n.opensuse.org/projects/zypper/master/nl/>\n"
@@ -125,7 +125,8 @@ msgstr " Gebruik een geheel getal van %d tot %d"
 
 #: src/Config.cc:172
 msgid "The path specified in the --root option must be absolute."
-msgstr "De bij --rootoptie opgegeven locatie dient een directe locatie te zijn."
+msgstr ""
+"De bij --rootoptie opgegeven locatie dient een directe locatie te zijn."
 
 #. translators: --help, -h
 #: src/Config.cc:236
@@ -917,7 +918,8 @@ msgid "The following recommended application was automatically selected:"
 msgid_plural ""
 "The following %d recommended applications were automatically selected:"
 msgstr[0] "Het volgende aanbevolen programma is automatisch geselecteerd:"
-msgstr[1] "De volgende %d aanbevolen programma's zijn automatisch geselecteerd:"
+msgstr[1] ""
+"De volgende %d aanbevolen programma's zijn automatisch geselecteerd:"
 
 #: src/Summary.cc:1147
 #, c-format, boost-format
@@ -928,8 +930,8 @@ msgid_plural ""
 "The following %d packages are recommended, but will not be installed (only "
 "required packages will be installed):"
 msgstr[0] ""
-"Het volgende pakket is aanbevolen, maar zal niet worden geïnstalleerd ("
-"alleen vereiste pakketten zullen geïnstalleerd worden):"
+"Het volgende pakket is aanbevolen, maar zal niet worden geïnstalleerd "
+"(alleen vereiste pakketten zullen geïnstalleerd worden):"
 msgstr[1] ""
 "De volgende %d pakketten zijn aanbevolen, maar zullen niet worden "
 "geïnstalleerd (alleen vereiste pakketten zullen geïnstalleerd worden):"
@@ -969,7 +971,8 @@ msgstr[1] ""
 msgid "The following patch is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d patches are recommended, but will not be installed:"
-msgstr[0] "De volgende patch is aanbevolen, maar zal niet worden geïnstalleerd:"
+msgstr[0] ""
+"De volgende patch is aanbevolen, maar zal niet worden geïnstalleerd:"
 msgstr[1] ""
 "De volgende %d patches zijn aanbevolen, maar zullen niet worden "
 "geïnstalleerd:"
@@ -979,7 +982,8 @@ msgstr[1] ""
 msgid "The following pattern is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d patterns are recommended, but will not be installed:"
-msgstr[0] "Het volgende patroon is aanbevolen, maar zal niet worden geïnstalleerd:"
+msgstr[0] ""
+"Het volgende patroon is aanbevolen, maar zal niet worden geïnstalleerd:"
 msgstr[1] ""
 "De volgende %d patronen zijn aanbevolen, maar zullen niet worden "
 "geïnstalleerd:"
@@ -989,7 +993,8 @@ msgstr[1] ""
 msgid "The following product is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d products are recommended, but will not be installed:"
-msgstr[0] "Het volgende product is aanbevolen, maar zal niet worden geïnstalleerd:"
+msgstr[0] ""
+"Het volgende product is aanbevolen, maar zal niet worden geïnstalleerd:"
 msgstr[1] ""
 "De volgende %d producten zijn aanbevolen, maar zullen niet worden "
 "geïnstalleerd:"
@@ -1137,14 +1142,16 @@ msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
 msgstr[0] "Het volgende pakket wordt niet ondersteund door de leverancier:"
-msgstr[1] "De volgende %d pakketten worden niet ondersteund door de leverancier:"
+msgstr[1] ""
+"De volgende %d pakketten worden niet ondersteund door de leverancier:"
 
 #: src/Summary.cc:1382
 #, c-format, boost-format
 msgid "The following package is not supported by its vendor:"
 msgid_plural "The following %d packages are not supported by their vendor:"
 msgstr[0] "Het volgende pakket wordt niet ondersteund door de leverancier:"
-msgstr[1] "De volgende %d pakketten worden niet ondersteund door de leverancier:"
+msgstr[1] ""
+"De volgende %d pakketten worden niet ondersteund door de leverancier:"
 
 #: src/Summary.cc:1400
 #, c-format, boost-format
@@ -1421,7 +1428,8 @@ msgstr ""
 #: src/Summary.cc:1824
 #, boost-format
 msgid "%1% is set, otherwise a system reboot would be required."
-msgstr "%1% is ingesteld, anders zou een herstart van het systeen vereist zijn."
+msgstr ""
+"%1% is ingesteld, anders zou een herstart van het systeen vereist zijn."
 
 #: src/Summary.cc:1826
 msgid "System reboot required."
@@ -1468,7 +1476,7 @@ msgstr "PackageKit is nog actief (waarschijnlijk bezig)."
 msgid "Try again?"
 msgstr "Opnieuw proberen?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Onverwachte uitzondering."
 
@@ -1499,12 +1507,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "De %s-optie heeft hier geen effect en wordt genegeerd."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Programma-argumenten die geen optie zijn: "
 
@@ -1938,7 +1946,8 @@ msgstr ""
 #. help text for the "Abort, retry, ignore?" prompt for media errors
 #: src/callbacks/media.cc:34
 msgid "Change current base URI and try retrieving the file again."
-msgstr "Wijzig de huidige basis-uri en probeer het bestand opnieuw op te halen."
+msgstr ""
+"Wijzig de huidige basis-uri en probeer het bestand opnieuw op te halen."
 
 #. translators: this is a prompt label, will appear as "New URI: "
 #: src/callbacks/media.cc:49
@@ -2275,17 +2284,17 @@ msgid "Commands:"
 msgstr "Opdrachten:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Toon de uitgebreide installatiesamenvatting."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Het soort pakket (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2293,9 +2302,15 @@ msgstr ""
 "Het best mogelijke resultaat uitvoeren bij het bijwerken. Bijwerken naar een "
 "lagere versie dan de hoogste is ook acceptabel."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "Beschouw alleen patches die het beheer van pakketten zelf beïnvloeden."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2377,7 +2392,7 @@ msgstr "zypper [--global-options] <opdracht> [--opdrachtopties] [argumenten]"
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <subopdracht> [--opdrachtopties] [argumenten]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Toon zyppers hulppagina"
 
@@ -2465,8 +2480,8 @@ msgid ""
 "Remove packages with specified capabilities. A capability is NAME[.ARCH]"
 "[OP<VERSION>], where OP is one of <, <=, =, >=, >."
 msgstr ""
-"Verwijder pakketten met gespecificeerde capaciteiten. Een capaciteit is NAAM"
-"[.ARCH][OP<VERSIE>], waarbij OP één is van <, <=, =, >=, >."
+"Verwijder pakketten met gespecificeerde capaciteiten. Een capaciteit is "
+"NAAM[.ARCH][OP<VERSIE>], waarbij OP één is van <, <=, =, >=, >."
 
 # /usr/lib/YaST2/clients/lan_inetd_custom.ycp:764
 #: src/commands/installremove.cc:104 src/commands/installremove.cc:234
@@ -2602,22 +2617,22 @@ msgstr ""
 "bijgewerkte versies."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [OPTIES]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Bechikbare patches tonen."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Toon alle van toepassing zijnde patches."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Toon alle patches, niet alleen van toepassing zijnde patches."
 
@@ -2672,37 +2687,41 @@ msgstr ""
 "lijst van alle beschikbare regiocodes ophalen door '%s' aan te roepen."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [OPTIES] [REGIOCODE] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Gevraagde regiocodes (taalcodes) tonen."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Gevraagde regiocodes en bijbehorenden pakketten tonen."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Bijbehorende pakketten tonen."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Alle beschikbare regiocodes tonen."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 "Positionele argumenten worden genegeerd omdat het argument --all is "
 "aangeleverd."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "De regiocode(s) waarvoor de informatie afgedrukt zal worden."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2710,15 +2729,15 @@ msgstr ""
 "Alle regiocodes ophalen met taalcode 'en' die hun eigen landcode hebben, met "
 "uitzondering van de terugval 'en':"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr "Alle regiocodes met taalcode 'en' met of zonder landcode:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "De regiocode die exact overeenkomt met het argument: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "De lijst met pakketten die beschikbaar zijn voor 'de' en 'en':"
 
@@ -2830,11 +2849,11 @@ msgstr[1] "%lu vergrendelingen verwijderd."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Naam"
 
@@ -2844,8 +2863,8 @@ msgstr "Overeenkomsten"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Type"
@@ -2853,7 +2872,7 @@ msgstr "Type"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Installatiebron"
@@ -3216,8 +3235,8 @@ msgid ""
 msgstr ""
 "Probeer daarnaast alle pakketten bij te werken die niet gedekt zijn door "
 "patches. De optie wordt genegeerd als de patchopdracht eerst de software "
-"voor bijwerken moet bijwerken. Kan niet gecombineerd worden met "
-"--updatestack-only."
+"voor bijwerken moet bijwerken. Kan niet gecombineerd worden met --"
+"updatestack-only."
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/patchcheck.cc:17
@@ -3320,7 +3339,7 @@ msgid "Command"
 msgstr "Opdracht"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Service"
 
@@ -3380,8 +3399,8 @@ msgid ""
 msgstr ""
 "Gedetailleerde informatie over gespecificeerde pakketten tonen. Standaard "
 "worden de pakketten getoond die exact overeenkomen met de gegeven naam. Om "
-"alle pakketten te zien die gedeeltelijk overeenkomen gebruikt u de optie "
-"'--match-substrings' of gebruikt u jokertekens (*?) in de naam."
+"alle pakketten te zien die gedeeltelijk overeenkomen gebruikt u de optie '--"
+"match-substrings' of gebruikt u jokertekens (*?) in de naam."
 
 #: src/commands/query/info.cc:25
 msgid ""
@@ -3494,22 +3513,22 @@ msgid "Show detailed information for products."
 msgstr "Gedetailleerde informatie over producten tonen."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "pakketten (pa) [opties] [opslagruimte] …"
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Toon alle beschikbare pakketten."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Toon alle beschikbare pakketten in de gekozen installatiebronnen."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
@@ -3517,20 +3536,20 @@ msgstr ""
 "oplosser, tonen."
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 "Geïnstalleerde pakketten, die expliciet door de gebruiker zijn geselecteerd, "
 "tonen."
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 "Geïnstalleerde pakketten tonen die niet door een opslagruimte zijn geleverd."
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
@@ -3539,84 +3558,84 @@ msgstr ""
 "kandidaat voor bijwerken)."
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Gesuggereerde pakketten tonen."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Aanbevolen pakketten tonen."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Onnodige pakketten tonen."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "De lijst sorteren op pakketnaam."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "De lijst sorteren op opslagruimte."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [opslagruimte] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Geef alle beschikbare patches weer."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Alle beschikbare patches in de gespecificeerde opslagruimtes tonen."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [opties] [opslagruimte] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Geef alle beschikbare patronen weer."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Alle beschikbare patronen in de gespecificeerde opslagruimtes tonen."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [opties] [opslagruimte] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Geef alle beschikbare producten weer."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Alle beschikbare producten in de gespecificeerde opslagruimtes tonen."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Alleen XML-uitvoer: woordelijk doorgeven van de XML-tags die gevonden zijn "
 "in een productbestand."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "Optie %1% heeft geen effect zonder de globale optie %2%."
@@ -3661,13 +3680,13 @@ msgstr ""
 "Het type opslagruimte wordt altijd automatisch gedetecteerd. Deze optie "
 "wordt genegeerd."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 "Kan %s niet samen met %s gebruiken. Instellingen uit %s worden gebruikt."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3712,113 +3731,117 @@ msgid "Clean both metadata and package caches."
 msgstr "Beide metagegevens- en pakketten-caches opschonen."
 
 # ../../db/printers.ycp.noloc:1270
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "Uri"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Ingeschakeld"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Gpg-controle"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Prioriteit"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Automatisch vernieuwen"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Aan"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Uit"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Pakketten behouden"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI van GPG-sleutel"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Padvoorvoegsel"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Hoofddienst"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Trefwoorden"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Info-pad van inst.bron"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "MD Cache-pad"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [opties] [repo] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Toon alle gedefinieerde opslagruimtes."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 "Alle gedefinieerde opslagruimtes als een enkel lokaal .repo-bestand "
 "exporteren."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "De installatiebronnen kunnen niet worden uitgelezen:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Kan %s niet openen voor schrijven."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Misschien hebt u geen schrijfrechten?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "De opslagruimtes zijn met succes geëxporteerd naar %s."
@@ -3826,20 +3849,20 @@ msgstr "De opslagruimtes zijn met succes geëxporteerd naar %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Vernieuwen"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "Behouden"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Er zijn geen installatiebronnen gekozen."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 "Gebruik de opdracht ‘zypper addrepo’ om een of meer installatiebronnen toe "
@@ -3948,7 +3971,7 @@ msgstr "De algemene optie '%s' heeft hier geen effect."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Argumenten zijn niet toegestaan als '%s' wordt gebruikt."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Gekozen installatiebronnen: "
 
@@ -3957,7 +3980,7 @@ msgstr "Gekozen installatiebronnen: "
 msgid "Refreshing repository '%s'."
 msgstr "Bezig met vernieuwen van ‘%s’."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Bezig met doorzoeken van inhoud van uitgeschakelde opslagruimte ‘%s’."
@@ -3967,7 +3990,7 @@ msgstr "Bezig met doorzoeken van inhoud van uitgeschakelde opslagruimte ‘%s’
 msgid "Skipping disabled repository '%s'"
 msgstr "Uitgeschakelde opslagruimte ‘%s’ wordt overgeslagen"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "‘%s’ wordt wegens bovenstaande foutmelding overgeslagen."
@@ -3997,7 +4020,7 @@ msgid "Could not refresh the repositories because of errors."
 msgstr ""
 "De installatiebronnen kunnen wegens foutmeldingen niet worden vernieuwd."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Enkele installatiebronnen zijn wegens foutmeldingen niet vernieuwd."
 
@@ -4054,13 +4077,13 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Opslagruimte '%s' is hernoemd naar '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 "Er bestaat al een opslagruimte met de naam '%s'. Gebruik een andere alias."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Fout bij het wijzigen van de opslagruimte:"
 
@@ -4517,7 +4540,8 @@ msgstr "Hoofdlettergevoelige zoekopdracht uitvoeren."
 #. translators: -s, --details
 #: src/commands/search/search.cc:201
 msgid "Show each available version in each repository on a separate line."
-msgstr "Elke beschikbare versie in elke opslagruimte tonen op een aparte regel."
+msgstr ""
+"Elke beschikbare versie in elke opslagruimte tonen op een aparte regel."
 
 #. translators: -v, --verbose
 #: src/commands/search/search.cc:205
@@ -4525,28 +4549,28 @@ msgid ""
 "Like --details, with additional information where the search has matched "
 "(useful for search in dependencies)."
 msgstr ""
-"Zoals --details, met extra informatie waar de zoekopdracht overeenkwam ("
-"nuttig bij zoeken in afhankelijkheden)."
+"Zoals --details, met extra informatie waar de zoekopdracht overeenkwam "
+"(nuttig bij zoeken in afhankelijkheden)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Gespecificeerde opslagruimte '%s' is uitgeschakeld."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Geen overeenkomstige items gevonden."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Probleem bij het initialiseren of uitvoeren van de zoekopdracht"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Zie bovenstaande melding voor een hint."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 "Het draaien van 'zypper refresh' als root zou het probleem op kunnen lossen."
@@ -4651,7 +4675,7 @@ msgstr ""
 "service '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Overslaan van service '%s' vanwege bovengenoemde fout."
@@ -4670,24 +4694,28 @@ msgstr "Verwijderen van service '%s':"
 msgid "Service '%s' has been removed."
 msgstr "Service '%s' is verwijderd."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [opties]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Geef alle gedefinieerde services weer."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Toon alle gedefinieerde services."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Geen services gedefinieerd. Gebruik de opdracht '%s' om één of meer services "
 "toe te voegen."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5002,7 +5030,8 @@ msgstr ""
 
 #: src/commands/solveroptionset.cc:64
 msgid "Set the solvers general attitude when resolving a job."
-msgstr "Stel de algemene houding van de oplossers in bij oplossen van een taak."
+msgstr ""
+"Stel de algemene houding van de oplossers in bij oplossen van een taak."
 
 #: src/commands/solveroptionset.cc:84
 msgid "Expert options"
@@ -5120,7 +5149,8 @@ msgstr "waitpid voor %1% is mislukt (%2%)"
 #: src/commands/subcommand.cc:370
 #, boost-format
 msgid "waitpid for %1% returns unexpected pid %2% while waiting for %3%"
-msgstr "waitpid voor %1% geeft een onverwachte pid %2% terug bij wachten op %3%"
+msgstr ""
+"waitpid voor %1% geeft een onverwachte pid %2% terug bij wachten op %3%"
 
 #. translators: %1% - command name or path
 #. translators: %2% - signal number
@@ -5529,7 +5559,8 @@ msgstr "alle broncode-rpm's naar deze map downloaden."
 #. translators: --delete/--no-delete
 #: src/commands/utils/source-download.cc:501
 msgid "Whether to delete extraneous source rpms in the local directory."
-msgstr "Of overtollige broncode-rpms in de lokale map verwijderd moeten worden."
+msgstr ""
+"Of overtollige broncode-rpms in de lokale map verwijderd moeten worden."
 
 #. translators: --status
 #: src/commands/utils/source-download.cc:505
@@ -5652,15 +5683,15 @@ msgstr "%s is ouder dan %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Versie"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arch"
 
@@ -5799,13 +5830,13 @@ msgstr "(leeg)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Afhankelijkheden"
 
@@ -5842,7 +5873,7 @@ msgid "Flavor"
 msgstr "Smaak"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "In de basis"
 
@@ -6108,57 +6139,57 @@ msgstr[1] "%1% installatiebronnen"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Controleert of vernieuwen van metagegevens voor %s noodzakelijk is"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "De ‘%s’-installatiebron is actueel."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "De updatecontrole van ‘%s’ is uitgesteld."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "De onbewerkte metagegevens worden gedwongen vernieuwd"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "De metagegevens van ‘%s’ worden opgehaald"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Wilt u de installatiebron ‘%s’ permanent uitschakelen?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "‘%s’ kan niet worden uitgeschakeld."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Er kunnen geen bestanden worden opgehaald uit ‘%s’."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Zie bovenstaande foutmelding voor een hint."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Geen URI's gedefinieerd voor '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -6167,38 +6198,38 @@ msgstr ""
 "Voeg één of meer items voor basis-URI's (baseurl=URI) toe aan %s voor "
 "opslagruimte '%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Geen alias gedefinieerd voor deze opslagruimte."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "De installatiebron ‘%s’ is ongeldig."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 "Controleer of de opgegeven uri's verwijzen naar een geldige installatiebron."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Fout bij ophalen van metagegevens voor '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Bouwen van opslagruimtecache forceren"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Fout bij analyseren van metagegevens voor '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6210,45 +6241,45 @@ msgstr ""
 "u twijfelt, geeft u de fout door aan de hand van de instructies op http://"
 "nl.opensuse.org/Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 "Metagegevens in opslagruimte voor '%s' niet gevonden in de lokale cache."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Fout bij opbouwen van de cache:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 "Opslagruimte '%s' is niet gevonden aan de hand van de alias, nummer of URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Gebruik '%s' voor een lijst met gedefinieerde opslagruimtes."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "De uitgeschakelde installatiebron ‘%s’ wordt genegeerd"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "Algemene optie '%s' kan gebruikt worden om tijdelijk opslagruimtes in te "
 "schakelen."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Opslagruimte '%s' wordt genegeerd vanwege de optie '%s'."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Tijdelijk inschakelen van opslagruimte '%s'."
@@ -6256,7 +6287,7 @@ msgstr "Tijdelijk inschakelen van opslagruimte '%s'."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6265,7 +6296,7 @@ msgstr ""
 "Opslagruimte '%s' is niet actueel. U kunt als root 'zypper refresh' "
 "uitvoeren om deze bij te werken."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6274,82 +6305,82 @@ msgstr ""
 "De metagegevenscache moet gebouwd worden voor opslagruimte '%s'. U kunt als "
 "root 'zypper refresh' uitvoeren om dat te doen."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Opslagruimte '%s' blijft uitgeschakeld."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Doel initialiseren"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Doelinitialisatie is mislukt:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Opschonen van metagegevenscache voor '%s'."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Opschonen van onbewerkte metagegevenscache voor '%s'."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Bewaren van ruwe metagegevenscache voor %s '%s'."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Opschonen van pakketten voor '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Opschonen van opslagruimte '%s' kan niet vanwege een fout."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Opschonen van cache voor geïnstalleerde pakketten."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 "Opschonen van cache voor geïnstalleerde pakketten kan niet vanwege een fout."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Kan de opslagruimten niet opschonen vanwege fouten."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Enkele opslagruimtes zijn vanwege fouten niet opgeschoond."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "De gespecificeerde opslagruimtes zijn opgeschoond."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Alle opslagruimtes zijn opgeschoond."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Dit is een verwisselbaar alleen-lezen medium (cd/dvd). Automatisch "
 "vernieuwen wordt daarom uitgeschakeld."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Ongeldige alias van opslagruimte: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6357,25 +6388,26 @@ msgstr ""
 "Kan het type opslagruimte niet bepalen. Controleer of de gedefinieerde URI's "
 "(zie hieronder) naar een geldige opslagruimte verwijzen:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Kan geen geldige opslagruimte vinden op de opgegeven locatie:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
-msgstr "Probleem bij het overdragen van opslagruimtegegevens van opgegeven URI:"
+msgstr ""
+"Probleem bij het overdragen van opslagruimtegegevens van opgegeven URI:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Controleer of de opgegeven URI toegankelijk is."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Onbekend probleem bij toevoegen van opslagruimte:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6384,137 +6416,137 @@ msgstr ""
 "Controleren met GPG is uitgeschakeld in de configuratie van opslagruimte "
 "'%1%'. Integriteit en oorsprong van pakketten kan niet worden geverifieerd."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Opslagruimte '%s' is toegevoegd"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Leest gegevens van medium '%s"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Probleem bij lezen van gegevens van '%s' medium"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Controleer of uw installatiemedium geldig en leesbaar is."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 "Gegevens lezen van medium '%s' is uitgesteld tot de volgende verversing."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Leest gegevens van medium '%s"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Probleem bij lezen van gegevens van '%s' medium"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Controleer of uw installatiemedium geldig en leesbaar is."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Probleem bij toegang tot het bestand op de opgegeven URI"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Controleer of de opgegeven URI juist en toegankelijk is."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Probleem bij het analyseren van het bestand op de opgegeven URI"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Is het een .repo-bestand?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Probleem bij het lezen van het bestand op de opgegeven URI"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 "Er is een opslagruimte zonder een gedefinieerde alias gevonden, overslaan."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Bij opslagruimte '%s' is geen URI gedefinieerd, overslaan."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Opslagruimte '%s' is verwijderd."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Prioriteit van opslagruimte '%s' is ongewijzigd (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Opslagruimte '%s' is geactiveerd."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Opslagruimte '%s' is gedeactiveerd."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Automatisch vernieuwen is geactiveerd voor opslagruimte '%s'."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Automatisch vernieuwen is gedeactiveerd voor opslagruimte '%s'."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "RPM-bestanden cachen is geactiveerd voor opslagruimte '%s'."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "RPM-bestanden cachen is gedeactiveerd voor opslagruimte '%s'."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "GPG-controle is geactiveerd voor opslagruimte '%s'."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "GPG-controle is gedeactiveerd voor opslagruimte '%s'."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "De prioriteit van opslagruimte '%s' is op %d gezet."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "De naam van opslagruimte '%s' is op '%s' gezet."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Niets te wijzigen voor opslagruimte '%s'."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Opslagruimte %s wordt ongewijzigd gelaten."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Bezig met ophalen van installatiebrongegevens…"
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6522,45 +6554,45 @@ msgstr ""
 "Geen opslagruimtes gedefinieerd. Er wordt nu alleen gewerkt met de "
 "geïnstalleerde oplosbare pakketten. Er kan niets worden geïnstalleerd."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Bezic met ophalen van ‘%s’-installatiebrongegevens…"
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 "Opslagruimte '%s' bevindt zich niet in de cache. Deze wordt nu toegevoegd..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Probleem bij laden van gegevens van '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 "Opslagruimte '%s' kan niet worden vernieuwd. De oude cache wordt gebruikt."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Oplosbare pakketten van '%s' zijn niet geladen vanwege een fout."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "Metagegevens in opslagruimte '%1%' zijn verlopen sinds %2%."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Probeer '%s', of zelfs '%s' alvorens dit te doen."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6568,38 +6600,38 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 "Metagegevens in opslagruimte zijn verlopen: Controleer of 'autorefresh' is "
-"aangezet (zypper lr), vernieuw anders handmatig de opslagruimte (zypper ref)"
-". Als dat does het probleem niet oplost, dan zou het kunnen dat u een "
+"aangezet (zypper lr), vernieuw anders handmatig de opslagruimte (zypper "
+"ref). Als dat does het probleem niet oplost, dan zou het kunnen dat u een "
 "gebroken mirror gebruikt of heeft de server de ondersteuning van de "
 "opslagruimte niet voortgezet."
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Bezig met inlezen van geïnstalleerde pakketten…"
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr ""
 "Er is een fout opgetreden bij het inlezen van de geïnstalleerde pakketten:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 "‘%s’ lijkt op een rpmbestand. Er wordt getracht het bestand op te halen."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Probleem met het RPM-bestand gespecificeerd als '%s', overslaan."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 "Probleem met het lezen van de RPM-header van %s. Is het een RPM-bestand?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Cache van gewone RPM-bestanden"
 
@@ -6607,26 +6639,26 @@ msgstr "Cache van gewone RPM-bestanden"
 msgid "System Packages"
 msgstr "Systeempakketten"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Geen noodzakelijke patches gevonden."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Geen patronen gevonden."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Geen pakketten gevonden."
 
 # inlognaam/gebruikersnaam
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Interne naam"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Geen producten gevonden."
 
@@ -7035,7 +7067,7 @@ msgid "Updatestack"
 msgstr "Bijwerkstapel"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Patches"
 
@@ -7059,7 +7091,7 @@ msgid "Needed software management updates will be installed first:"
 msgstr ""
 "Benodigde elementen voor softwarebeheer zullen eerst worden geïnstalleerd:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Geen items voor bijwerken gevonden."
 
@@ -7068,53 +7100,53 @@ msgstr "Geen items voor bijwerken gevonden."
 msgid "The following updates are also available:"
 msgstr "De volgende items voor bijwerken zijn ook beschikbaar:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Pakketupdates"
 
 # /usr/lib/YaST2/clients/inst_config_x11.ycp:947
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Patroonupdates"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Productupdates"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Huidige versie"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Beschikbare versie"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Er zijn geen overeenkomstige problemen gevonden."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "De volgende overeenkomsten in probleemnummers zijn gevonden:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 "Overeenkomsten in patchbeschrijvingen van de volgende patches zijn gevonden:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "Een oplossing voor bugzilla-probleem %s is niet gevonden of is niet nodig."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "Oplossing voor CVE-probleem %s is niet gevonden of is niet nodig."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "Reparatie voor %s issue-nummer %s is niet gevonden of is niet nodig."
@@ -7372,7 +7404,8 @@ msgstr ""
 #: src/utils/messages.cc:141
 #, c-format, boost-format
 msgid "Type '%s' to get a list of global options and commands."
-msgstr "Type '%s' om een lijst van algemene opties en opdrachten te verkrijgen."
+msgstr ""
+"Type '%s' om een lijst van algemene opties en opdrachten te verkrijgen."
 
 #. translators: %1% is the name of an (unknown) command
 #. translators: %2% something providing more info (like 'zypper help subcommand')

--- a/po/nn.po
+++ b/po/nn.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Norwegian Nynorsk <https://l10n.opensuse.org/projects/zypper/"
@@ -917,8 +917,8 @@ msgid_plural ""
 "The following %d packages are recommended, but will not be installed because "
 "they are unwanted (were manually removed before):"
 msgstr[0] ""
-"Denne pakken er anbefalt, men vert ikkje installert, sidan han er uønskt ("
-"han har blitt manuelt avinstallert før):"
+"Denne pakken er anbefalt, men vert ikkje installert, sidan han er uønskt "
+"(han har blitt manuelt avinstallert før):"
 msgstr[1] ""
 "Desse %d pakkane er anbefalte, men vert ikkje installerte, sidan dei er "
 "uønskte (dei har blitt manuelt avinstallerte før):"
@@ -1156,7 +1156,8 @@ msgid "The following item is locked and will not be changed by any action:"
 msgid_plural ""
 "The following %d items are locked and will not be changed by any action:"
 msgstr[0] "Dette elementet er låst, og vert ikkje endra av nokon handlingar:"
-msgstr[1] "Desse %d elementa er låste, og vert ikkje endra av nokon handlingar:"
+msgstr[1] ""
+"Desse %d elementa er låste, og vert ikkje endra av nokon handlingar:"
 
 #. always as plain name list
 #. translators: used as 'tag:' (i.e. followed by ':')
@@ -1396,7 +1397,7 @@ msgstr "PackageKit køyrer framleis (er truleg oppteken)."
 msgid "Try again?"
 msgstr "Vil du prøva på nytt?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Uventa unntak."
 
@@ -1423,17 +1424,17 @@ msgid ""
 msgstr ""
 "Den symbolske lenkja «/etc/products.d/baseproduct» manglar eller peikar "
 "ikkje ikkje til ei reell fil.\n"
-"Lenkja må peika til .prod-fila til kjerneproduktet ditt i «/etc/products.d»."
-"\n"
+"Lenkja må peika til .prod-fila til kjerneproduktet ditt i «/etc/"
+"products.d».\n"
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Valet %s har ikkje nokon effekt her og vert ignorert."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Programargument som ikkje er val: "
 
@@ -2151,24 +2152,30 @@ msgid "Commands:"
 msgstr "Kommandoar:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2241,7 +2248,7 @@ msgstr "zypper [--globale-val] <kommando> [--val-for-kommando] [argument]"
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <underkommando> [--val-for-kommando] [argument]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Vis zypper hjelp"
 
@@ -2426,22 +2433,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [VAL]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Vis oversikt over aktuelle programfiksar."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Vis alle programfiksar, ikkje berre dei aktuelle."
 
@@ -2492,49 +2499,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2636,11 +2647,11 @@ msgstr[1] "Fjerna %lu låsar."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Namn"
 
@@ -2650,8 +2661,8 @@ msgstr "Gjeld"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Type"
@@ -2659,7 +2670,7 @@ msgstr "Type"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Pakkebrønn"
@@ -3091,7 +3102,7 @@ msgid "Command"
 msgstr "Kommando"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Teneste"
 
@@ -3254,120 +3265,120 @@ msgid "Show detailed information for products."
 msgstr "Vis detaljert informasjon for produkt."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Vis oversikt over tilgjengelege pakkar."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Vis oversikt over tilgjengelege programfiksar."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Vis oversikt over tilgjengelege mønster."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Vis oversikt over tilgjengelege produkt."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr "Berre XML-utdata: Vidaresend XML-taggane i produktfila direkte."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "Valet %1% har ikkje nokon effekt utan det globale valet %2%."
@@ -3407,12 +3418,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "Kan ikkje bruka %s saman med %s. Brukar innstillinga %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3456,111 +3467,115 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "Adresse"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Verksam"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "GPG-kontroll"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Prioritet"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Autooppdater"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "På"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Av"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Behald pakkar"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "Adresse til GPG-nøkkel"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Adresseprefiks"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Overordna teneste"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Nøkkelord"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Adresse til pakkebrønninfo"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Adresse til MD-mellomlager"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Vis oversikt over pakkebrønnar."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Feil ved lesing av pakkebrønnar:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Klarte ikkje opna %s for skriving."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Det kan vera du manglar skriveløyve."
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Pakkebrønnane er no eksporterte til %s."
@@ -3568,20 +3583,20 @@ msgstr "Pakkebrønnane er no eksporterte til %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Oppdater"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Ingen pakkebrønnar er definerte."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 "Bruk kommandoen «zypper addrepo» for å leggja til éin eller fleire "
@@ -3684,7 +3699,7 @@ msgstr "Det globale valet «%s» har ingen effekt her."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Argument er ikkje tillatne dersom «%s» vert brukt."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Valde pakkebrønnar: "
 
@@ -3693,7 +3708,7 @@ msgstr "Valde pakkebrønnar: "
 msgid "Refreshing repository '%s'."
 msgstr "Oppdaterer pakkebrønnen «%s»."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Les innhaldet i den uverksame pakkebrønnen «%s»."
@@ -3703,7 +3718,7 @@ msgstr "Les innhaldet i den uverksame pakkebrønnen «%s»."
 msgid "Skipping disabled repository '%s'"
 msgstr "Hoppar over den uverksame pakkebrønnen «%s»"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Hoppar over pakkebrønnen «%s», på grunn av feilen ovanfor."
@@ -3733,7 +3748,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "Klarte ikkje oppdatera pakkebrønnane, på grunn av feil."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Nokre av pakkebrønnane vart ikkje oppdaterte, på grunn av feil."
 
@@ -3788,12 +3803,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Pakkebrønnen «%s» heiter no «%s»."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "Det finst alt ein pakkebrønn med namnet «%s». Bruk eit anna alias."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Feil ved endring av pakkebrønnen:"
 
@@ -4229,25 +4244,25 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Den valde pakkebrønnen «%s» er uverksam."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Fann ikkje nokon samsvarande element."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Det oppstod ein feil ved klargjering eller køyring av søket"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Sjå feilmeldinga ovanfor for eit hint."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "Det kan hjelpa å køyra «zypper refresh» som rotbrukar."
 
@@ -4337,7 +4352,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Feil ved henting indeksfil for pakkebrønn for tenesta «%s»:"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Hoppar over tenesta «%s» på grunn av feilen ovanfor."
@@ -4356,24 +4371,28 @@ msgstr "Fjernar tenesta «%s»:"
 msgid "Service '%s' has been removed."
 msgstr "Tenesta «%s» er no fjerna."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Vis oversikt over tenester."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Ingen tenester er definerte. Bruk kommandoen «%s» for å leggja til éi eller "
 "fleire tenester."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5280,15 +5299,15 @@ msgstr "%s er eldre enn %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Versjon"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arkitektur"
 
@@ -5422,13 +5441,13 @@ msgstr "(tom)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Avhengnad"
 
@@ -5465,7 +5484,7 @@ msgid "Flavor"
 msgstr "Variant"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Er grunnval"
 
@@ -5727,57 +5746,57 @@ msgstr[1] "%1% pakkebrønnar"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Kontrollerer om metadata må oppdaterast for %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Pakkebrønnen «%s» er oppdatert."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Kontroll om pakkebrønnen «%s» er oppdatert er utsett."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Tvingar gjennom oppdatering av metadata"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Hentar metadata for pakkebrønnen «%s»"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Vil du gjera pakkebrønnen %s uverksam for alltid?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Feil ved forsøk på å gjera pakkebrønnen «%s» uverksam."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Feil ved henting av filer frå «%s»."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Sjå feilmeldinga ovanfor for eit hint."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Ingen nettadresser er definerte for «%s»."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -5786,16 +5805,16 @@ msgstr ""
 "Legg éi eller fleire grunnadresser («baseurl»-verdiar) til %s for "
 "pakkebrønnen «%s»."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Inkje alias er definert for denne pakkebrønnen."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Pakkebrønnen «%s» er ugyldig."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -5803,22 +5822,22 @@ msgstr ""
 "Kontroller at nettadressene definerte for denne pakkebrønnen peikar til ein "
 "gyldig pakkebrønn."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Feil ved henting av metadata for «%s»:"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Tvingar bygging av mellomlager for pakkebrønnen"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Feil ved tolking av metadata for «%s»:"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5830,43 +5849,43 @@ msgstr ""
 "tvil om grunnen, meld det inn som ein feil, slik forklart på http://"
 "en.opensuse.org/Zypper/Troubleshooting."
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Fann ikkje pakkebrønnmetadata for «%s» i det lokale mellomlageret."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Feil ved bygging av mellomlager:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Fann ikkje pakkebrønnen «%s» etter alias, tal eller nettadresse."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Bruk «%s» for å henta oversikt over definerte pakkebrønnar."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Hoppar over den uverksame pakkebrønnen «%s»"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "Globale val «%s» kan brukast til å mellombels gjera uverksame pakkebrønnar "
 "verksame."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Hoppar over pakkebrønnen «%s» på grunn av valet «%s»."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Gjer pakkebrønnen «%s» mellombels verksam."
@@ -5874,7 +5893,7 @@ msgstr "Gjer pakkebrønnen «%s» mellombels verksam."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -5883,7 +5902,7 @@ msgstr ""
 "Pakkebrønnen «%s» er utdatert. Køyr «zypper refresh» som rotbrukar for å "
 "oppdatera han."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -5892,82 +5911,82 @@ msgstr ""
 "Må byggja metadatamellomlageret for pakkebrønnen «%s». Du kan køyra «zypper "
 "refresh» som rotbrukar for å gjera dette."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Pakkebrønnen «%s» forblir uverksam."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Gjer klar mål"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Klarte ikkje klargjera mål:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Tømmer metadatamellomlager for «%s»."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Fjernar råmetadata-mellomlager for «%s»."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Beheld råmetadata-mellomlager for %s «%s»."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Ryddar opp i pakkar for «%s»."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Klarte ikkje rydda opp i pakkebrønnen «%s», på grunn av ein feil."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Ryddar opp i mellomlager for installerte pakkar."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 "Klarte ikkje rydda opp i mellomlager for installerte pakkar, på grunn av ein "
 "feil."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Klarte ikkje rydda opp i pakkebrønnar, på grunn av ein feil."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Nokre av pakkebrønnane vart ikkje rydda opp i, på grunn av ein feil."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Dei valde pakkebrønnane er no rydda opp i."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Alle pakkebrønnane er no rydda opp i."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Dette er eit utbytbart skriveverna medium (CD/DVD). Slår av autooppdatering."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Ugyldig pakkebrønnalias: «%s»"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -5975,26 +5994,26 @@ msgstr ""
 "Klarte ikkje fastslå type pakkebrønn. Sjå til at nettadressene nedanfor "
 "peikar til ein gyldig pakkebrønn:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Fann ikkje ein gyldig pakkebrønn på den oppgjevne adressa:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 "Feil ved overføring av metadata for pakkebrønn frå den oppgjevne adressa:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Kontroller at den oppgjevne adressa fungerer."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Ukjend problem ved forsøk på å leggja til pakkebrønn:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6003,135 +6022,135 @@ msgstr ""
 "GPG-kontroll er slått av i oppsettet til pakkebrønnen «%1%». Kan derfor "
 "ikkje stadfesta integritet og opphav til pakkar."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Pakkebrønnen «%s» er no lagd til"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Les data frå mediet «%s»"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Feil ved lesing av data frå mediet «%s»"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Kontroller at installasjonsmediet er gyldig og lesbart."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Lesing av data frå mediet «%s» er utsett til neste oppdatering."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Les data frå mediet «%s»"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Feil ved lesing av data frå mediet «%s»"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Kontroller at installasjonsmediet er gyldig og lesbart."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Feil ved tilgang til fila på denne oppgjevne adressa"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Kontroller at adressa er gyldig og fungerer."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Feil ved tolking av fila på den oppgjevne adressa"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Er det ei .repo-fil?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Det oppstod ein feil ved forsøk på å lesa fil på den oppgjevne adressa"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Fann pakkebrønn utan definert alias i fila; hoppar over."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Pakkebrønnen «%s» har ikkje noko nettadresse definert; hoppar over."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Pakkebrønnen «%s» er no fjerna."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Prioriteten til pakkebrønnen «%s» vart ikkje endra (er %d)."
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Pakkebrønnen «%s» er no verksam."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Pakkebrønnen «%s» er no uverksam."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Automatisk oppdatering er slått på for pakkebrønnen «%s»."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Automatisk oppdatering er slått av for pakkebrønnen «%s»."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Mellomlagring av RPM-filer er slått på for pakkebrønnen «%s»."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Mellomlagring av RPM-filer er slått av for pakkebrønnen «%s»."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "GPG-kontroll er slått på for pakkebrønnen «%s»."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "GPG-kontroll er slått av for pakkebrønnen «%s»."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Prioriteten til pakkebrønnen «%s» er sett til %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Namnet på pakkebrønnen «%s» er sett til «%s»."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Ingen endringar var nødvendige for pakkebrønnen «%s»."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Gjer ingen endringar på pakkebrønnen «%s»."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Lastar pakkebrønndata …"
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6139,43 +6158,43 @@ msgstr ""
 "Ingen pakkebrønnar er definerte. Held berre fram med dei installerte "
 "elementa. Ingenting kan installerast."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Hentar data for pakkebrønnen «%s» …"
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Pakkebrønnen «%s» finst ikkje i mellomlageret. Gjer klar mellomlager …"
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Feil ved lasting av data frå «%s»"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "Klarte ikkje oppdatera pakkebrønnen «%s». Brukar gammalt mellomlager."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "På grunn av feil vart ikkje element frå «%s» lasta."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Prøv «%s», eventuelt òg «%s», før du gjer dette."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6183,30 +6202,30 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Les installerte pakkar …"
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Feil ved lesing av installerte pakkar:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "«%s» ser ut til å vera ei RPM-fil. Prøver å lasta ho ned."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Problem med RPM-fila spesifisert som «%s». Hoppar over."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Problem med lesing av RPM-filhovud til %s. Er det ei RPM-fil?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Mellomlager for RPM-filer"
 
@@ -6214,25 +6233,25 @@ msgstr "Mellomlager for RPM-filer"
 msgid "System Packages"
 msgstr "Systempakkar"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Fann ingen nødvendige programfiksar."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Fann ikkje nokon mønster."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Fann ikkje nokon pakkar."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Internt namn"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Fann ikkje nokon produkt."
 
@@ -6615,7 +6634,7 @@ msgid "Updatestack"
 msgstr "Oppdateringsstabel"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Programfiksar"
 
@@ -6638,7 +6657,7 @@ msgstr "Brukte kategoriar"
 msgid "Needed software management updates will be installed first:"
 msgstr "Nødvendige pakkehandsamingsoppdateringar vert installerte først:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Fann ikkje nokon oppdateringar."
 
@@ -6647,46 +6666,46 @@ msgstr "Fann ikkje nokon oppdateringar."
 msgid "The following updates are also available:"
 msgstr "Desse oppdateringane er òg tilgjengelege:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Pakkeoppdateringar"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Mønsteroppdateringar"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Produktoppdateringar"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Gjeldande versjon"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Tilgjengelege versjon"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Fann ikkje nokon samsvarande feilrapportar."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Fann treff i følgjande feilrapport-ID-ar:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "Fann treff i programfiksskildringar til desse programfiksane:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "Programfiks for Bugzilla-feilrapport-ID %s vart ikkje funnen eller er ikkje "
 "nødvendig."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
@@ -6694,7 +6713,7 @@ msgstr ""
 "nødvendig."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""
@@ -6892,7 +6911,8 @@ msgstr "Send inn ein feilrapport på dette."
 #. unless you translate the actual page :)
 #: src/utils/messages.cc:22
 msgid "See http://en.opensuse.org/Zypper/Troubleshooting for instructions."
-msgstr "Sjå http://en.opensuse.org/Zypper/Troubleshooting for meir informasjon."
+msgstr ""
+"Sjå http://en.opensuse.org/Zypper/Troubleshooting for meir informasjon."
 
 #: src/utils/messages.cc:38
 msgid "Too many arguments."
@@ -7202,7 +7222,8 @@ msgstr ""
 #: src/utils/prompt.cc:289
 #, c-format, boost-format
 msgid "Enter '%s' for '%s' or '%s' for '%s' if nothing else works for you."
-msgstr "Bruk «%s» for «%s» eller «%s» for «%s» dersom ikkje noko anna fungerer."
+msgstr ""
+"Bruk «%s» for «%s» eller «%s» for «%s» dersom ikkje noko anna fungerer."
 
 #: src/utils/prompt.cc:294
 msgid ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -10,11 +10,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper.pa\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Punjabi <https://l10n.opensuse.org/projects/zypper/master/pa/>"
-"\n"
+"Language-Team: Punjabi <https://l10n.opensuse.org/projects/zypper/master/pa/"
+">\n"
 "Language: pa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "ਇੰਸਟਾਲੇਸ਼ਨ ਤਿਆਰ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ..."
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "ਅਚਾਨਕ ਅਪਵਾਦ ਆਇਆ ਹੈ।"
 
@@ -1405,12 +1405,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "ਨਾ-ਚੋਣ ਪਰੋਗਰਾਮ ਆਰਗੂਮਿੰਟ: "
 
@@ -2108,24 +2108,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2195,7 +2201,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2380,22 +2386,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2446,49 +2452,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2592,11 +2602,11 @@ msgstr[1] "ਸਭ ਪੈਕੇਜ ਹਟਾਓ"
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "ਨਾਂ"
 
@@ -2606,8 +2616,8 @@ msgstr ""
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "ਕਿਸਮ"
@@ -2615,7 +2625,7 @@ msgstr "ਕਿਸਮ"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "ਰਿਪੋਜ਼ਟਰੀ"
@@ -3040,7 +3050,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "ਸਰਵਿਸ"
 
@@ -3203,120 +3213,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3356,12 +3366,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3403,116 +3413,120 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "ਉਪ-ਨਾਂ"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "ਯੋਗ ਕੀਤੀ"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 #, fuzzy
 msgid "GPG Check"
 msgstr "DNS ਚੈੱਕ"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "ਆਟੋ-ਤਾਜ਼ਾ"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "ਚਾਲੂ"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "ਬੰਦ"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Keep Packages"
 msgstr "ਸਿਸਟਮ ਏਰੀਆ ਆਈਟਮਾਂ"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 #, fuzzy
 msgid "Path Prefix"
 msgstr "ਡਾਇਲ ਪ੍ਰੀ-ਫਿਕਸ"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "ਪਰਿੰਟ ਸਰਵਰ"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "ਰਿਪੋਜ਼ਟਰੀ ਤੋਂ ਪੜ੍ਹਨ ਦੌਰਾਨ ਗਲਤੀ:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "ਲਿਖਣ ਲਈ ਫਾਇਲ ਖੋਲੀ ਨਹੀਂ ਜਾ ਸਕਦੀ ਹੈ।"
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 #, fuzzy
 msgid "Maybe you do not have write permissions?"
 msgstr "%s ਨੂੰ ਲਿਖਣ ਲਈ ਖੋਲ੍ਹਿਆ ਨਹੀਂ ਜਾ ਸਕਦਾ। ਸ਼ਾਇਦ ਤੁਹਾਨੂੰ ਲਿਖਣ ਅਧਿਕਾਰ ਨਾ ਹੋ?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "ਰਿਪੋਜ਼ਟਰੀਆਂ ਠੀਕ ਤਰ੍ਹਾਂ %s ਲਈ ਐਕਸਪੋਰਟ ਕੀਤੀਆਂ ਗਈਆਂ।"
@@ -3520,20 +3534,20 @@ msgstr "ਰਿਪੋਜ਼ਟਰੀਆਂ ਠੀਕ ਤਰ੍ਹਾਂ %s ਲਈ
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "ਤਾਜ਼ਾ ਕਰੋ"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr ""
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3634,7 +3648,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 #, fuzzy
 msgid "Specified repositories: "
 msgstr "ਦਿੱਤੀਆਂ ਰਿਪੋਜ਼ਟਰੀਆਂ ਤਾਜ਼ਾ ਕੀਤੀਆਂ ਗਈਆਂ।"
@@ -3644,7 +3658,7 @@ msgstr "ਦਿੱਤੀਆਂ ਰਿਪੋਜ਼ਟਰੀਆਂ ਤਾਜ਼ਾ 
 msgid "Refreshing repository '%s'."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਸ਼ਾਮਲ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ।"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr ""
@@ -3654,7 +3668,7 @@ msgstr ""
 msgid "Skipping disabled repository '%s'"
 msgstr "ਆਯੋਗ ਕੀਤੀ ਰਿਪੋਜ਼ਟਰੀ '%s' ਛੱਡੀ ਜਾ ਰਹੀ ਹੈ"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਉੱਤੇ ਦਿੱਤੀ ਗਲਤੀ ਕਰਕੇ ਛੱਡੀ ਜਾ ਰਹੀ ਹੈ।"
@@ -3684,7 +3698,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "ਗਲਤੀਆਂ ਕਰਕੇ ਰਿਪੋਜ਼ਟਰੀਆਂ ਤਾਜ਼ਾ ਨਹੀਂ ਕੀਤੀਆਂ ਜਾ ਸਕੀਆਂ।"
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "ਕੁਝ ਰਿਪੋਜ਼ਟਰੀਆਂ ਤਾਜ਼ਾ ਨਹੀਂ ਕੀਤੀਆਂ ਜਾ ਸਕੀਆਂ, ਕਿਉਂਕਿ ਇੱਕ ਗਲਤੀ ਸੀ।"
 
@@ -3737,12 +3751,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ %s ਦਾ ਨਾਂ %s ਬਦਲਿਆ"
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, fuzzy, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ ਨਾਂ '%s' ਪਹਿਲਾਂ ਹੀ ਮੌਜੂਦ ਹੈ। ਹੋਰ ਏਲੀਆਸ ਵਰਤੋਂ ਜੀ।"
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "ਰਿਪੋਜ਼ਟਰੀਆਂ ਨੂੰ ਸੋਧਣ ਦੌਰਾਨ ਗਲਤੀ:"
 
@@ -4176,27 +4190,27 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "ਆਟੋ-ਤਾਜ਼ਾ"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "ਕੋਈ ਮੇਲ ਨਹੀਂ ਲੱਭਿਆ"
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 #, fuzzy
 msgid "See the above message for a hint."
 msgstr "ਇਸ਼ਾਰੇ ਲਈ ਉੱਤੇ ਦਿੱਤਾ ਗਲਤੀ ਸੁਨੇਹਾ ਵੇਖੋ ਜੀ।"
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4287,7 +4301,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "ਦਿੱਤੇ URL ਤੋਂ ਰਿਪੋਜ਼ਟਰੀ ਡਾਟਾ ਟਰਾਂਸਫਰ ਕਰਨ ਦੌਰਾਨ ਸਮੱਸਿਆ:"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, fuzzy, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਉੱਤੇ ਦਿੱਤੀ ਗਲਤੀ ਕਰਕੇ ਛੱਡੀ ਜਾ ਰਹੀ ਹੈ।"
@@ -4307,23 +4321,27 @@ msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਹਟਾਈ ਜਾ ਰਹੀ ਹੈ।
 msgid "Service '%s' has been removed."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ %s ਨੂੰ ਹਟਾਇਆ।"
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, fuzzy, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "ਕੋਈ ਰਿਪੋਜ਼ਟਰੀ ਨਹੀਂ ਦਿੱਤੀ ਗਈ ਹੈ। ਇੱਕ ਜਾਂ ਹੋਰ ਰਿਪੋਜ਼ਟਰੀਆਂ ਸ਼ਾਮਲ ਕਰਨ ਲਈ 'zypper addrepo' ਵਰਤੋਂ।"
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5207,15 +5225,15 @@ msgstr "%s %s ਰਾਹੀਂ ਚਾਹੀਦਾ ਹੈ"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "ਵਰਜਨ"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "ਢਾਂਚਾ"
 
@@ -5350,13 +5368,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "ਨਿਰਭਰਤਾ"
 
@@ -5394,7 +5412,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5656,96 +5674,96 @@ msgstr[1] "ਰਿਪੋਜ਼ਟਰੀ"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "ਚੈੱਕ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ ਕਿ ਕੀ %s ਮੇਟਾ-ਡਾਟਾ ਤਾਜ਼ਾ ਹੈ"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਅੱਪ-ਟੂ-ਡੇਟ ਹੈ।"
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, fuzzy, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ %s ਨੂੰ ਹਟਾਇਆ।"
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "ਰਾਅ ਮੇਟਾਡਾਟਾ ਤਾਜ਼ਾ ਲਈ ਫੋਰਸ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਡਾਟਾ ਲਿਆ ਜਾ ਰਿਹਾ ਹੈ..."
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr ""
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr ""
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, fuzzy, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "'%s' ਤੋਂ ਫਾਇਲਾਂ ਡਾਊਨਲੋਡ ਕਰਨ ਦੌਰਾਨ ਸਮੱਸਿਆ।"
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 #, fuzzy
 msgid "Please see the above error message for a hint."
 msgstr "ਇਸ਼ਾਰੇ ਲਈ ਉੱਤੇ ਦਿੱਤਾ ਗਲਤੀ ਸੁਨੇਹਾ ਵੇਖੋ ਜੀ।"
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, fuzzy, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "'%s' ਲਈ ਕੋਈ URL ਨਹੀਂ ਹੈ।"
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 #, fuzzy
 msgid "No alias defined for this repository."
 msgstr "ਇਹ ਰਿਪੋਜ਼ਟਰੀ ਲਈ ਕੋਈ ਏਲੀਆਸ ਨਹੀਂ ਹੈ।"
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਗਲਤ ਹੈ।"
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, fuzzy, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਤੋਂ ਮੇਟਾ-ਡਾਟਾ ਪਾਰਸਿੰਗ ਦੌਰਾਨ ਗਲਤੀ:"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "ਰਿਪੋਜ਼ਟਰੀ ਕੈਚੇ ਬਿਲਡ ਕਰਨ ਲਈ ਫੋਰਸ ਕੀਤਾ ਜਾਂਦਾ ਹੈ"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਤੋਂ ਮੇਟਾ-ਡਾਟਾ ਪਾਰਸਿੰਗ ਦੌਰਾਨ ਗਲਤੀ:"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5753,44 +5771,44 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "'%s' ਲਈ ਰਿਪੋਜ਼ਟਰੀ ਮੇਟਾਡਾਟਾ ਲੋਕਲ ਕੈਚੇ ਵਿੱਚ ਨਹੀਂ ਹੈ।"
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 #, fuzzy
 msgid "Error building the cache:"
 msgstr "ਕੈਚੇ ਡਾਟਾਬ ਬਿਲਡਿੰਗ ਗਲਤੀ:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਇਸ ਦੇ ਏਲੀਆਸ ਜਾਂ ਨੰਬਰ ਨਾਲ ਨਹੀਂ ਲੱਭੀ ਹੈ।"
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, fuzzy, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "ਦਿੱਤੀਆਂ ਰਿਪੋਜ਼ਟਰੀਆਂ ਦੀ ਲਿਸਟ ਵੇਖਣ ਲਈ 'zypper repos' ਵਰਤੋਂ।"
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "ਆਯੋਗ ਕੀਤੀ ਰਿਪੋਜ਼ਟਰੀ '%s' ਛੱਡੀ ਜਾ ਰਹੀ ਹੈ"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, fuzzy, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "ਰਿਪੋਜ਼ਟਰੀ ਸ਼ਾਮਲ ਕਰਨ ਜਾਂ ਯੋਗ ਕਰਨ ਲਈ 'zypper addrepo' ਜਾਂ 'zypper modifyrepo' ਕਮਾਂਡਾਂ "
 "ਵਰਤੋਂ।"
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, fuzzy, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਉੱਤੇ ਦਿੱਤੀ ਗਲਤੀ ਕਰਕੇ ਆਯੋਗ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ।"
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr ""
@@ -5798,7 +5816,7 @@ msgstr ""
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -5807,7 +5825,7 @@ msgstr ""
 "ਰਿਪੋਜ਼ਟਰੀ '%s' ਆਉਟ-ਆਫ-ਡੇਟ ਹੈ। ਤੁਸੀਂ ਇਸ ਨੂੰ ਅੱਪਡੇਟ ਕਰਨ ਲਈ root ਦੇ ਤੌਰ ਉੱਤੇ 'zypper refresh' "
 "ਚਲਾ ਸਕਦੇ ਹੋ।"
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, fuzzy, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -5816,298 +5834,297 @@ msgstr ""
 "ਰਿਪੋਜ਼ਟਰੀ '%s' ਆਉਟ-ਆਫ-ਡੇਟ ਹੈ। ਤੁਸੀਂ ਇਸ ਨੂੰ ਅੱਪਡੇਟ ਕਰਨ ਲਈ root ਦੇ ਤੌਰ ਉੱਤੇ 'zypper refresh' "
 "ਚਲਾ ਸਕਦੇ ਹੋ।"
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr ""
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "ਟਾਰਗੇਟ ਸ਼ੁਰੂ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
 
 # %s is either BOOTP or DHCP
-#: src/repos.cc:984
+#: src/repos.cc:977
 #, fuzzy
 msgid "Target initialization failed:"
 msgstr "ਸ਼ੁਰੂਆਤ ਫੇਲ੍ਹ ਹੋਈ"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, fuzzy, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਤੋਂ ਮੇਟਾ-ਡਾਟਾ ਪਾਰਸਿੰਗ ਦੌਰਾਨ ਗਲਤੀ:"
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, fuzzy, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਤੋਂ ਮੇਟਾ-ਡਾਟਾ ਪਾਰਸਿੰਗ ਦੌਰਾਨ ਗਲਤੀ:"
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, fuzzy, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਤੋਂ ਮੇਟਾ-ਡਾਟਾ ਪਾਰਸਿੰਗ ਦੌਰਾਨ ਗਲਤੀ:"
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, fuzzy, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਉੱਤੇ ਦਿੱਤੀ ਗਲਤੀ ਕਰਕੇ ਆਯੋਗ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ।"
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 #, fuzzy
 msgid "Cleaning installed packages cache."
 msgstr "ਇੰਸਟਾਲ ਪੈਕੇਜ ਪੜ੍ਹੇ ਜਾ ਰਹੇ ਹਨ"
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 #, fuzzy
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਉੱਤੇ ਦਿੱਤੀ ਗਲਤੀ ਕਰਕੇ ਆਯੋਗ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ।"
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 #, fuzzy
 msgid "Could not clean the repositories because of errors."
 msgstr "ਗਲਤੀਆਂ ਕਰਕੇ ਰਿਪੋਜ਼ਟਰੀਆਂ ਤਾਜ਼ਾ ਨਹੀਂ ਕੀਤੀਆਂ ਜਾ ਸਕੀਆਂ।"
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 #, fuzzy
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "ਕੁਝ ਰਿਪੋਜ਼ਟਰੀਆਂ ਤਾਜ਼ਾ ਨਹੀਂ ਕੀਤੀਆਂ ਜਾ ਸਕੀਆਂ, ਕਿਉਂਕਿ ਇੱਕ ਗਲਤੀ ਸੀ।"
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 #, fuzzy
 msgid "Specified repositories have been cleaned up."
 msgstr "ਦਿੱਤੀਆਂ ਰਿਪੋਜ਼ਟਰੀਆਂ ਤਾਜ਼ਾ ਕੀਤੀਆਂ ਗਈਆਂ।"
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 #, fuzzy
 msgid "All repositories have been cleaned up."
 msgstr "ਸਭ ਰਿਪੋਜ਼ਟਰੀਆਂ ਤਾਜ਼ਾ ਕੀਤੀਆਂ ਗਈਆਂ।"
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
-msgstr ""
-"ਇਹ ਬਦਲਣਯੋਗ ਕੇਵਲ ਪੜ੍ਹਨ ਵਾਸਤੇ ਮੀਡਿਆ (CD/DVD) ਹੈ, ਆਟੋ-ਤਾਜ਼ਾ ਆਯੋਗ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ।"
+msgstr "ਇਹ ਬਦਲਣਯੋਗ ਕੇਵਲ ਪੜ੍ਹਨ ਵਾਸਤੇ ਮੀਡਿਆ (CD/DVD) ਹੈ, ਆਟੋ-ਤਾਜ਼ਾ ਆਯੋਗ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ।"
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, fuzzy, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਸ਼ਾਮਲ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ।"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "ਦਿੱਤੇ ਟਿਕਾਣੇ ਉੱਤੇ ਇੱਕ ਠੀਕ ਰਿਪੋਜ਼ਟਰੀ ਨਹੀਂ ਲੱਭੀ ਜਾ ਸਕਦੀ:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 #, fuzzy
 msgid "Problem transferring repository data from specified URI:"
 msgstr "ਦਿੱਤੇ URL ਤੋਂ ਰਿਪੋਜ਼ਟਰੀ ਡਾਟਾ ਟਰਾਂਸਫਰ ਕਰਨ ਦੌਰਾਨ ਸਮੱਸਿਆ:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 #, fuzzy
 msgid "Please check whether the specified URI is accessible."
 msgstr "ਚੈੱਕ ਕਰੋ ਕਿ ਕੀ URL ਅਸੈੱਸਬਲ ਹੈ।"
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "ਰਿਪੋਜ਼ਟਰੀ ਸ਼ਾਮਲ ਕਰਨ ਦੌਰਾਨ ਅਣਜਾਣੀ ਸਮੱਸਿਆ:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਠੀਕ ਤਰ੍ਹਾਂ ਸ਼ਾਮਲ ਹੋ ਗਈ"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "ਮੀਡਿਆ '%s' ਤੋਂ ਡਾਟਾ ਪੜ੍ਹਿਆ ਜਾ ਰਿਹਾ ਹੈ"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "ਮੀਡਿਆ '%s' ਤੋਂ ਡਾਟਾ ਪੜ੍ਹਨ ਦੌਰਾਨ ਸਮੱਸਿਆ"
-
-#: src/repos.cc:1276
-#, fuzzy
-msgid "Please check if your installation media is valid and readable."
-msgstr "ਚੈੱਕ ਕਰੋ ਕਿ ਕਿ ਤੁਹਾਡਾ ਇੰਸਟਾਲੇਸ਼ਨ ਮੀਡਿਆ ਵੈਧ ਅਤੇ ਪੜ੍ਹਨਯੋਗ ਹੈ।"
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "ਮੀਡਿਆ '%s' ਤੋਂ ਡਾਟਾ ਪੜ੍ਹਿਆ ਜਾ ਰਿਹਾ ਹੈ"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "ਮੀਡਿਆ '%s' ਤੋਂ ਡਾਟਾ ਪੜ੍ਹਨ ਦੌਰਾਨ ਸਮੱਸਿਆ"
+
+#: src/repos.cc:1274
+#, fuzzy
+msgid "Please check if your installation media is valid and readable."
+msgstr "ਚੈੱਕ ਕਰੋ ਕਿ ਕਿ ਤੁਹਾਡਾ ਇੰਸਟਾਲੇਸ਼ਨ ਮੀਡਿਆ ਵੈਧ ਅਤੇ ਪੜ੍ਹਨਯੋਗ ਹੈ।"
+
+#: src/repos.cc:1345
 #, fuzzy
 msgid "Problem accessing the file at the specified URI"
 msgstr "ਦਿੱਤੇ URL ਤੋਂ ਰਿਪੋਜ਼ਟਰੀ ਡਾਟਾ ਟਰਾਂਸਫਰ ਕਰਨ ਦੌਰਾਨ ਸਮੱਸਿਆ।"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 #, fuzzy
 msgid "Please check if the URI is valid and accessible."
 msgstr "ਚੈੱਕ ਕਰੋ ਕਿ ਕੀ URL ਅਸੈੱਸਬਲ ਹੈ।"
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 #, fuzzy
 msgid "Problem parsing the file at the specified URI"
 msgstr "ਦਿੱਤੇ URL ਤੋਂ ਰਿਪੋਜ਼ਟਰੀ ਡਾਟਾ ਟਰਾਂਸਫਰ ਕਰਨ ਦੌਰਾਨ ਸਮੱਸਿਆ।"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 #, fuzzy
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "ਦਿੱਤੇ URL ਤੋਂ ਰਿਪੋਜ਼ਟਰੀ ਡਾਟਾ ਟਰਾਂਸਫਰ ਕਰਨ ਦੌਰਾਨ ਸਮੱਸਿਆ।"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 #, fuzzy
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਨਹੀਂ ਲੱਭੀ।"
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਨਹੀਂ ਲੱਭੀ।"
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ %s ਨੂੰ ਹਟਾਇਆ।"
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "ਰਿਪੋਜ਼ਟਰੀ %s ਨੂੰ ਹਟਾਇਆ।"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ %s ਠੀਕ ਤਰ੍ਹਾਂ ਸੋਧੀ ਗਈ ਹੈ।"
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ %s ਠੀਕ ਤਰ੍ਹਾਂ ਸੋਧੀ ਗਈ ਹੈ।"
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, fuzzy, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "ਆਯੋਗ ਕੀਤੀ ਰਿਪੋਜ਼ਟਰੀ '%s' ਛੱਡੀ ਜਾ ਰਹੀ ਹੈ"
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "ਆਯੋਗ ਕੀਤੀ ਰਿਪੋਜ਼ਟਰੀ '%s' ਛੱਡੀ ਜਾ ਰਹੀ ਹੈ"
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "ਆਯੋਗ ਕੀਤੀ ਰਿਪੋਜ਼ਟਰੀ '%s' ਛੱਡੀ ਜਾ ਰਹੀ ਹੈ"
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "ਆਯੋਗ ਕੀਤੀ ਰਿਪੋਜ਼ਟਰੀ '%s' ਛੱਡੀ ਜਾ ਰਹੀ ਹੈ"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "ਆਯੋਗ ਕੀਤੀ ਰਿਪੋਜ਼ਟਰੀ '%s' ਛੱਡੀ ਜਾ ਰਹੀ ਹੈ"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ %s ਨੂੰ ਹਟਾਇਆ।"
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, fuzzy, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ %s ਨੂੰ ਹਟਾਇਆ।"
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, fuzzy, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਸ਼ਾਮਲ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ।"
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ %s ਅਣ-ਬਦਲੀ ਹੀ ਛੱਡੀ ਜਾ ਰਹੀ ਹੈ"
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 #, fuzzy
 msgid "Loading repository data..."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਡਾਟਾ ਲਿਆ ਜਾ ਰਿਹਾ ਹੈ..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਡਾਟਾ ਲਿਆ ਜਾ ਰਿਹਾ ਹੈ..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "ਰਿਪੋਜ਼ਟਰੀ '%s' ਕੈਚੇ ਨਹੀਂ ਹੈ। ਕੈਚੇ ਕੀਤਾ ਜਾ ਰਹੀ ਹੈ..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "'%s' ਤੋਂ ਡਾਟਾ ਲੋਡ ਕਰਨ ਦੌਰਾਨ ਸਮੱਸਿਆ"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "'%s' ਲਈ ਰਿਪੋਜ਼ਟਰੀ ਮੇਟਾਡਾਟਾ ਲੋਕਲ ਕੈਚੇ ਵਿੱਚ ਨਹੀਂ ਹੈ।"
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "'%s' ਤੋਂ ਹੱਲ-ਕਰਤਾ ਗਲਤੀ ਕਰਕੇ ਲੋਡ ਨਹੀਂ ਕੀਤੇ ਜਾ ਸਕੇ।"
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6115,31 +6132,31 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "ਇੰਸਟਾਲ ਪੈਕੇਜ ਪੜ੍ਹੇ ਜਾ ਰਹੇ ਹਨ"
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr ""
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6148,28 +6165,28 @@ msgstr ""
 msgid "System Packages"
 msgstr "ਸਿਸਟਮ ਏਰੀਆ ਆਈਟਮਾਂ"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "ਕੋਈ ਲੋੜੀਦਾ ਪੈਂਚ ਨਹੀਂ ਮਿਲਿਆ।"
 
-#: src/search.cc:342
+#: src/search.cc:344
 #, fuzzy
 msgid "No patterns found."
 msgstr "ਕੋਈ ਅੱਪਡੇਟ ਨਹੀਂ ਲੱਭਿਆ।"
 
-#: src/search.cc:450
+#: src/search.cc:453
 #, fuzzy
 msgid "No packages found."
 msgstr "ਕੋਈ ਅੱਪਡੇਟ ਨਹੀਂ ਲੱਭਿਆ।"
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "ਅੰਦਰੂਨੀ ਗਲਤੀ"
 
-#: src/search.cc:544
+#: src/search.cc:549
 #, fuzzy
 msgid "No products found."
 msgstr "ਕੋਈ ਅੱਪਡੇਟ ਨਹੀਂ ਲੱਭਿਆ।"
@@ -6564,7 +6581,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "ਪੈਂਚ"
 
@@ -6588,7 +6605,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "ਹੇਠ ਦਿੱਤੇ ਪੈਕੇਜ ਇੰਸਟਾਲ ਕੀਤੇ ਜਾਣਗੇ:\n"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "ਕੋਈ ਅੱਪਡੇਟ ਨਹੀਂ ਲੱਭਿਆ।"
 
@@ -6598,57 +6615,57 @@ msgstr "ਕੋਈ ਅੱਪਡੇਟ ਨਹੀਂ ਲੱਭਿਆ।"
 msgid "The following updates are also available:"
 msgstr "ਅੱਗੇ ਦਿੱਤੇ ਅੱਪਡੇਟ ਉਪਲੱਬਧ ਹਨ:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 #, fuzzy
 msgid "Package updates"
 msgstr "ਪੈਕੇਜ਼"
 
-#: src/update.cc:704
+#: src/update.cc:711
 #, fuzzy
 msgid "Pattern updates"
 msgstr "ਬੈਟਰੀ ਹਾਲਤ"
 
-#: src/update.cc:706
+#: src/update.cc:713
 #, fuzzy
 msgid "Product updates"
 msgstr "ਉਤਪਾਦ ਰੀਵਿਜ਼ਨ"
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "ਮੌਜੂਦਾ ਕੁਨੈਕਸ਼ਨ"
 
-#: src/update.cc:795
+#: src/update.cc:801
 #, fuzzy
 msgid "Available Version"
 msgstr "ਉਪਲੱਬਧ ਮੈਮੋਰੀ"
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "ਕੋਈ ਮੇਲ ਨਹੀਂ ਲੱਭਿਆ"
 
-#: src/update.cc:978
+#: src/update.cc:986
 #, fuzzy
 msgid "The following matches in issue numbers have been found:"
 msgstr "ਹੇਠ ਦਿੱਤੇ ਪੈਕੇਜ ਅੱਪਡੇਟ ਕੀਤੇ ਜਾਣਗੇ:\n"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -9,11 +9,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Polish <https://l10n.opensuse.org/projects/zypper/master/pl/>"
-"\n"
+"Language-Team: Polish <https://l10n.opensuse.org/projects/zypper/master/pl/"
+">\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -74,7 +74,8 @@ msgstr "Instalacja zakończyła się błędem."
 #: src/CommitSummary.cc:93
 #, boost-format
 msgid "You may run '%1%' to repair any dependency problems."
-msgstr "Możesz uruchomić '%1%', aby naprawić wszelkie problemy z zależnościami."
+msgstr ""
+"Możesz uruchomić '%1%', aby naprawić wszelkie problemy z zależnościami."
 
 #: src/CommitSummary.cc:127
 #, c-format, boost-format
@@ -822,7 +823,8 @@ msgstr[2] "Następujących %d aplikacji zostanie uaktualnionych:"
 msgid "The following package is going to be downgraded:"
 msgid_plural "The following %d packages are going to be downgraded:"
 msgstr[0] "Następujący pakiet zostanie przywrócony do wcześniejszej wersji:"
-msgstr[1] "Następujące %d pakiety zostaną przywrócone do wcześniejszych wersji:"
+msgstr[1] ""
+"Następujące %d pakiety zostaną przywrócone do wcześniejszych wersji:"
 msgstr[2] ""
 "Następujących %d pakietów zostanie przywróconych do wcześniejszych wersji:"
 
@@ -831,7 +833,8 @@ msgstr[2] ""
 msgid "The following patch is going to be downgraded:"
 msgid_plural "The following %d patches are going to be downgraded:"
 msgstr[0] "Następująca poprawka zostanie przywrócona do wcześniejszej wersji:"
-msgstr[1] "Następujące %d poprawki zostaną przywrócone do wcześniejszych wersji:"
+msgstr[1] ""
+"Następujące %d poprawki zostaną przywrócone do wcześniejszych wersji:"
 msgstr[2] ""
 "Następujących %d poprawek zostanie przywróconych do wcześniejszych wersji:"
 
@@ -849,7 +852,8 @@ msgstr[2] ""
 msgid "The following product is going to be downgraded:"
 msgid_plural "The following %d products are going to be downgraded:"
 msgstr[0] "Następujący produkt zostanie przywrócony do wcześniejszej wersji:"
-msgstr[1] "Następujące %d produkty zostaną przywrócone do wcześniejszych wersji:"
+msgstr[1] ""
+"Następujące %d produkty zostaną przywrócone do wcześniejszych wersji:"
 msgstr[2] ""
 "Następujących %d produktów zostanie przywróconych do wcześniejszych wersji:"
 
@@ -858,7 +862,8 @@ msgstr[2] ""
 msgid "The following application is going to be downgraded:"
 msgid_plural "The following %d applications are going to be downgraded:"
 msgstr[0] "Następująca aplikacja zostanie przywrócona do wcześniejszej wersji:"
-msgstr[1] "Następujące %d aplikacje zostaną przywrócone do wcześniejszych wersji:"
+msgstr[1] ""
+"Następujące %d aplikacje zostaną przywrócone do wcześniejszych wersji:"
 msgstr[2] ""
 "Następujących %d aplikacji zostanie przywróconych do wcześniejszych wersji:"
 
@@ -929,7 +934,8 @@ msgid_plural ""
 "The following %d recommended patterns were automatically selected:"
 msgstr[0] "Następujący zalecany wzorzec został automatycznie zaznaczony:"
 msgstr[1] "Następujące %d zalecane wzorce zostały automatycznie zaznaczone:"
-msgstr[2] "Następujących %d zalecanych wzorców zostało automatycznie zaznaczonych:"
+msgstr[2] ""
+"Następujących %d zalecanych wzorców zostało automatycznie zaznaczonych:"
 
 #: src/Summary.cc:1089
 #, c-format, boost-format
@@ -946,7 +952,8 @@ msgstr[2] ""
 msgid "The following recommended source package was automatically selected:"
 msgid_plural ""
 "The following %d recommended source packages were automatically selected:"
-msgstr[0] "Następujący zalecany pakiet źródłowy został automatycznie zaznaczony:"
+msgstr[0] ""
+"Następujący zalecany pakiet źródłowy został automatycznie zaznaczony:"
 msgstr[1] ""
 "Następujące %d zalecane pakiety źródłowe zostały automatycznie zaznaczone:"
 msgstr[2] ""
@@ -978,8 +985,8 @@ msgstr[1] ""
 "Następujące %d pakiety są zalecane, ale nie zostaną zainstalowane (zostaną "
 "zainstalowane wyłącznie wymagane pakiety):"
 msgstr[2] ""
-"Następujących %d pakietów jest zalecanych, ale nie zostanie zainstalowanych ("
-"zostaną zainstalowane wyłącznie wymagane pakiety):"
+"Następujących %d pakietów jest zalecanych, ale nie zostanie zainstalowanych "
+"(zostaną zainstalowane wyłącznie wymagane pakiety):"
 
 # Do rozważenia: "niechciany", "niepożądany".
 #: src/Summary.cc:1159
@@ -1053,8 +1060,10 @@ msgstr[2] ""
 msgid "The following application is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d applications are recommended, but will not be installed:"
-msgstr[0] "Następująca aplikacja jest zalecana, ale nie zostanie zainstalowana:"
-msgstr[1] "Następujące %d aplikacje są zalecane, ale nie zostaną zainstalowane:"
+msgstr[0] ""
+"Następująca aplikacja jest zalecana, ale nie zostanie zainstalowana:"
+msgstr[1] ""
+"Następujące %d aplikacje są zalecane, ale nie zostaną zainstalowane:"
 msgstr[2] ""
 "Następujących %d aplikacji jest zalecanych, ale nie zostanie zainstalowanych:"
 
@@ -1064,7 +1073,8 @@ msgid "The following package is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d packages are suggested, but will not be installed:"
 msgstr[0] "Następujący pakiet jest sugerowany, ale nie zostanie zainstalowany:"
-msgstr[1] "Następujące %d pakiety są sugerowane, ale nie zostaną zainstalowane:"
+msgstr[1] ""
+"Następujące %d pakiety są sugerowane, ale nie zostaną zainstalowane:"
 msgstr[2] ""
 "Następujących %d pakietów jest sugerowanych, ale nie zostanie "
 "zainstalowanych:"
@@ -1074,8 +1084,10 @@ msgstr[2] ""
 msgid "The following patch is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d patches are suggested, but will not be installed:"
-msgstr[0] "Następująca poprawka jest sugerowana, ale nie zostanie zainstalowana:"
-msgstr[1] "Następujące %d poprawki są sugerowane, ale nie zostaną zainstalowane:"
+msgstr[0] ""
+"Następująca poprawka jest sugerowana, ale nie zostanie zainstalowana:"
+msgstr[1] ""
+"Następujące %d poprawki są sugerowane, ale nie zostaną zainstalowane:"
 msgstr[2] ""
 "Następujących %d poprawek jest sugerowanych, ale nie zostanie "
 "zainstalowanych:"
@@ -1085,7 +1097,8 @@ msgstr[2] ""
 msgid "The following pattern is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d patterns are suggested, but will not be installed:"
-msgstr[0] "Następujący wzorzec jest sugerowany, ale nie zostanie zainstalowany:"
+msgstr[0] ""
+"Następujący wzorzec jest sugerowany, ale nie zostanie zainstalowany:"
 msgstr[1] "Następujące %d wzorce są sugerowane, ale nie zostaną zainstalowane:"
 msgstr[2] ""
 "Następujących %d wzorców jest sugerowanych, ale nie zostanie zainstalowanych:"
@@ -1095,8 +1108,10 @@ msgstr[2] ""
 msgid "The following product is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d products are suggested, but will not be installed:"
-msgstr[0] "Następujący produkt jest sugerowany, ale nie zostanie zainstalowany:"
-msgstr[1] "Następujące %d produkty są sugerowane, ale nie zostaną zainstalowane:"
+msgstr[0] ""
+"Następujący produkt jest sugerowany, ale nie zostanie zainstalowany:"
+msgstr[1] ""
+"Następujące %d produkty są sugerowane, ale nie zostaną zainstalowane:"
 msgstr[2] ""
 "Następujących %d produktów jest sugerowanych, ale nie zostanie "
 "zainstalowanych:"
@@ -1106,8 +1121,10 @@ msgstr[2] ""
 msgid "The following application is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d applications are suggested, but will not be installed:"
-msgstr[0] "Następująca aplikacja jest sugerowana, ale nie zostanie zainstalowana:"
-msgstr[1] "Następujące %d aplikacje są sugerowane, ale nie zostaną zainstalowane:"
+msgstr[0] ""
+"Następująca aplikacja jest sugerowana, ale nie zostanie zainstalowana:"
+msgstr[1] ""
+"Następujące %d aplikacje są sugerowane, ale nie zostaną zainstalowane:"
 msgstr[2] ""
 "Następujących %d aplikacji jest sugerowanych, ale nie zostanie "
 "zainstalowanych:"
@@ -1258,7 +1275,8 @@ msgid "The following package update will NOT be installed:"
 msgid_plural "The following %d package updates will NOT be installed:"
 msgstr[0] "Następująca aktualizacja pakietu NIE zostanie zainstalowana:"
 msgstr[1] "Następujące %d aktualizacje pakietów NIE zostaną zainstalowane:"
-msgstr[2] "Następujących %d aktualizacji pakietów NIE zostanie zainstalowanych:"
+msgstr[2] ""
+"Następujących %d aktualizacji pakietów NIE zostanie zainstalowanych:"
 
 #: src/Summary.cc:1465
 #, c-format, boost-format
@@ -1266,7 +1284,8 @@ msgid "The following product update will NOT be installed:"
 msgid_plural "The following %d product updates will NOT be installed:"
 msgstr[0] "Następująca aktualizacja produktu NIE zostanie zainstalowana:"
 msgstr[1] "Następujące %d aktualizacje produktów NIE zostaną zainstalowane:"
-msgstr[2] "Następujących %d aktualizacji produktów NIE zostanie zainstalowanych:"
+msgstr[2] ""
+"Następujących %d aktualizacji produktów NIE zostanie zainstalowanych:"
 
 #: src/Summary.cc:1471
 #, c-format, boost-format
@@ -1274,7 +1293,8 @@ msgid "The following application update will NOT be installed:"
 msgid_plural "The following %d application updates will NOT be installed:"
 msgstr[0] "Następująca aktualizacja aplikacji NIE zostanie zainstalowana:"
 msgstr[1] "Następujące %d aktualizacje aplikacji NIE zostaną zainstalowane:"
-msgstr[2] "Następujących %d aktualizacji aplikacji NIE zostanie zainstalowanych:"
+msgstr[2] ""
+"Następujących %d aktualizacji aplikacji NIE zostanie zainstalowanych:"
 
 #: src/Summary.cc:1504
 #, c-format, boost-format
@@ -1550,7 +1570,7 @@ msgstr "Program PackageKit ciągle działa (prawdopodobnie zajęty)."
 msgid "Try again?"
 msgstr "Spróbować ponownie?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Niespodziewany wyjątek."
 
@@ -1582,12 +1602,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Opcja %s nie dotyczy tego polecenia, została zignorowana."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Parametry programu nie będące opcjami: "
 
@@ -1738,7 +1758,8 @@ msgstr "Plik '%1%' jest podpisany nieznanym kluczem '%2%'."
 #: src/callbacks/keyring.h:217
 #, boost-format
 msgid "File '%1%' from repository '%3%' is signed with an unknown key '%2%'."
-msgstr "Plik '%1%' z repozytorium '%3%' jest podpisany nieznanym kluczem '%2%'."
+msgstr ""
+"Plik '%1%' z repozytorium '%3%' jest podpisany nieznanym kluczem '%2%'."
 
 #: src/callbacks/keyring.h:246
 msgid "Automatically importing the following key:"
@@ -2318,17 +2339,17 @@ msgid "Commands:"
 msgstr "Polecenia:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Wyświetlenie szczegółowego podsumowania instalacji."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Typ pakietu (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2336,9 +2357,15 @@ msgstr ""
 "Wykonanie aktualizacji w trybie najwyższej efektywności. Aktualizacje do "
 "wersji niższej niż ostatnia są również możliwe."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "Weź pod uwagę tylko poprawki mające wpływ na zarządzanie pakietami."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2414,7 +2441,7 @@ msgstr "zypper [--global-options] <polecenie> [--command-options] [argumenty]"
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <podpolecenie> [--command-options] [argumenty]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Wyświetla pomoc"
 
@@ -2500,9 +2527,9 @@ msgid ""
 "Remove packages with specified capabilities. A capability is NAME[.ARCH]"
 "[OP<VERSION>], where OP is one of <, <=, =, >=, >."
 msgstr ""
-"Usuwa pakiety o określonych właściwościach. Właściwość to NAZWA"
-"[.ARCHITEKTURA][OP<WERSJA>],  gdzie OP jest jednym z operatorów <, <=, =, "
-">=, >."
+"Usuwa pakiety o określonych właściwościach. Właściwość to "
+"NAZWA[.ARCHITEKTURA][OP<WERSJA>],  gdzie OP jest jednym z operatorów <, <=, "
+"=, >=, >."
 
 #: src/commands/installremove.cc:104 src/commands/installremove.cc:234
 #: src/utils/messages.cc:53
@@ -2626,22 +2653,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [OPCJE]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Wyświetla listę wszystkich odpowiednich poprawek."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Wyświetla listę wszystkich poprawek, nie tylko odpowiednich."
 
@@ -2697,36 +2724,40 @@ msgstr ""
 "języka. Listę dostępnych ustawień regionalnych można uzyskać za pomocą '%s'."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [opcje] [ustawienia regionalne] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Lista żądanych ustawień regionalnych (kodów języka)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Lista żądanych ustawień regionalnych i odpowiadających im pakietów."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Wyświetlenie odpowiadających pakietów."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Lista wszystkich dostępnych ustawień regionalnych."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 "Ignorowanie argumentów pozycyjnych, ponieważ został podany argument --all."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "Ustawienia regionalne, dla których mają zostać wydrukowane informacje."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2734,17 +2765,17 @@ msgstr ""
 "Pobranie wszystkich ustawień regionalnych z kodem języka 'en', które mają "
 "swój własny kod kraju, za wyjątkiem awaryjnego domyślnego kodu 'en':"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 "Pobranie wszystkich ustawień regionalnych z kodem języka 'en', z kodem kraju "
 "lub bez niego:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "Pobranie ustawień regionalnych dokładnie zgodnych z argumentem: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "Pobranie listy pakietów dostępnych dla kodów 'de' i 'en':"
 
@@ -2772,7 +2803,8 @@ msgstr ""
 
 #: src/commands/locale/removelocalecmd.cc:46
 msgid "Do not remove corresponding packages for given locale(s)."
-msgstr "Nie usuwanie odpowiadających pakietów dla danych ustawień regionalnych."
+msgstr ""
+"Nie usuwanie odpowiadających pakietów dla danych ustawień regionalnych."
 
 #. translators: command synopsis; do not translate the command 'name (abbreviations)' or '-option' names
 #: src/commands/locks/add.cc:29
@@ -2850,11 +2882,11 @@ msgstr[2] "Usunięto %lu blokad."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Nazwa"
 
@@ -2864,8 +2896,8 @@ msgstr "Pasujący"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Typ"
@@ -2873,7 +2905,7 @@ msgstr "Typ"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Repozytorium"
@@ -3137,7 +3169,8 @@ msgstr ""
 msgid ""
 "Automatically accept product licenses only. See 'man zypper' for more "
 "details."
-msgstr "Automatycznie akceptuj tylko licencje produktów. Szczegóły: man zypper."
+msgstr ""
+"Automatycznie akceptuj tylko licencje produktów. Szczegóły: man zypper."
 
 #. translators: --replacefiles
 #: src/commands/optionsets.cc:264
@@ -3330,7 +3363,7 @@ msgid "Command"
 msgstr "Polecenie"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Usługa"
 
@@ -3498,125 +3531,125 @@ msgid "Show detailed information for products."
 msgstr "Wyświetla szczegółowe informacje na temat produktów."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [opcje] [repozytorium]..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Wyświetlenie wszystkich dostępnych pakietów."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 "Wyświetla listę wszystkich pakietów dostępnych w określonych repozytoriach."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Pokaż sugerowane pakiety."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Pokaż zalecane pakiety."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Pokaż niepotrzebne pakiety."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Sortuj pakiety według nazwy."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Sortuj listę według repozytorium."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [repozytorium] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Wyświetlenie wszystkich dostępnych poprawek."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 "Wyświetla listę wszystkich poprawek dostępnych w określonych repozytoriach."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [opcje] [repozytorium] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Wyświetlenie wszystkich dostępnych wzorców."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 "Wyświetla listę wszystkich wzorców dostępnych w określonym repozytorium."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [opcje] [repozytorium] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Wyświetlenie wszystkich dostępnych produktów."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Wyświetla listę produktów dostępnych w określonych repozytoriach."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Tylko dane wyjściowe XML: dosłownie przekazuj znaczniki XML znalezione w "
 "pliku produktu."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "Opcja %1% nie ma zastosowania bez opcji globalnej %2%."
@@ -3660,12 +3693,12 @@ msgstr ""
 "Typ repozytorium jest zawsze automatycznie wykrywany. Ta opcja jest "
 "ignorowana."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "Nie można użyć %s razem z %s. Użyto ustawienia %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3708,113 +3741,117 @@ msgstr "Wyczyszczenie pamięci podręcznej nieprzetworzonych metadanych."
 msgid "Clean both metadata and package caches."
 msgstr "Wyczyszczenie zarówno pamięci podręcznej metadanych, jak i pakietów."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "Adres URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Włączono"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Sprawdzaj GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Priorytet"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Automatyczne odświeżanie"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Włącz"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Wyłącz"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Zachowaj pakiety"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "Adres URI klucza GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Prefiks ścieżki"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Usługa nadrzędna"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Słowa kluczowe"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Ścieżka do informacji w repozytorium"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Ścieżka MD Cache"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [opcje] [repozytorium] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Wyświetla wszystkie zdefiniowane repozytoria."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
-"Eksportuje wszystkie zdefiniowane repozytoria jako pojedynczy lokalny plik "
-".repo."
+"Eksportuje wszystkie zdefiniowane repozytoria jako pojedynczy lokalny "
+"plik .repo."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Błąd podczas odczytywania repozytoriów:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Nie można otworzyć pliku %s do zapisu."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Sprawdź uprawnienia do zapisu."
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Repozytoria zostały wyeksportowane do '%s'."
@@ -3822,20 +3859,20 @@ msgstr "Repozytoria zostały wyeksportowane do '%s'."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Odśwież"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Nie zdefiniowano żadnego repozytorium."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr "Aby dodać repozytoria, użyj polecenia 'zypper addrepo'."
 
@@ -3940,7 +3977,7 @@ msgstr "Opcja globalna '%s' nie ma tutaj zastosowania."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Argumenty są niedozwolone, gdy jest używane '%s'."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Wybrane repozytoria: "
 
@@ -3949,7 +3986,7 @@ msgstr "Wybrane repozytoria: "
 msgid "Refreshing repository '%s'."
 msgstr "Odświeżanie repozytorium '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Skanowanie zawartości wyłączonego repozytorium '%s'."
@@ -3959,7 +3996,7 @@ msgstr "Skanowanie zawartości wyłączonego repozytorium '%s'."
 msgid "Skipping disabled repository '%s'"
 msgstr "Pomijanie wyłączonego repozytorium '%s'"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Pominięto repozytorium '%s' z powodu powyższego błędu."
@@ -3986,7 +4023,7 @@ msgstr "Należy użyć '%s' lub '%s', aby dodać i odblokować repozytoria."
 msgid "Could not refresh the repositories because of errors."
 msgstr "Nie można odświeżyć repozytoriów z powodu błędów."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Część repozytoriów nie została odświeżona z powodu błędów."
 
@@ -4042,12 +4079,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Zmieniono nazwę repozytorium '%s' na '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "Repozytorium '%s' już istnieje. Użyj innego aliasu."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Błąd podczas modyfikacji repozytorium:"
 
@@ -4496,28 +4533,28 @@ msgid ""
 "Like --details, with additional information where the search has matched "
 "(useful for search in dependencies)."
 msgstr ""
-"Podobnie jak --details, ale dodaje informację o miejscu znalezienia frazy ("
-"przydatne podczas wyszukiwania zależności)."
+"Podobnie jak --details, ale dodaje informację o miejscu znalezienia frazy "
+"(przydatne podczas wyszukiwania zależności)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Określone repozytorium '%s' jest wyłączone."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Nie znaleziono pasujących elementów."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Wystąpił problem z inicjalizacją lub wykonaniem zapytania"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Wskazówki można znaleźć w powyższym komunikacie."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 "Uruchomienie polecenia 'zypper refresh' z uprawnieniami użytkownika root "
@@ -4612,7 +4649,7 @@ msgstr ""
 "'%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Pominięto usługę '%s' z powodu powyższego błędu."
@@ -4631,23 +4668,27 @@ msgstr "Usuwanie usługi '%s':"
 msgid "Service '%s' has been removed."
 msgstr "Usunięto usługę '%s'."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [opcje]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Wyświetlanie wszystkich zdefiniowanych usług."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Wyświetla zdefiniowane usługi."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Nie zdefiniowano żadnych usług. Aby je dodać, należy użyć polecenia '%s'."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4744,9 +4785,12 @@ msgstr "Nazwa usługi '%s' została ustawiona na '%s'."
 msgid "Repository '%s' has been added to enabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been added to enabled repositories of service '%s'"
-msgstr[0] "Repozytorium '%s' zostało dodane do włączonych repozytoriów usługi '%s'"
-msgstr[1] "Repozytoria '%s' zostały dodane do włączonych repozytoriów usługi '%s'"
-msgstr[2] "Repozytoria '%s' zostały dodane do włączonych repozytoriów usługi '%s'"
+msgstr[0] ""
+"Repozytorium '%s' zostało dodane do włączonych repozytoriów usługi '%s'"
+msgstr[1] ""
+"Repozytoria '%s' zostały dodane do włączonych repozytoriów usługi '%s'"
+msgstr[2] ""
+"Repozytoria '%s' zostały dodane do włączonych repozytoriów usługi '%s'"
 
 #: src/commands/services/modify.cc:262
 #, c-format, boost-format
@@ -4755,8 +4799,10 @@ msgid_plural ""
 "Repositories '%s' have been added to disabled repositories of service '%s'"
 msgstr[0] ""
 "Repozytorium '%s' zostało dodane do wyłączonych repozytoriów usługi '%s'"
-msgstr[1] "Repozytoria '%s' zostały dodane do wyłączonych repozytoriów usługi '%s'"
-msgstr[2] "Repozytoria '%s' zostały dodane do wyłączonych repozytoriów usługi '%s'"
+msgstr[1] ""
+"Repozytoria '%s' zostały dodane do wyłączonych repozytoriów usługi '%s'"
+msgstr[2] ""
+"Repozytoria '%s' zostały dodane do wyłączonych repozytoriów usługi '%s'"
 
 #: src/commands/services/modify.cc:269
 #, c-format, boost-format
@@ -4766,8 +4812,10 @@ msgid_plural ""
 "Repositories '%s' have been removed from enabled repositories of service '%s'"
 msgstr[0] ""
 "Repozytorium '%s' zostało usunięte z włączonych repozytoriów usługi '%s'"
-msgstr[1] "Repozytoria '%s' zostały usunięte z włączonych repozytoriów usługi '%s'"
-msgstr[2] "Repozytoria '%s' zostały usunięte z włączonych repozytoriów usługi '%s'"
+msgstr[1] ""
+"Repozytoria '%s' zostały usunięte z włączonych repozytoriów usługi '%s'"
+msgstr[2] ""
+"Repozytoria '%s' zostały usunięte z włączonych repozytoriów usługi '%s'"
 
 #: src/commands/services/modify.cc:276
 #, c-format, boost-format
@@ -4800,7 +4848,8 @@ msgstr "Nie zmieniono usługi %s."
 #: src/commands/services/refresh.cc:86
 #, c-format, boost-format
 msgid "Service '%s' not found by its alias, number, or URI."
-msgstr "Nie odnaleziono usługi '%s' na podstawie aliasu, numeru ani adresu URI."
+msgstr ""
+"Nie odnaleziono usługi '%s' na podstawie aliasu, numeru ani adresu URI."
 
 #: src/commands/services/refresh.cc:89
 #, c-format, boost-format
@@ -4878,7 +4927,8 @@ msgstr "Usuwa określoną usługę indeksu repozytorium (RIS) z systemu."
 #: src/commands/services/remove.cc:76
 #, c-format, boost-format
 msgid "Service '%s' not found by alias, number or URI."
-msgstr "Nie odnaleziono usługi '%s' na podstawie aliasu, numeru ani adresu URI."
+msgstr ""
+"Nie odnaleziono usługi '%s' na podstawie aliasu, numeru ani adresu URI."
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/shell.cc:20
@@ -5253,8 +5303,8 @@ msgid ""
 msgstr ""
 "Pobiera pakiety rpm określone w wierszu poleceń do katalogu lokalnego. "
 "Domyślnie pakiety są pobierane do pamięci podręcznej pakietu libzypp (/var/"
-"cache/zypp/packages; w przypadku użytkowników innych niż root jest to $"
-"XDG_CACHE_HOME/zypp/packages), ale ustawienie to można zmienić za pomocą "
+"cache/zypp/packages; w przypadku użytkowników innych niż root jest to "
+"$XDG_CACHE_HOME/zypp/packages), ale ustawienie to można zmienić za pomocą "
 "opcji globalnej --pkg-cache-dir."
 
 #. translators: command description
@@ -5584,15 +5634,15 @@ msgstr "%s jest starsze niż %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Wersja"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Architektura"
 
@@ -5727,13 +5777,13 @@ msgstr "(puste)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Zależność"
 
@@ -5770,7 +5820,7 @@ msgid "Flavor"
 msgstr "Rodzaj"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Podstawowy z dystrybucji"
 
@@ -6032,57 +6082,57 @@ msgstr[2] "Repozytorium"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Sprawdzanie, czy trzeba odświeżyć metadane dla %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Repozytorium \"%s\" jest aktualne."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Sprawdzenie aktualizacji '%s' zostało przełożone na później."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Wymuszono odświeżenie surowych metadanych"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Pobieranie metadanych repozytorium '%s'"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Czy trwale wyłączyć repozytorium %s?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Wystąpił błąd podczas wyłączania repozytorium '%s'."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Problem podczas pobierania plików z '%s'."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Więcej informacji zawiera powyższy komunikat błędów."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Nie określono adresów URI dla '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -6091,16 +6141,16 @@ msgstr ""
 "Dodaj co najmniej jeden bazowy adres URI (baseurl=URI) do pliku %s dla "
 "repozytorium '%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Nie określono aliasu dla tego repozytorium."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Repozytorium '%s' jest niepoprawne."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -6108,22 +6158,22 @@ msgstr ""
 "Proszę sprawdzić, czy zdefiniowane adresy URI dla tego repozytorium wskazują "
 "na poprawne repozytorium."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Błąd przetwarzania metadanych dla '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Wymuszono zbudowanie bufora repozytorium"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Błąd przetwarzania metadanych dla '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6135,42 +6185,42 @@ msgstr ""
 "zgodnie z instrukcją pod adresem http://en.opensuse.org/Zypper/"
 "Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Metadane repozytorium '%s' nie zostały znalezione w buforze lokalnym."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Błąd podczas budowania pamięci podręcznej:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 "Nie znaleziono repozytorium '%s' na podstawie aliasu, numeru ani adresu URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Należy użyć '%s', aby otrzymać listę zdefiniowanych repozytoriów."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Pomijanie wyłączonego repozytorium '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr "Można użyć opcji globalnej '%s', aby tymczasowo włączyć repozytoria."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Ignorowanie repozytorium '%s' z powodu opcji '%s'."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Tymczasowe włączanie repozytorium '%s'."
@@ -6178,7 +6228,7 @@ msgstr "Tymczasowe włączanie repozytorium '%s'."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6187,7 +6237,7 @@ msgstr ""
 "Repozytorium '%s' jest nieaktualne. Aby je zaktualizować, należy uruchomić "
 "polecenie 'zypper refresh' jako użytkownik root."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6196,81 +6246,81 @@ msgstr ""
 "Konieczne jest zbudowanie bufora metadanych dla repozytorium '%s'. Aby to "
 "zrobić, należy uruchomić polecenie 'zypper refresh' jako użytkownik root."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Repozytorium '%s' pozostaje wyłączone."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Inicjalizacja obiektu docelowego"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Inicjalizacja obiektu docelowego nie powiodła się:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Czyszczenie bufora metadanych dla '%s'."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Czyszczenie bufora surowych metadanych dla '%s'."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Zachowanie bufora surowych metadanych dla %s '%s'."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Czyszczenie pakietów dla '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Nie można wyczyścić repozytorium '%s' z powodu błędu."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Czyszczenie bufora zainstalowanych pakietów."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Nie można wyczyścić bufora zainstalowanych pakietów z powodu błędu."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Nie udało się wyczyścić repozytoriów z powodu błędów."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Niektóre z repozytoriów nie zostały wyczyszczone z powodu błędów."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Wybrane repozytoria zostały wyczyszczone."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Wszystkie repozytoria zostały wyczyszczone."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "To jest wymienny nośnik tylko do odczytu (CD/DVD). Automatyczne odświeżanie "
 "wyłączone."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Nieprawidłowy alias repozytorium: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6278,26 +6328,26 @@ msgstr ""
 "Nie można określić typu repozytorium. Proszę sprawdzić czy zdefiniowane "
 "adresy URI (poniżej) wskazują na poprawne repozytoria:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Nie można znaleźć poprawnego repozytorium w podanym miejscu:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 "Problem podczas przesyłania danych repozytorium spod podanego adresu URI:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Proszę sprawdzić, czy podany adres URI jest dostępny."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Nieokreślony problem podczas dodawania repozytorium:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6306,139 +6356,139 @@ msgstr ""
 "Sprawdzanie GPG jest wyłączone w konfiguracji repozytorium %1%. Nie można "
 "zweryfikować integralności ani pochodzenia pakietów."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Repozytorium '%s' zostało dodane"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Odczytywanie danych z nośnika '%s'"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Problem podczas odczytywania danych z nośnika '%s'"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-"Proszę sprawdzić, czy nośnik instalacyjny jest poprawny i można go odczytać."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 "Odczyt danych z nośnika %s jest opóźniony do czasu następnego odświeżenia."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Odczytywanie danych z nośnika '%s'"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Problem podczas odczytywania danych z nośnika '%s'"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+"Proszę sprawdzić, czy nośnik instalacyjny jest poprawny i można go odczytać."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Problem z dostępem do pliku spod podanego adresu URI"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Proszę sprawdzić, czy podany adres URI jest poprawny i dostępny."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Problem podczas analizy pliku pod podanym adresem URI"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Czy jest to plik .repo?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Napotkano problem podczas próby odczytu pliku spod podanego adresu URI"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 "Znaleziono w pliku repozytorium bez określonego aliasu. Zostanie ono "
 "pominięte."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Nie zdefiniowano adresu URI repozytorium '%s'. Zostanie ono pominięte."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Usunięto repozytorium '%s'."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Nie zmieniono priorytetu repozytorium '%s' (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Włączono repozytorium '%s'."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Wyłączono repozytorium '%s'."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Włączono automatycznie odświeżanie dla repozytorium '%s'."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Wyłączono automatyczne odświeżanie repozytorium '%s'."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Włączono buforowanie pakietów RPM dla repozytorium '%s'."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Wyłączono buforowanie pakietów RPM dla repozytorium '%s'."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Sprawdzanie GPG zostało włączone w repozytorium '%s'."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Sprawdzanie GPG zostało wyłączone w repozytorium '%s'."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Ustawiono priorytet repozytorium '%s' na %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Nazwa repozytorium '%s' została ustawiona na '%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Nie ma żadnych zmian dla repozytorium '%s'."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Nie zmieniono repozytorium '%s'."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Wczytywanie danych repozytorium..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6446,45 +6496,45 @@ msgstr ""
 "Nie zdefiniowano repozytoriów. Działanie tylko z zainstalowanymi obiektami "
 "rozstrzygalnymi. Nie można zainstalować."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Pobieranie danych repozytorium '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Repozytorium '%s' nie jest zbuforowane. Buforowanie..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Problem podczas wczytywania danych z '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 "Nie można odświeżyć repozytorium '%s'. Zostaje użyta stara pamięć podręczna."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Obiekty rozwiązywalne z '%s' nie zostały wczytane z powodu błędu."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 "Przed wykonaniem tej czynności należy użyć polecenia '%s' lub nawet '%s'."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6492,33 +6542,33 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Odczytywanie zainstalowanych pakietów..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Wystąpił problem podczas odczytywania zainstalowanych pakietów:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "\"%s\" wygląda jak plik RPM. Nastąpi próba pobrania."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 "Wystąpił problem z plikiem RPM określonym jako '%s' i został on pominięty."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 "Wystąpił problem podczas odczytu nagłówka pliku RPM %s. Czy to na pewno plik "
 "RPM?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Prosty bufor plików RPM"
 
@@ -6526,25 +6576,25 @@ msgstr "Prosty bufor plików RPM"
 msgid "System Packages"
 msgstr "Pakiety systemowe"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Nie znaleziono potrzebnych poprawek."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Nie znaleziono wzorców."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Nie znaleziono pakietów."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Nazwa wewnętrzna"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Nie znaleziono produktów."
 
@@ -6967,7 +7017,7 @@ msgid "Updatestack"
 msgstr "Aktualizacja stosu"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Poprawki"
 
@@ -6992,7 +7042,7 @@ msgstr ""
 "Potrzebne aktualizacje systemu zarządzania oprogramowaniem zostaną "
 "zainstalowane w pierwszej kolejności:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Nie znaleziono aktualizacji."
 
@@ -7001,52 +7051,52 @@ msgstr "Nie znaleziono aktualizacji."
 msgid "The following updates are also available:"
 msgstr "Dostępne są również następujące uaktualnienia:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Aktualizacje pakietów"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Aktualizacje wzorców"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Aktualizacje produktu"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Obecna wersja"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Dostępna wersja"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Nie znaleziono pasujących zgłoszeń."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Znaleziono wyniki w zgłoszeniach o następujących numerach:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "Znaleziono wyniki w opisach następujących poprawek:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "Nie znaleziono poprawki błędu nr %s w bugzilli lub nie jest ona wymagana."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 "Nie znaleziono poprawki dla zgłoszenia CVE nr %s lub nie jest ona wymagana."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""
@@ -7302,7 +7352,8 @@ msgstr ""
 #: src/utils/messages.cc:141
 #, c-format, boost-format
 msgid "Type '%s' to get a list of global options and commands."
-msgstr "Wprowadź '%s', aby uzyskać listę wszystkich globalnych opcji i poleceń."
+msgstr ""
+"Wprowadź '%s', aby uzyskać listę wszystkich globalnych opcji i poleceń."
 
 #. translators: %1% is the name of an (unknown) command
 #. translators: %2% something providing more info (like 'zypper help subcommand')

--- a/po/pt.po
+++ b/po/pt.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper.pt\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Portuguese <https://l10n.opensuse.org/projects/zypper/master/"
@@ -911,7 +911,8 @@ msgstr[1] ""
 msgid "The following recommended source package was automatically selected:"
 msgid_plural ""
 "The following %d recommended source packages were automatically selected:"
-msgstr[0] "O seguinte pacote fonte recomendado foi automaticamente seleccionado:"
+msgstr[0] ""
+"O seguinte pacote fonte recomendado foi automaticamente seleccionado:"
 msgstr[1] ""
 "Os seguintes %d pacotes fonte recomendados foram automaticamente "
 "selecionados:"
@@ -949,8 +950,8 @@ msgid_plural ""
 "The following %d packages are recommended, but will not be installed because "
 "they are unwanted (were manually removed before):"
 msgstr[0] ""
-"O pacote seguinte é recomendado, mas não será instalado porque é indesejado ("
-"foi removido manualmente antes):"
+"O pacote seguinte é recomendado, mas não será instalado porque é indesejado "
+"(foi removido manualmente antes):"
 msgstr[1] ""
 "Os seguintes %d pacotes são recomendados, mas não serão instalados porque "
 "são indesejados (foram removidos manualmente antes):"
@@ -992,7 +993,8 @@ msgid "The following product is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d products are recommended, but will not be installed:"
 msgstr[0] "O seguinte produto é recomendado, mas não será instalado:"
-msgstr[1] "Os seguintes %d produtos são recomendados, mas não serão instalados:"
+msgstr[1] ""
+"Os seguintes %d produtos são recomendados, mas não serão instalados:"
 
 #: src/Summary.cc:1195
 #, c-format, boost-format
@@ -1000,7 +1002,8 @@ msgid "The following application is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d applications are recommended, but will not be installed:"
 msgstr[0] "A seguinte aplicação é recomendada, mas não será instalada:"
-msgstr[1] "A seguintes %d aplicações são recomendadas, mas não serão instaladas:"
+msgstr[1] ""
+"A seguintes %d aplicações são recomendadas, mas não serão instaladas:"
 
 #: src/Summary.cc:1228
 #, c-format, boost-format
@@ -1439,7 +1442,7 @@ msgstr "O PackageKit ainda está a ser executado (provavelmente está ocupado)."
 msgid "Try again?"
 msgstr "Tentar novamente?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Excepção inesperada."
 
@@ -1470,12 +1473,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "A opção %s não tem nenhum efeito aqui, a ignorar."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Argumentos do programa sem opções: "
 
@@ -1578,8 +1581,10 @@ msgstr "O ficheiro de assinatura da chave gpg '%1%' expirou."
 #, boost-format
 msgid "The gpg key signing file '%1%' will expire in %2% day."
 msgid_plural "The gpg key signing file '%1%' will expire in %2% days."
-msgstr[0] "O ficheiro de assinatura da chave gpg '%1%' vai expirar num %2% dia."
-msgstr[1] "O ficheiro de assinatura da chave gpg '%1%' vai expirar em %2% dias."
+msgstr[0] ""
+"O ficheiro de assinatura da chave gpg '%1%' vai expirar num %2% dia."
+msgstr[1] ""
+"O ficheiro de assinatura da chave gpg '%1%' vai expirar em %2% dias."
 
 #: src/callbacks/keyring.h:152
 #, c-format, boost-format
@@ -1847,7 +1852,8 @@ msgstr ""
 
 #: src/callbacks/locks.h:30
 msgid "The following query locks some of the objects you want to unlock:"
-msgstr "A seguinte interrogação tranca alguns dos objectos que quer destrancar:"
+msgstr ""
+"A seguinte interrogação tranca alguns dos objectos que quer destrancar:"
 
 # power-off message
 #: src/callbacks/locks.h:35 src/callbacks/locks.h:50
@@ -2214,17 +2220,17 @@ msgid "Commands:"
 msgstr "Comandos:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Ver o resumo detalhado da instalação."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Tipo de pacote (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2232,9 +2238,15 @@ msgstr ""
 "Fazer uma abordagem 'melhor esforço' para a atualização. As atualizações "
 "para uma versão inferior à mais recente também são aceitáveis."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "Considerar apenas os remendos que afetam a própria gestão do pacote."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2311,7 +2323,7 @@ msgstr "zypper [--OPÇÕES-GLOBAIS] <COMANDO> [--OPÇÕES-DO-COMANDO] [ARGUMENTO
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <SUB-COMANDO> [--OPÇÕES-DO-COMANDO] [ARGUMENTOS]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Imprimir a ajuda do zypper"
 
@@ -2398,8 +2410,8 @@ msgid ""
 "Remove packages with specified capabilities. A capability is NAME[.ARCH]"
 "[OP<VERSION>], where OP is one of <, <=, =, >=, >."
 msgstr ""
-"Remover pacotes com capacidades especificadas. Uma capacidade é um NOME"
-"[.ARCH] ou [OP<VERSÃO>], onde OP é um dos sinais <, <=, =, >=, >."
+"Remover pacotes com capacidades especificadas. Uma capacidade é um "
+"NOME[.ARCH] ou [OP<VERSÃO>], onde OP é um dos sinais <, <=, =, >=, >."
 
 #: src/commands/installremove.cc:104 src/commands/installremove.cc:234
 #: src/utils/messages.cc:53
@@ -2522,22 +2534,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [OPÇÕES]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Lista de remendos disponíveis."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Lista todos os remendos aplicáveis."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Lista todos os remendos, incluindo os não aplicáveis."
 
@@ -2592,35 +2604,39 @@ msgstr ""
 "uma lista de todos os dialetos disponíveis, ao chamar \"%s\"."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [OPÇÕES] [DIALETOS] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Lista dialetos requisitados (códigos de língua)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Lista dialetos requisitados e os respetivos pacotes."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Mostrar pacotes correspondentes."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Listar todos os dialetos disponíveis."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr "Ignorar argumentos posicionais porque o argumento --all foi fornecido."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "O(s) dialeto(s) para o(s) qual(is) a informação será apresentada."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2628,17 +2644,17 @@ msgstr ""
 "Obter todos os dialetos com código de linguagem 'en' que tenham o seu "
 "próprio código de país, excluindo o de reserva 'en':"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 "Obter todos os dialetos com código de linguagem 'en' com ou sem código de "
 "país:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "Obter o dialeto que corresponde exatamente ao argumento: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "Obter a lista de pacotes que estão disponíveis para 'de' e 'en':"
 
@@ -2742,11 +2758,11 @@ msgstr[1] "Removidos %lu bloqueios."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Nome"
 
@@ -2756,8 +2772,8 @@ msgstr "Igualdades"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Tipo"
@@ -2765,7 +2781,7 @@ msgstr "Tipo"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Repositório"
@@ -3040,8 +3056,8 @@ msgid ""
 "download-as-needed disables the fileconflict check."
 msgstr ""
 "Instalar os pacotes mesmo que estes substituam ficheiros de outros pacotes "
-"já instalados. O padrão é tratar os conflitos de ficheiros como um erro. "
-"--download-as-needed  desativa a verificação de conflito de ficheiros."
+"já instalados. O padrão é tratar os conflitos de ficheiros como um erro. --"
+"download-as-needed  desativa a verificação de conflito de ficheiros."
 
 #. translators: -y, --no-confirm
 #: src/commands/optionsets.cc:291
@@ -3049,8 +3065,8 @@ msgid ""
 "Don't require user interaction. Alias for the --non-interactive global "
 "option."
 msgstr ""
-"Não é necessária a interação do utilizador. Pseudónimo para a opção global "
-"--non-interactive."
+"Não é necessária a interação do utilizador. Pseudónimo para a opção global --"
+"non-interactive."
 
 #: src/commands/optionsets.cc:309
 msgid ""
@@ -3222,7 +3238,7 @@ msgid "Command"
 msgstr "Comando"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Serviço"
 
@@ -3294,7 +3310,8 @@ msgstr ""
 #. translators: -s, --match-substrings
 #: src/commands/query/info.cc:65
 msgid "Print information for packages partially matching name."
-msgstr "Imprimir informação para pacotes que correspondam parcialmente ao nome."
+msgstr ""
+"Imprimir informação para pacotes que correspondam parcialmente ao nome."
 
 #. translators: --provides
 #: src/commands/query/info.cc:70
@@ -3391,122 +3408,122 @@ msgid "Show detailed information for products."
 msgstr "Mostrar informação detalhada para os produtos."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [OPÇÕES] [REPOSITÓRIO] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Listar todos os pacotes disponíveis."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Listar todos os pacotes disponíveis em repositórios especificados."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Mostrar pacotes que são sugeridos."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Mostrar pacotes que são recomendados."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Mostrar pacotes que são desnecessários."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Ordenar a lista pelo nome do pacote."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Ordenar a lista por repositório."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [REPOSITÓRIO] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Listar todos os remendos disponíveis."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Listar todos os remendos disponíveis em repositórios especificados."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [OPÇÕES] [REPOSITÓRIO] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Listar todos os padrões disponíveis."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Listar todos os padrões disponíveis em repositórios especificados."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [OPÇÕES] [REPOSITÓRIO] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Listar todos os produtos disponíveis."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Listar todos os produtos disponíveis em repositórios especificados."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Apenas saída em XML: Encaminhar literalmente as etiquetas XML encontradas "
 "num ficheiro de produto."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "A opção %1% não tem qualquer efeito sem a opção global %2%."
@@ -3529,8 +3546,8 @@ msgid ""
 "or can be read from specified .repo file (even remote)."
 msgstr ""
 "Adicionar um repositório ao sistema. O repositório pode ser especificado "
-"pelo seu URI ou pode ser lido a partir de um ficheiro .repo especificado ("
-"mesmo remoto)."
+"pelo seu URI ou pode ser lido a partir de um ficheiro .repo especificado "
+"(mesmo remoto)."
 
 #: src/commands/repos/add.cc:40
 msgid "Just another means to specify a .repo file to read."
@@ -3548,12 +3565,12 @@ msgstr "Não sondar URI, sondar mais tarde durante o refrescar."
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr "O tipo de repositório é sempre auto-detetado. Esta opção é ignorada."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "Incapaz de usar %s junto com %s. A utilizar as definições %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3598,112 +3615,116 @@ msgstr "Limpar cache de meta-dados puros."
 msgid "Clean both metadata and package caches."
 msgstr "Limpar tanto os meta-dados como as caches de pacotes."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alcunha"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Activado"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Verificação de GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Prioridade"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Auto-actualizar"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Ligado"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Desligado"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Manter Pacotes"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI da Chave GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Prefixo do Camimho"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Servidor Parente"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Palavras-chave"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Informação do Caminho da Repo"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Cache do Caminho MD"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [OPÇÕES] [REPO] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Listar todos os repositórios definidos."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 "Exportar todos os repositórios definidos como um único ficheiro local .repo."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Erro na leitura dos repositórios:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Incapaz de abrir %s para escrita."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Talvez você não tenha permissões de escrita?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Os repositórios foram exportados com sucesso para %s."
@@ -3711,20 +3732,20 @@ msgstr "Os repositórios foram exportados com sucesso para %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Refrescar"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Sem repositórios definidos."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 "Utilizar o comando 'zypper addrepo' para adicionar um ou mais repositórios."
@@ -3830,7 +3851,7 @@ msgstr "A opção global '%s' não tem nenhum efeito aqui."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Não são permitidos argumentos quando se utiliza '%s'."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Repositórios especificados: "
 
@@ -3839,7 +3860,7 @@ msgstr "Repositórios especificados: "
 msgid "Refreshing repository '%s'."
 msgstr "A refrescar o repositório '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "A examinar o conteúdo do repositório desativado '%s'."
@@ -3849,7 +3870,7 @@ msgstr "A examinar o conteúdo do repositório desativado '%s'."
 msgid "Skipping disabled repository '%s'"
 msgstr "A saltar o repositório desactivado '%s'"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "A saltar o repositório '%s' devido ao erro acima."
@@ -3877,7 +3898,7 @@ msgstr "Use os comandos '%s' ou '%s' para adicionar ou activar repositórios."
 msgid "Could not refresh the repositories because of errors."
 msgstr "Não foi possível refrescar os repositórios devido a erros."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Alguns dos repositórios não foram refrescados devido a um erro."
 
@@ -3932,13 +3953,13 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Repositório '%s' renomeado para '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 "Um repositório com o nome '%s' já existe. Por favor utilize outra alcunha."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Erro enquanto modificava o repositório:"
 
@@ -4392,7 +4413,8 @@ msgstr "Efetuar pesquisa sensível a maiúsculas e minúsculas."
 #. translators: -s, --details
 #: src/commands/search/search.cc:201
 msgid "Show each available version in each repository on a separate line."
-msgstr "Mostrar cada versão disponível em cada repositório numa linha separada."
+msgstr ""
+"Mostrar cada versão disponível em cada repositório numa linha separada."
 
 #. translators: -v, --verbose
 #: src/commands/search/search.cc:205
@@ -4400,28 +4422,28 @@ msgid ""
 "Like --details, with additional information where the search has matched "
 "(useful for search in dependencies)."
 msgstr ""
-"Como --details, com informação adicional onde a pesquisa se tenha igualado ("
-"útil para pesquisa em dependências)."
+"Como --details, com informação adicional onde a pesquisa se tenha igualado "
+"(útil para pesquisa em dependências)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "O repositório especificado '%s' está desativado."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Não foram encontradas igualdades."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Ocorreram problemas a iniciar ou a executar a consulta da pesquisa"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Veja a mensagem acima para uma sugestão."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "Executar 'zypper refresh' como root poderá resolver o problema."
 
@@ -4510,10 +4532,11 @@ msgstr "A refrescar o serviço '%s'."
 #: src/commands/services/common.cc:136 src/commands/services/common.cc:146
 #, c-format, boost-format
 msgid "Problem retrieving the repository index file for service '%s':"
-msgstr "Problema ao obter o ficheiro índice do repositório para o serviço '%s':"
+msgstr ""
+"Problema ao obter o ficheiro índice do repositório para o serviço '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "A saltar o repositório '%s' devido ao erro acima."
@@ -4532,24 +4555,28 @@ msgstr "A remover o serviço '%s':"
 msgid "Service '%s' has been removed."
 msgstr "O serviço '%s' foi removido."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [OPÇÕES]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Listar todos os serviços definidos."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Listar serviços definidos."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Nenhum serviço definido. Use o comando '%s' para adicionar um ou mais "
 "serviços."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4729,7 +4756,8 @@ msgstr "Refrescar também os repositórios de serviço."
 
 #: src/commands/services/refresh.cc:115
 msgid "Also restore service repositories enabled/disabled state."
-msgstr "Restaurar também os repositórios de serviços habilitados/desabilitados."
+msgstr ""
+"Restaurar também os repositórios de serviços habilitados/desabilitados."
 
 #: src/commands/services/refresh.cc:179
 #, c-format, boost-format
@@ -4964,7 +4992,8 @@ msgstr "waitpid para  %1% , falhou (%2%)"
 #: src/commands/subcommand.cc:370
 #, boost-format
 msgid "waitpid for %1% returns unexpected pid %2% while waiting for %3%"
-msgstr "waitpid para %1% devolve um pid inesperado %2%, enquanto espera por %3%"
+msgstr ""
+"waitpid para %1% devolve um pid inesperado %2%, enquanto espera por %3%"
 
 #. translators: %1% - command name or path
 #. translators: %2% - signal number
@@ -5220,7 +5249,8 @@ msgstr "Imprimir relatório sobre licenças e EULAs de pacotes instalados."
 #. translators: command description
 #: src/commands/utils/licenses.cc:23
 msgid "Report licenses and EULAs of currently installed software packages."
-msgstr "Relata licenças e EULAs dos pacotes de software actualmente instalados."
+msgstr ""
+"Relata licenças e EULAs dos pacotes de software actualmente instalados."
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/utils/purge-kernels.cc:26
@@ -5482,15 +5512,15 @@ msgstr "%s é mais velho que %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Versão"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arch"
 
@@ -5624,13 +5654,13 @@ msgstr "(vazio)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Dependência"
 
@@ -5667,7 +5697,7 @@ msgid "Flavor"
 msgstr "Preferência"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "É Base"
 
@@ -5934,57 +5964,57 @@ msgstr[1] "%1% repositórios"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "A verificar se refresca a metadata de %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "O repositório '%s' está actualizado."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "A verificação de actualidade de '%s' foi adiada."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "A forçar resfrescagem de metadata sem formatação"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "A obter metadados do repositório '%s'"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Quer desativar o repositório %s permanentemente?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Erro ao desativar o repositório '%s'."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Problema ao obter ficheiros de '%s'."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Por favor, veja o erro acima para uma sugestão."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Nenhum URI definido para '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -5993,16 +6023,16 @@ msgstr ""
 "Por favor, adicione uma ou mais entradas de URI base (baseurl=URI) ao %s "
 "para o repositório '%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Nenhuma alcunha definida para este repositório."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Repositório '%s' inválido."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -6010,22 +6040,22 @@ msgstr ""
 "Por favor, verifique se o os URIs definidos para este repositório estão a "
 "apontar para um repositório válido."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Erro ao obter metadados de '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "A forçar construção da cache do repositório"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Erro ao interpretar a metadata de '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6037,43 +6067,44 @@ msgstr ""
 "preencha um relatório de erro seguindo as instruções em http://"
 "en.opensuse.org/Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Não foi encontrada a metadata do repositório '%s' na cache local."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Erro ao construir a cache:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
-msgstr "O repositório '%s' não foi encontrado pela sua alcunha, número, ou URI."
+msgstr ""
+"O repositório '%s' não foi encontrado pela sua alcunha, número, ou URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Use '%s' para obter a lista dos repositórios definidos."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "A ignorar o repositório desativado '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "A opção global '%s' pode ser utilizada para ativar temporariamente "
 "repositórios."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "A ignorar o repositório '%s' devido à opção '%s'."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "A ativar temporariamente o repositório '%s'."
@@ -6081,7 +6112,7 @@ msgstr "A ativar temporariamente o repositório '%s'."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6090,7 +6121,7 @@ msgstr ""
 "O repositório '%s' está desactualizado. Para o actualizar, poderá correr "
 "'zypper refresh'."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6099,82 +6130,82 @@ msgstr ""
 "A cache dos metadados precisa ser construida para o repositório '%s'. Pode "
 "correr 'zypper refresh' como root para fazer isto."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "O repositório '%s' permanece desativado."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "A inicializar o Destino"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Falhou a inicialização do alvo:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "A limpar a cache dos metadados de '%s'."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "A limpar a cache dos metadados raw de '%s'."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Mantendo a cache dos metadados raw para %s '%s'."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "A limpar os pacotes de '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Incapaz de limpar repositório '%s' devido a um erro."
 
 # /usr/lib/YaST2/clients/sw_single.ycp:12
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "A limpar a cache de pacotes instalados."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Incapaz de limpar a cache de pacotes instalados por causa de um erro."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Não foi possível limpar os repositórios devido a erros."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Alguns dos repositórios não foram limpos devido a um erro."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Os repositórios especificados foram limpos."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Todos os repositórios foram limpos."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Este é um suporte apenas de leitura alterável (CD/DVD), a desactivar "
 "refrescagem automática."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Pseudónimo de repositório inválido: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6182,25 +6213,25 @@ msgstr ""
 "Não foi possível determinar o tipo do repositório. Por favor verifique se os "
 "URIs definidos (veja abaixo) apontam para um repositório válido:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Não é possível encontrar um repositório válido na localização dada:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Problema ao transferir dados do repositório do URI especificado:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Por favor verifique se o URI especificado está acessível."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Programa desconhecido ao adicionar o repositório:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6209,136 +6240,136 @@ msgstr ""
 "A verificação GPG está desativada na configuração do repositório '%1%'. A "
 "integridade e a origem dos pacotes não podem ser verificadas."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "O repositório '%s' foi adicionado com sucesso"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "A ler os dados do suporte '%s'"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Problema ao ler os dados do suporte '%s'"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Por favor verifique se o seu suporte de instalação é válido e legível."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 "A leitura dos dados dos meios \"%s\" é adiada até o próximo refrescamento."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "A ler os dados do suporte '%s'"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Problema ao ler os dados do suporte '%s'"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Por favor verifique se o seu suporte de instalação é válido e legível."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Problema ao aceder o ficheiro no URI especificado"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Por favor verifique se o URI é válido e acessível."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Problema ao interpretar o ficheiro no URI especificado"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "É um ficheiro .repo?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Problema encontrado ao tentar ler o ficheiro no URI especificado"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Repositório sem alcunha definida encontado no ficheiro, a saltar."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Repositório '%s' não tem URI definido, a saltar."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Repositório '%s' foi removido."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Prioridade do repositório '%s' foi deixada inalterada (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "O repositório '%s' foi activado com sucesso."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "O repositório '%s' foi desactivado com sucesso."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "A auto-actualização foi activada para o repositório '%s'."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Auto-actualização foi desactivada para o repositório '%s'."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Foi activada a cache de ficheiros RPM para o repositório '%s'."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Foi desactivada a cache de ficheiros RPM para o repositório '%s'."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "A verificação GPG foi ativada para o repositório '%s'."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "A verificação GPG foi desativada para o repositório '%s'."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "A prioridade do repositório '%s' foi foi definida para %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "O nome do repositório '%s' foi definido para '%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Nada a mudar para o repositório '%s'."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "A deixar o repositório %s inalterado."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "A obter dados do repositório..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6346,43 +6377,43 @@ msgstr ""
 "Nenhum repositórios definido. A funcionar apenas com os resolvedores "
 "instalados. Nada pode ser instalado."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "A obter dados do repositório '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "O repositório '%s' não está em cache. A colocar em cache..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Problema ao carregar dados de '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "O repositório '%s' não pôde ser refrescado. A utilizar cache antiga."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Os resolúveis de '%s' não foram carregados devido a um erro."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "Metadados do repositório '%1%' expirou desde %2%."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Tente '%s', ou ainda '%s' antes de fazer isso."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6391,30 +6422,30 @@ msgid ""
 msgstr ""
 
 # /usr/lib/YaST2/clients/sw_single.ycp:12
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "A ler pacotes instalados..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Um problema ocorreu ao ler os pacotes instalados:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' parece ser um ficheiro RPM. Tente descarregá-lo."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Problemas com o ficheiro RPM especificado como '%s', a ignorar."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Problemas ao ler o cabeçalho RPM de %s. Será mesmo um ficheiro RPM?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Cache de ficheiros RPM simples"
 
@@ -6422,25 +6453,25 @@ msgstr "Cache de ficheiros RPM simples"
 msgid "System Packages"
 msgstr "Pacotes de Sistema"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Nenhuma correcção necessária encontrada."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Nenhuma padrão encontrado."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Nenhum pacote encontrado."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Nome Interno"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Nenhuma produto encontrado."
 
@@ -6837,7 +6868,7 @@ msgid "Updatestack"
 msgstr "Pilha de atualização"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Correcções"
 
@@ -6862,7 +6893,7 @@ msgstr ""
 "As atualizações de gestão de software necessárias irão ser instaladas de "
 "antemão:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Nenhuma actualização encontrada."
 
@@ -6872,55 +6903,55 @@ msgstr "Nenhuma actualização encontrada."
 msgid "The following updates are also available:"
 msgstr "As seguintes atualizações estão também disponíveis:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Actualizações de pacotes"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Actualizações de padrões"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Actualizações de produtos"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Versão Atual"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Versão Disponível"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Não foram encontrados problemas de correspondência."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "As seguintes correspondências foram encontradas em números de emissão:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 "Foram encontradas correspondências nas descrições da correção, nas seguintes "
 "correções:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "A correção para o problema no bugzilla numero %s ou não foi encontrado ou "
 "não é necessário."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 "A correção para o CVE numero %s ou não foi encontrada ou não é necessária."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "A correção para %s numero %s não foi encontrada ou não é necessária."
@@ -7118,7 +7149,8 @@ msgstr "Por favor submeta um relatório de erro sobre disto."
 #. unless you translate the actual page :)
 #: src/utils/messages.cc:22
 msgid "See http://en.opensuse.org/Zypper/Troubleshooting for instructions."
-msgstr "Consulte http://en.opensuse.org/Zypper/Troubleshooting para instruções."
+msgstr ""
+"Consulte http://en.opensuse.org/Zypper/Troubleshooting para instruções."
 
 #: src/utils/messages.cc:38
 msgid "Too many arguments."
@@ -7431,7 +7463,8 @@ msgstr "Resposta ambígua '%s'."
 #: src/utils/prompt.cc:289
 #, c-format, boost-format
 msgid "Enter '%s' for '%s' or '%s' for '%s' if nothing else works for you."
-msgstr "Insira '%s' para '%s' ou '%s' para '%s' se nada mais funcionar consigo."
+msgstr ""
+"Insira '%s' para '%s' ou '%s' para '%s' se nada mais funcionar consigo."
 
 #: src/utils/prompt.cc:294
 msgid ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-08-04 14:59+0000\n"
 "Last-Translator: Samanta Magalhaes <samanta_texttrans@outlook.com>\n"
 "Language-Team: Portuguese (Brazil) <https://l10n.opensuse.org/projects/"
@@ -912,7 +912,8 @@ msgstr[1] ""
 msgid "The following recommended source package was automatically selected:"
 msgid_plural ""
 "The following %d recommended source packages were automatically selected:"
-msgstr[0] "O seguinte pacote fonte recomendado foi selecionado automaticamente:"
+msgstr[0] ""
+"O seguinte pacote fonte recomendado foi selecionado automaticamente:"
 msgstr[1] ""
 "Os seguintes %d pacotes fontes recomendados foram selecionados "
 "automaticamente:"
@@ -977,7 +978,8 @@ msgid "The following patch is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d patches are recommended, but will not be installed:"
 msgstr[0] "A seguinte correção é recomendada, mas não será instalada:"
-msgstr[1] "As seguintes %d correções são recomendadas, mas não serão instaladas:"
+msgstr[1] ""
+"As seguintes %d correções são recomendadas, mas não serão instaladas:"
 
 #: src/Summary.cc:1186
 #, c-format, boost-format
@@ -993,7 +995,8 @@ msgid "The following product is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d products are recommended, but will not be installed:"
 msgstr[0] "O seguinte produto é recomendado, mas não será instalado:"
-msgstr[1] "Os seguintes %d produtos são recomendados, mas não serão instalados:"
+msgstr[1] ""
+"Os seguintes %d produtos são recomendados, mas não serão instalados:"
 
 #: src/Summary.cc:1195
 #, c-format, boost-format
@@ -1001,7 +1004,8 @@ msgid "The following application is recommended, but will not be installed:"
 msgid_plural ""
 "The following %d applications are recommended, but will not be installed:"
 msgstr[0] "O seguinte aplicativo é recomendado, mas não será instalado:"
-msgstr[1] "Os seguintes %d aplicativos são recomendados, mas não serão instalados:"
+msgstr[1] ""
+"Os seguintes %d aplicativos são recomendados, mas não serão instalados:"
 
 #: src/Summary.cc:1228
 #, c-format, boost-format
@@ -1041,7 +1045,8 @@ msgid "The following application is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d applications are suggested, but will not be installed:"
 msgstr[0] "O seguinte aplicativo é sugerido, mas não será instalado:"
-msgstr[1] "Os seguintes %d aplicativos são sugeridos, mas não serão instalados:"
+msgstr[1] ""
+"Os seguintes %d aplicativos são sugeridos, mas não serão instalados:"
 
 #: src/Summary.cc:1274
 #, c-format, boost-format
@@ -1118,7 +1123,8 @@ msgstr[1] "Os seguintes %d aplicativos irão alterar de fornecedor:"
 msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
-msgstr[0] "O seguinte pacote não possui informação de suporte de seu fornecedor:"
+msgstr[0] ""
+"O seguinte pacote não possui informação de suporte de seu fornecedor:"
 msgstr[1] ""
 "Os seguintes %d pacotes não possuem informação de suporte de seus "
 "fornecedores:"
@@ -1202,7 +1208,8 @@ msgstr[1] "As seguintes %d atualizações de aplicativo NÃO serão instaladas:"
 msgid "The following item is locked and will not be changed by any action:"
 msgid_plural ""
 "The following %d items are locked and will not be changed by any action:"
-msgstr[0] "O seguinte item está bloqueado e não será alterado por nenhuma ação:"
+msgstr[0] ""
+"O seguinte item está bloqueado e não será alterado por nenhuma ação:"
 msgstr[1] ""
 "Os seguintes %d itens estão bloqueados e não serão alterados por nenhuma "
 "ação:"
@@ -1450,7 +1457,7 @@ msgstr "O PackageKit ainda está em execução (provavelmente ocupado)."
 msgid "Try again?"
 msgstr "Tentar novamente?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Exceção inesperada."
 
@@ -1481,12 +1488,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "A opção %s não tem efeito aqui, ignorando."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Argumentos sem opção do programa: "
 
@@ -1769,7 +1776,8 @@ msgstr ""
 #, boost-format
 msgid "Received %1% new package signing key from repository \"%2%\":"
 msgid_plural "Received %1% new package signing keys from repository \"%2%\":"
-msgstr[0] "Recebido %1% novo pacote de chave de assinatura do repositório \"%2%\":"
+msgstr[0] ""
+"Recebido %1% novo pacote de chave de assinatura do repositório \"%2%\":"
 msgstr[1] ""
 "Recebidos %1% novos pacotes de chaves de assinatura do repositório \"%2%\":"
 
@@ -1925,7 +1933,8 @@ msgstr "c/r/i/u/s"
 
 #: src/callbacks/media.cc:79
 msgid "Disable SSL certificate authority check and continue."
-msgstr "Desabilitar a verificação da autoridade do certificado SSL e continuar."
+msgstr ""
+"Desabilitar a verificação da autoridade do certificado SSL e continuar."
 
 #. translators: this is a prompt text
 #: src/callbacks/media.cc:82 src/callbacks/media.cc:174
@@ -2240,17 +2249,17 @@ msgid "Commands:"
 msgstr "Comandos:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Exibir o resumo de instalação detalhado."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Tipo de pacote (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2258,9 +2267,15 @@ msgstr ""
 "Adotar o método 'melhor esforço' para atualizar. Atualizações para uma "
 "versão anterior à mais recente também são aceitáveis."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "Considere apenas os patches que afetam o gerenciamento de pacotes."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2342,7 +2357,7 @@ msgstr "zypper [--opções-globais] <comando> [--opções-de-comando] [argumento
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <subcomando> [--opções-de-comando] [argumentos]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Exibir a ajuda"
 
@@ -2428,8 +2443,9 @@ msgid ""
 "Remove packages with specified capabilities. A capability is NAME[.ARCH]"
 "[OP<VERSION>], where OP is one of <, <=, =, >=, >."
 msgstr ""
-"Remove os pacotes com os recursos especificados. Um recurso é NOME"
-"[.ARQUITETURA][OP<VERSÃO>], em que OP é um dos operadores <, <=, =, >=, >."
+"Remove os pacotes com os recursos especificados. Um recurso é "
+"NOME[.ARQUITETURA][OP<VERSÃO>], em que OP é um dos operadores <, <=, =, >=, "
+">."
 
 #: src/commands/installremove.cc:104 src/commands/installremove.cc:234
 #: src/utils/messages.cc:53
@@ -2564,22 +2580,22 @@ msgstr ""
 "atualização."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [opções]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Liste os patches disponíveis."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Lista todas as correções aplicáveis."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Lista todas as correções, não apenas as aplicáveis."
 
@@ -2636,38 +2652,42 @@ msgstr ""
 "Obtenha uma lista de todas as localidades disponíveis chamando '%s'."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locais (lloc) [OPTIONS] [LOCALE] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Listar localidades solicitadas (códigos de idiomas)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Listar os locais solicitados e os pacotes correspondentes."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Mostrar os pacotes correspondentes."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Listar todos os locais disponíveis."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 "Ignorando argumentos posicionais porque --todos os argumentos foram "
 "fornecidos."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 "O (s) local (ais) para o (s) qual (is) a informação será (em) impressa (s)."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2675,17 +2695,17 @@ msgstr ""
 "Obtenha todas as localidades com o código de idioma 'en' que tenham seu "
 "próprio código de país, excluindo o substituto 'en':"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 "Obtenha todas as localidades com o código de idioma 'en' com ou sem código "
 "do país:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "Obtenha o código do idioma correspondente exatamente ao argumento: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "Obtenha a lista de pacotes disponíveis para 'de' e 'en':"
 
@@ -2798,11 +2818,11 @@ msgstr[1] "Bloqueios %lu removidos."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Nome"
 
@@ -2812,8 +2832,8 @@ msgstr "Correspondências"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Tipo"
@@ -2821,7 +2841,7 @@ msgstr "Tipo"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Repositório"
@@ -3285,7 +3305,7 @@ msgid "Command"
 msgstr "Comando"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Serviço"
 
@@ -3458,22 +3478,22 @@ msgid "Show detailed information for products."
 msgstr "Exibe informações detalhadas dos produtos."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [opções] [repositório] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Listar todos os pacotes disponíveis."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Lista todos os pacotes disponíveis nos repositórios especificados."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
@@ -3481,20 +3501,20 @@ msgstr ""
 "solucionador."
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 "Mostrar os pacotes instalados que foram selecionados explicitamente pelo "
 "usuário."
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 "Mostrar pacotes instalados que não são fornecidos por nenhum repositório."
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
@@ -3503,84 +3523,84 @@ msgstr ""
 "de atualização)."
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Exibir pacotes sugeridos."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Exibir pacotes recomendados."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Exibir pacotes desnecessários."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Ordenar a lista pelo nome do pacote."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Ordenar a lista pelo repositório."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [repositório] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Listar todas as correções disponíveis."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Lista todas as correções disponíveis no repositório especificado."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [opções] [repositório] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Listar todos os padrões disponíveis."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Lista todos os padrões disponíveis nos repositórios especificados."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [opções] [repositório] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Listar todos os produtos disponíveis."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Lista todos os produtos disponíveis nos repositórios especificados."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Saída XML apenas: Literalmente encaminhar as etiquetas XML encontradas em um "
 "arquivo de produto."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "A opção %1% não tem efeito sem a opção global %2%."
@@ -3619,14 +3639,15 @@ msgstr "Não testar o URI, testá-lo mais tarde durante a atualização."
 
 #: src/commands/repos/add.cc:46
 msgid "The repository type is always autodetected. This option is ignored."
-msgstr "O tipo de repositório sempre é autodetectado. Essa opção será ignorada."
+msgstr ""
+"O tipo de repositório sempre é autodetectado. Essa opção será ignorada."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "Não é possível utilizar %s junto com %s. Usando a configuração de %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3671,111 +3692,115 @@ msgstr "Limpar o cache de metadados brutos."
 msgid "Clean both metadata and package caches."
 msgstr "Limpar ambos os caches de metadados e pacotes."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Apelido"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Habilitado"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Verificação GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Prioridade"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Atualização automática"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Ativado"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Desativado"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Manter pacotes"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI da chave GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Prefixo do caminho"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Serviço pai"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Palavras-chave"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Caminho de informações do repositório"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Caminho do cache MD"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [opções] [repositório] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Lista todos os repositórios definidos."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "Exportar todos os repositórios definidos como um único arquivo .repo."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Erro ao ler os repositórios:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Não foi possível abrir %s para gravação."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Talvez você não tenha permissão de gravação?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Os repositórios foram exportados para %s com sucesso."
@@ -3783,20 +3808,20 @@ msgstr "Os repositórios foram exportados para %s com sucesso."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Atualizar"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "Manter"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Nenhum repositório definido."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr "Use o comando 'zypper addrepo' para adicionar um ou mais repositórios."
 
@@ -3904,7 +3929,7 @@ msgstr "A opção global '%s' não tem efeito aqui."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Argumentos não serão permitidos se '%s' for utilizado."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Repositórios especificados: "
 
@@ -3913,7 +3938,7 @@ msgstr "Repositórios especificados: "
 msgid "Refreshing repository '%s'."
 msgstr "Atualizando o repositório '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Examinando o conteúdo do repositório desabilitado '%s'."
@@ -3923,7 +3948,7 @@ msgstr "Examinando o conteúdo do repositório desabilitado '%s'."
 msgid "Skipping disabled repository '%s'"
 msgstr "Ignorando o repositório desabilitado '%s'"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Ignorando o repositório '%s' devido ao erro acima."
@@ -3945,13 +3970,14 @@ msgstr "Não há repositórios habilitados definidos."
 #: src/commands/repos/refresh.cc:331
 #, c-format, boost-format
 msgid "Use '%s' or '%s' commands to add or enable repositories."
-msgstr "Use o comando '%s' ou '%s' para adicionar ou habilitar os repositórios."
+msgstr ""
+"Use o comando '%s' ou '%s' para adicionar ou habilitar os repositórios."
 
 #: src/commands/repos/refresh.cc:337
 msgid "Could not refresh the repositories because of errors."
 msgstr "Não foi possível atualizar os repositórios devido a erros."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Alguns dos repositórios não foram atualizados devido a um erro."
 
@@ -4006,12 +4032,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Repositório '%s' renomeado para '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "Um repositório chamado '%s' já existe. Escolha outro apelido."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Erro ao alterar o repositório:"
 
@@ -4478,25 +4504,25 @@ msgstr ""
 "Semelhante a --details, com informações adicionais sobre o local da "
 "correspondência (útil para pesquisar dependências)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "O repositório especificado '%s' está desabilitado."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Nenhum item correspondente encontrado."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Problema ao inicializar ou executar a pesquisa"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Veja a mensagem acima para uma dica."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "Executar 'zypper refresh' como root deve resolver o problema."
 
@@ -4591,7 +4617,7 @@ msgstr ""
 "Problema ao baixar o arquivo de índice do repositório para o serviço '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Ignorando o serviço '%s' devido ao erro acima."
@@ -4610,24 +4636,28 @@ msgstr "Removendo o serviço '%s':"
 msgid "Service '%s' has been removed."
 msgstr "Serviço '%s' removido."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [opções]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Listar todos os serviços definidos."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Lista os serviços definidos."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Nenhum serviço definido. Use o comando '%s' para adicionar um ou mais "
 "serviços."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4745,7 +4775,8 @@ msgid ""
 "Repository '%s' has been removed from enabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been removed from enabled repositories of service '%s'"
-msgstr[0] "Repositório '%s' removido dos repositórios habilitados do serviço '%s'"
+msgstr[0] ""
+"Repositório '%s' removido dos repositórios habilitados do serviço '%s'"
 msgstr[1] ""
 "Repositórios '%s' removidos dos repositórios habilitados do serviço '%s'"
 
@@ -4945,7 +4976,8 @@ msgstr "Se é para permitir alteração de nomes dos resolvíveis instalados."
 
 #: src/commands/solveroptionset.cc:91
 msgid "Whether to allow changing the architecture of installed resolvables."
-msgstr "Se é para permitir alteração da arquitetura dos resolvíveis instalados."
+msgstr ""
+"Se é para permitir alteração da arquitetura dos resolvíveis instalados."
 
 #: src/commands/solveroptionset.cc:93
 msgid "Whether to allow changing the vendor of installed resolvables."
@@ -5121,8 +5153,8 @@ msgid ""
 "Using zypper subcommands available from elsewhere on your $PATH is disabled "
 "in zypper.conf."
 msgstr ""
-"O uso de sub-comandos zypper disponíveis em qualquer outro lugar em seu $"
-"PATH está desabilitado em zypper.conf."
+"O uso de sub-comandos zypper disponíveis em qualquer outro lugar em seu "
+"$PATH está desabilitado em zypper.conf."
 
 #. translators: helptext; %1% is a zypper command
 #: src/commands/subcommand.cc:485
@@ -5566,15 +5598,15 @@ msgstr "%s é mais antigo que %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Versão"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arquitetura"
 
@@ -5710,13 +5742,13 @@ msgstr "(vazio)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Dependência"
 
@@ -5753,7 +5785,7 @@ msgid "Flavor"
 msgstr "Tipo"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Base"
 
@@ -5883,7 +5915,8 @@ msgstr "Você concorda com os termos da licença?"
 
 #: src/misc.cc:193
 msgid "Aborting installation due to the need for license confirmation."
-msgstr "Cancelando a instalação devido à necessidade da confirmação da licença."
+msgstr ""
+"Cancelando a instalação devido à necessidade da confirmação da licença."
 
 #. translators: %s is '--auto-agree-with-licenses'
 #: src/misc.cc:196
@@ -6017,57 +6050,57 @@ msgstr[1] "%1% repositórios"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Verificando se é necessário atualizar os metadados para %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "O repositório '%s' está atualizado."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "A verificação atualizada de '%s' foi atrasada."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Forçando a atualização de metadados brutos"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Baixando os metadados do repositório '%s'"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Deseja desabilitar o repositório %s permanentemente?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Erro ao desabilitar o repositório '%s'."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Problema ao baixar os arquivos de '%s'."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Veja a mensagem de erro acima para uma dica."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Nenhum URI definido para '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -6076,16 +6109,16 @@ msgstr ""
 "Adicione uma ou mais entradas de URI base (baseurl=URL) ao %s para o "
 "repositório '%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Nenhum apelido definido para este repositório."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "O repositório '%s' é inválido."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -6093,22 +6126,22 @@ msgstr ""
 "Verifique se os URIs definidos para este repositório apontam para um "
 "repositório válido."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Erro ao baixar os metadados de '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Forçando a construção do cache do repositório"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Erro ao analisar os metadados de '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6120,44 +6153,44 @@ msgstr ""
 "preencha um relatório de bug seguindo as instruções em http://"
 "en.opensuse.org/Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 "Os metadados de repositório para '%s' não foram encontrados no cache local."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Erro ao construir o cache:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Repositório '%s' não encontrado pelo apelido, número ou URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Use '%s' para a lista dos repositórios definidos."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Ignorando o repositório desabilitado '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "É possível usar a opção global '%s' para habilitar os repositórios "
 "temporariamente."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Ignorando o repositório '%s' devido à opção '%s'."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Habilitando temporariamente o repositório '%s'."
@@ -6165,7 +6198,7 @@ msgstr "Habilitando temporariamente o repositório '%s'."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6174,7 +6207,7 @@ msgstr ""
 "O repositório '%s' está desatualizado. Execute 'zypper refresh' como root "
 "para atualizá-lo."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6183,81 +6216,82 @@ msgstr ""
 "O cache de metadados necessita ser construído para o repositório '%s'. Você "
 "pode executar 'zypper refresh' como root para fazer isso."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "O repositório '%s' permanece desabilitado."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Inicializando destino"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Falha na inicialização do destino:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Limpando o cache de metadados de '%s'."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Limpando o cache de metadados brutos de '%s'."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Mantendo o cache de metadados brutos para %s '%s'."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Limpando os pacotes para '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Não foi possível limpar o repositório '%s' devido a um erro."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Limpando o cache de pacotes instalados."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
-msgstr "Não foi possível limpar o cache de pacotes instalados devido a um erro."
+msgstr ""
+"Não foi possível limpar o cache de pacotes instalados devido a um erro."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Não foi possível limpar os repositórios devido a erros."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Alguns dos repositórios não foram limpos devido a um erro."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Os repositórios especificados foram limpos."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Todos os repositórios foram limpos."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Esta é uma mídia removível apenas leitura (CD/DVD), desabilitando a "
 "atualização automática."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Apelido de repositório inválido: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6265,25 +6299,25 @@ msgstr ""
 "Não foi possível determinar o tipo do repositório. Verifique se os URIs "
 "definidos (veja abaixo) apontam para um repositório válido:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Não foi possível encontrar um repositório válido no local indicado:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Problema ao transferir os dados do repositório do URI especificado:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Verifique se o URI especificado é acessível."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Problema desconhecido ao adicionar o repositório:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6292,135 +6326,135 @@ msgstr ""
 "A verificação GPG está desabilitada na configuração do repositório '%1%'. A "
 "integridade e origem dos pacotes não pode ser verificada."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Repositório '%s' adicionado com sucesso"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Lendo dados da mídia '%s'"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Problema ao ler dados da mídia '%s'"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Verifique se sua mídia de instalação é válida e legível."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Leitura dos dados da mídia '%s' adiada até a próxima atualização."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Lendo dados da mídia '%s'"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Problema ao ler dados da mídia '%s'"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Verifique se sua mídia de instalação é válida e legível."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Problema ao acessar o arquivo no URI especificado"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Verifique se o URI é válido e acessível."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Problema ao analisar o arquivo no URI especificado"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Isto é um arquivo .repo?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Problema encontrado ao tentar ler o arquivo no URI especificado"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Repositório sem apelido definido encontrado no arquivo, ignorando."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "O repositório '%s' não tem um URI definido, ignorando."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Repositório '%s' removido."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Prioridade do repositório '%s' não alterada (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Repositório '%s' habilitado com sucesso."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Repositório '%s' desabilitado com sucesso."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Atualização automática para o repositório '%s' habilitada."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Atualização automática para o repositório '%s' desabilitada."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Cache dos arquivos RPM habilitado para o repositório '%s'."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Cache dos arquivos RPM desabilitado para o repositório '%s'."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Verificação GPG habilitada para o repositório '%s'."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Verificação GPG desabilitada para o repositório '%s'."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Prioridade do repositório '%s' alterada para %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Nome do repositório '%s' definido para '%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Nada a alterar para o repositório '%s'."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Mantendo o repositório %s inalterado."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Carregando dados do repositório..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6428,43 +6462,43 @@ msgstr ""
 "Nenhum repositório definido. Operando somente com os resolvíveis instalados. "
 "Nada pode ser instalado."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Baixando dados do repositório '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "O repositório '%s' não está no cache. Criando o cache..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Problema ao carregar os dados de '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "O repositório '%s' não pôde ser atualizado. Utilizando o cache antigo."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Os resolvíveis de '%s' não foram carregados devido a um erro."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "Os metadados do repositório '%1%' estão expirados desde %2%."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Tente '%s' ou mesmo '%s' antes disso."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6472,34 +6506,34 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 "Metadados do repositório expirado: Verifique se a 'atualização automática' "
-"está ligada (zypper lr), caso contrário, atualize manualmente o repositório ("
-"zypper ref). Se isto não resolver o problema, pode ser que você esteja "
+"está ligada (zypper lr), caso contrário, atualize manualmente o repositório "
+"(zypper ref). Se isto não resolver o problema, pode ser que você esteja "
 "usando um mirror com problemas e que descontinuou o suporte ao repositório."
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Lendo os pacotes instalados..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Problema ao ler os pacotes instalados:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' se parece com um arquivo RPM. Tentará ser baixado."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Problema com o arquivo RPM especificado como %s, ignorando."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Problema ao ler o cabeçalho RPM do %s. É um arquivo RPM?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Cache de arquivos RPM simples"
 
@@ -6507,25 +6541,25 @@ msgstr "Cache de arquivos RPM simples"
 msgid "System Packages"
 msgstr "Pacotes do sistema"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Nenhuma correção necessária encontrada."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Nenhum padrão encontrado."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Nenhum pacote encontrado."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Nome interno"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Nenhum produto encontrado."
 
@@ -6555,7 +6589,8 @@ msgstr "Informação detalhada: "
 msgid "Choose the above solution using '1' or skip, retry or cancel"
 msgid_plural "Choose from above solutions by number or skip, retry or cancel"
 msgstr[0] "Escolha a solução acima usando '1' ou ignore, repita ou cancele"
-msgstr[1] "Escolha uma das opções acima pelo número ou ignore, repita ou cancele"
+msgstr[1] ""
+"Escolha uma das opções acima pelo número ou ignore, repita ou cancele"
 
 #. translators: translate 'c' to whatever you translated the 'c' in
 #. "c" and "s/r/c" strings
@@ -6924,7 +6959,7 @@ msgid "Updatestack"
 msgstr "Atualização do gerenciador"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Correções"
 
@@ -6949,7 +6984,7 @@ msgstr ""
 "As atualizações no gerenciamento de softwares necessárias serão instaladas "
 "primeiro:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Nenhuma atualização encontrada."
 
@@ -6959,56 +6994,56 @@ msgstr "Nenhuma atualização encontrada."
 msgid "The following updates are also available:"
 msgstr "As seguintes atualizações também estão disponíveis:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Atualizações de pacotes"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Atualizações de padrões"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Atualizações de produtos"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Versão atual"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Versão disponível"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Nenhum problema correspondente encontrado."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 "As seguintes correspondências nos números de problemas foram encontradas:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 "Encontradas correspondências nas descrições da correção das seguintes "
 "correções:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "Correção para o problema número %s do Bugzilla não encontrada ou "
 "desnecessária."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 "Correção para o problema número %s do CVE não encontrada ou desnecessária."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "Correção para o problema %s número %s não encontrada ou desnecessária."
@@ -7205,7 +7240,8 @@ msgstr "Registre um relatório de bugs sobre isto."
 #. unless you translate the actual page :)
 #: src/utils/messages.cc:22
 msgid "See http://en.opensuse.org/Zypper/Troubleshooting for instructions."
-msgstr "Consulte http://en.opensuse.org/Zypper/Troubleshooting para instruções."
+msgstr ""
+"Consulte http://en.opensuse.org/Zypper/Troubleshooting para instruções."
 
 #: src/utils/messages.cc:38
 msgid "Too many arguments."

--- a/po/ro.po
+++ b/po/ro.po
@@ -31,7 +31,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSUSE\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Romanian <https://l10n.opensuse.org/projects/zypper/master/ro/"
@@ -1521,7 +1521,7 @@ msgstr "PackageKit rulează (probabil este ocupat)."
 msgid "Try again?"
 msgstr "Încerc din nou?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Excepție neașteptată."
 
@@ -1549,12 +1549,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Opțiunea %s nu are nici un efect aici, o ignor."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Argumente program non-opțiuni:"
 
@@ -1709,7 +1709,8 @@ msgstr "Am încredere implicit în următoarea cheie:"
 
 #: src/callbacks/keyring.h:250
 msgid "New repository or package signing key received:"
-msgstr "Am primit o nouă cheie de semnare a unei surse de instalare sau pachet:"
+msgstr ""
+"Am primit o nouă cheie de semnare a unei surse de instalare sau pachet:"
 
 #. translators: this message is shown after showing description of the key
 #: src/callbacks/keyring.h:284
@@ -1762,7 +1763,8 @@ msgstr "Am încredere temporar în cheie."
 #. translators: help text for the 'a' option in the 'r/t/a' prompt
 #: src/callbacks/keyring.h:330
 msgid "Trust the key and import it into trusted keyring."
-msgstr "Am încredere în cheie; import-o în baza de date cu cheile de încredere."
+msgstr ""
+"Am încredere în cheie; import-o în baza de date cu cheile de încredere."
 
 #: src/callbacks/keyring.h:367
 #, c-format, boost-format
@@ -2287,17 +2289,17 @@ msgid "Commands:"
 msgstr "Comenzi:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Tipuri de pachete (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2305,8 +2307,14 @@ msgstr ""
 "Abordare 'optimizată' a actualizării. Actualizări către o versiune mai veche "
 "decât cea recentă sunt de asemenea acceptate."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2380,7 +2388,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Tipărește un text de ajutor"
 
@@ -2565,22 +2573,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2633,49 +2641,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2779,11 +2791,11 @@ msgstr[2] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Nume"
 
@@ -2794,8 +2806,8 @@ msgstr "Petice"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Tip"
@@ -2803,7 +2815,7 @@ msgstr "Tip"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Sursă de instalare"
@@ -3232,7 +3244,7 @@ msgid "Command"
 msgstr "Comandă"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Serviciu"
 
@@ -3398,122 +3410,122 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Listează toate pachetele disponibile."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [sursă de instalare] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Listează toate peticele disponibile."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Listează toate peticele disponibile la sursa de instalare specificată."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [opțiuni] [sursă de instalare] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Listează toate modelele disponibile."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 "Listează toate modelele disponibile la sursele de instalare specificate."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [opțiuni] [sursă de instalare] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Listează toate produsele disponibile."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 "Listează toate produsele disponibile la sursele de instalare specificate."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3552,12 +3564,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "Nu pot utiliza %s împreună cu %s. Utilizez setarea %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3603,111 +3615,115 @@ msgstr "Curăță cache-ul metadata brut."
 msgid "Clean both metadata and package caches."
 msgstr "Curăță atât cache-ul metadata cât și cache-ul pachetelor."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Activat"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Verificare GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Importanță"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Reîmprospătare automată"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Pornit"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Închis"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Păstrează pachetele"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "Cheie URI GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Prefixul căii"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Serviciul părinte"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Calea Cache-ului MD"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Listează toate sursele definite."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Eroare la citirea surselor de instalare:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Nu pot deschide %s pentru scriere."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Este posibil să nu aveți drepturi de scriere?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Sursele de instalare au fost exportate cu succes în %s."
@@ -3715,21 +3731,21 @@ msgstr "Sursele de instalare au fost exportate cu succes în %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Reîmprospătează"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "Nu am găsit nici un repository."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 #, fuzzy
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
@@ -3837,7 +3853,7 @@ msgstr "Opțiunea globală '%s' nu are efect aici."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Nu se acceptă argumente dacă se utilizează '%s'."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Surse de instalare specificate:"
 
@@ -3846,7 +3862,7 @@ msgstr "Surse de instalare specificate:"
 msgid "Refreshing repository '%s'."
 msgstr "Dezactivez sursa de instalare '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Ignor sursa de instalare dezactivată '%s'"
@@ -3856,7 +3872,7 @@ msgstr "Ignor sursa de instalare dezactivată '%s'"
 msgid "Skipping disabled repository '%s'"
 msgstr "Omit sursa de instalare dezactivată '%s'"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Omit sursa de instalare '%s' datorită erorii de mai sus."
@@ -3871,7 +3887,8 @@ msgstr ""
 
 #: src/commands/repos/refresh.cc:325
 msgid "Specified repositories are not enabled or defined."
-msgstr "Sursele de instalare specificate nu sunt activate sau nu sunt definite."
+msgstr ""
+"Sursele de instalare specificate nu sunt activate sau nu sunt definite."
 
 #: src/commands/repos/refresh.cc:327
 msgid "There are no enabled repositories defined."
@@ -3888,7 +3905,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "Nu am putut reîmprospăta sursele de instalare din cauza unor erori."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 "O parte din sursele de instalare nu au fost reîmprospătate din cauza unei "
@@ -3945,12 +3962,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Sursa de instalare '%s' a fost redenumită ca '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "Numele de sursă de instalare '%s' există deja. Utilizați alt alias."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Eroare la modificarea sursei de instalare:"
 
@@ -4381,27 +4398,27 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Sursa de instalare specificată '%s' este dezactivată."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "Nici o problemă de potrivire nu a fost găsită."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 "A apărut o problemă la inițializarea sau la execuția interogării de căutare"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Consultați mesajul de mai sus pentru sugestii."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "Execuția 'zypper refresh' ca root poate rezolva problema."
 
@@ -4493,7 +4510,7 @@ msgstr ""
 "serviciul '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Se omite serviciul '%s' datorită erorii de mai sus."
@@ -4512,24 +4529,28 @@ msgstr "Îndepărtez serviciul '%s':"
 msgid "Service '%s' has been removed."
 msgstr "Serviciul '%s' a fost îndepărtat."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Listează toate serviciile definite."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Niciun serviciu definit. Utilizați comanda '%s' pentru a adăuga unul sau mai "
 "multe servicii."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5420,15 +5441,15 @@ msgstr "%s este mai vechi decât %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Versiune"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arh."
 
@@ -5565,13 +5586,13 @@ msgstr "(gol)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Dependență"
 
@@ -5609,7 +5630,7 @@ msgid "Flavor"
 msgstr "Variantă"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Este Baza"
 
@@ -5879,58 +5900,58 @@ msgstr[2] "Sursă de instalare"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Verific dacă trebuie reîmprospătate metadatele pentru %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Sursa de instalare '%s' este la zi."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Verificarea actualității '%s' a fost amânată."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Forțez reîmprospătarea metadatelor brute"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Obțin metadatele sursei de instalare '%s'"
 
 # power-off message
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Vreți să opriți sistemul acum?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Dezactivez sursa de instalare '%s'."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Problemă la obținerea fișierelor de la '%s'."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Consultați mesajul de eroare de mai sus pentru sugestii."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Nu a fost definit nici un URI pentru '%s'."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -5939,16 +5960,16 @@ msgstr ""
 "Adăugați unul sau mai multe intrări URI de bază (baseurl=URI) la %s pentru "
 "sursa de instalare '%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Nu a fost definit nici un alias pentru această sursă de instalare."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Sursa de instalare '%s' este invalidă."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -5956,22 +5977,22 @@ msgstr ""
 "Verificați dacă URI-urile definite pentru această sursă de instalare indică "
 "o sursă de instalare validă."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Eroare la obținerea metadatelor pentru '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Forțez construirea cache-ului surselor de instalare"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Eroare la parcurgerea metadatelor pentru '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5983,45 +6004,45 @@ msgstr ""
 "dubii, raportați vă rog eroarea conform instrucțiunilor la http://"
 "en.opensuse.org/Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 "Metadatele sursei de instalare pentru '%s' nu au fost găsite în cache-ul "
 "local."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Eroare la construirea cache-ului:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Sursa de instalare '%s' nu a fost găsită după alias, număr sau URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Utilizează '%s' pentru a găsi lista de surse de instalare definite."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Ignor sursa de instalare dezactivată '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, fuzzy, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "Folosiți comenzile '%s' sau '%s' pentru a adăuga sau activa surse de "
 "instalare."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Ignor sursa de instalare '%s' datorită opțiunii '%s'."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Dezactivez sursa de instalare '%s'."
@@ -6029,7 +6050,7 @@ msgstr "Dezactivez sursa de instalare '%s'."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6038,7 +6059,7 @@ msgstr ""
 "Sursa de instalare '%s' este învechită. Puteți rula 'zypper refresh' ca root "
 "pentru a o actualiza."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6047,81 +6068,81 @@ msgstr ""
 "Cache-ul de metadate trebuie reconstruit pentru sursa de instalare '%s'. "
 "Puteți rula 'zypper refresh' ca root pentru a efectua această operație."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Sursa de instalare '%s' este invalidă."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Ințializez destinația"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Inițializarea destinației a eșuat:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Curăț cache-ul de metadate pentru '%s'."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Curăț cache-ul raw de metadate pentru '%s'."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Păstrez cache-ul metadatei brute pentru %s '%s'."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Curăț pachetele pentru '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Nu pot curăța sursa de instalare '%s' din cauza unei erori."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Curăț cache-ul pachetelor instalate."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Nu pot curăța cache-ul pachetelor instalate din cauza unei erori."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Nu pot curăța sursele de instalare din cauza unor erori."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Unele surse de instalare nu au fost curățate din cauza unei erori."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Sursele de instalare specificate au fost curățate."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Toate sursele de instalare au fost curățate."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Acesta este un mediu de stocare read-only (CD/DVD), dezactivez "
 "reîmprospătarea automată."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Este invalidă alias-ul pentru sursa de instalare: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6129,163 +6150,164 @@ msgstr ""
 "Nu am putut determina tipul sursei de instalare. Verificați dacă URI-urile "
 "definite (vezi mai jos) indică o sursă de instalare validă:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Nu am putut găsi nici o sursă de instalare validă la locația dată:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 "Problemă la transferul datelor sursei de instalare de la URI-ul specificat:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Verificați dacă URI-ul specificat este accesibil."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Problemă necunoscută la adăugarea sursei de instalare:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Sursa de instalare '%s' a fost adăugată cu succes"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Citesc date de pe mediul '%s'"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Problemă la citirea datelor de pe mediul '%s'"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Verificați dacă mediul dvs. de instalare este valid și poate fi citit."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, fuzzy, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Citesc date de pe mediul '%s'"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Citesc date de pe mediul '%s'"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Problemă la citirea datelor de pe mediul '%s'"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Verificați dacă mediul dvs. de instalare este valid și poate fi citit."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Problemă la accesarea fișierului la URI-ul specificat"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Vă rugăm să verificați dacă URI-ul este valid și accesibil."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Problemă la parcurgerea fișierului de la URI-ul specificat"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Este un fișier .repo?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "A apărut o problemă la citirea fișierului de la URI-ul specificat"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Am găsit în fișier o sursă de instalare fără alias definit, o omit."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Sursa de instalare '%s' nu are nici un URI definit, o omit."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Sursa de instalare '%s' a fost îndepărtată."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Prioritatea sursei de instalare '%s' a rămas neschimbată (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Sursa de instalare '%s' a fost activată cu succes."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Sursa de instalare '%s' a fost dezactivată cu succes."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 "Reîmprospătarea automată a fost activată pentru sursa de instalare '%s'."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 "Reîmprospătarea automată a fost deactivată pentru sursa de instalare '%s'."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Cache-ul fișierelor RPM este activat pentru sursa de instalare '%s'."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
-msgstr "Cache-ul fișierelor RPM este dezactivat pentru sursa de instalare '%s'."
+msgstr ""
+"Cache-ul fișierelor RPM este dezactivat pentru sursa de instalare '%s'."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Verificarea GPG a fost activată pentru sursa de instalare '%s'."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Verificarea GPG a fost dezactivată pentru sursa de instalare '%s'."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Prioritatea sursei de instalare '%s' a fost setată pe %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Numele sursei de instalare '%s' este setat la '%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Nici o schimbare pentru sursa de instalare '%s'."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Păstrez sursa de instalare %s neschimbată."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Încarc datele sursei de instalare..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 #, fuzzy
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
@@ -6294,45 +6316,45 @@ msgstr ""
 "Avertisment: Nu au fost definite surse de instalare. Operez doar cu "
 "dependențele instalate. Nu poate fi instalat nimic."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Obțin datele sursei de instalare '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Sursa de instalare '%s' nu este în cache ..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Problemă la încărcarea datelor de la '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 "Sursa de instalare '%s' nu a putut fi reîmprospătată. Se va utiliza "
 "versiunea din memoria cache."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Dependențele de la '%s' nu au fost încărcate din cauza unei erori."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Încercați '%s' sau chiar '%s' înainte să faceți asta."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6340,31 +6362,31 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Citesc pachetele instalate..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "A apărut o problemă în timpul citirii pachetelor instalate:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' pare a fi un fișier RPM. Voi încerca să-l descarc."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Probleme cu fișierul RPM specificat ca '%s', îl omit."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Probleme la citirea header-ului RPM al %s. Este un fișier RPM?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Cache pentru fișiere RPM simple"
 
@@ -6372,25 +6394,25 @@ msgstr "Cache pentru fișiere RPM simple"
 msgid "System Packages"
 msgstr "Pachete sistem"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Nu au fost găsite petice necesare."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Nu a fost găsit niciun model."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Nu a fost găsit niciun pachet."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Nume intern"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Nu a fost găsit niciun produs."
 
@@ -6792,7 +6814,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Petice"
 
@@ -6818,7 +6840,7 @@ msgstr ""
 "Următoarele actualizări ale managerului de programe vor fi instalate mai "
 "întâi:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Nu au fost găsite actualizări."
 
@@ -6827,52 +6849,52 @@ msgstr "Nu au fost găsite actualizări."
 msgid "The following updates are also available:"
 msgstr "Următoarele actualizări sunt de asemenea disponibile:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Actualizări pachete"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Actualizări modele"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Actualizări produse"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Versiunea curentă"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Versiune disponibilă"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Nici o problemă de potrivire nu a fost găsită."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Următoarele potriviri în numerele de rezultat au fost găsite:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 "Potriviri în descrierile de petice ale următoarelor petice au fost găsite:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "Soluția Bugzilla pentru numărul %s nu a fost găsită sau nu este necesară."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "Soluția CVS pentru numărul %s nu a fost găsită sau nu este necesară."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, fuzzy, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "Soluția CVS pentru numărul %s nu a fost găsită sau nu este necesară."
@@ -7121,7 +7143,8 @@ msgstr ""
 #: src/utils/messages.cc:141
 #, c-format, boost-format
 msgid "Type '%s' to get a list of global options and commands."
-msgstr "Introduceți '%s' pentru a obține o listă de opțiuni globale și comenzi."
+msgstr ""
+"Introduceți '%s' pentru a obține o listă de opțiuni globale și comenzi."
 
 #. translators: %1% is the name of an (unknown) command
 #. translators: %2% something providing more info (like 'zypper help subcommand')

--- a/po/ru.po
+++ b/po/ru.po
@@ -9,11 +9,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-28 23:59+0000\n"
 "Last-Translator: Aleksey Fedorov <Aleksejfedorov963@gmail.com>\n"
-"Language-Team: Russian <https://l10n.opensuse.org/projects/zypper/master/ru/>"
-"\n"
+"Language-Team: Russian <https://l10n.opensuse.org/projects/zypper/master/ru/"
+">\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -199,7 +199,8 @@ msgstr "Переход в неинтерактивный режим."
 #. translators: --non-interactive, -n
 #: src/Config.cc:338
 msgid "Do not ask anything, use default answers automatically."
-msgstr "Ни о чем не спрашивать, автоматически использовать ответы по умолчанию."
+msgstr ""
+"Ни о чем не спрашивать, автоматически использовать ответы по умолчанию."
 
 #: src/Config.cc:343
 msgid ""
@@ -610,8 +611,8 @@ msgstr ""
 #, c-format, boost-format
 msgid "Patch '%s' is locked. Use '%s' to install it, or unlock it using '%s'."
 msgstr ""
-"Исправление \"%s\" заблокировано. Используйте \"%s\" для установки или \"%s\""
-" для разблокирования."
+"Исправление \"%s\" заблокировано. Используйте \"%s\" для установки или "
+"\"%s\" для разблокирования."
 
 #: src/RequestFeedback.cc:200
 #, c-format, boost-format
@@ -939,8 +940,10 @@ msgid "The following recommended source package was automatically selected:"
 msgid_plural ""
 "The following %d recommended source packages were automatically selected:"
 msgstr[0] "%d рекомендованный пакет с исходным кодом был выбран автоматически:"
-msgstr[1] "%d рекомендованных пакета с исходным кодом были выбраны автоматически:"
-msgstr[2] "%d рекомендованных пакетов с исходным кодом были выбраны автоматически:"
+msgstr[1] ""
+"%d рекомендованных пакета с исходным кодом были выбраны автоматически:"
+msgstr[2] ""
+"%d рекомендованных пакетов с исходным кодом были выбраны автоматически:"
 
 #: src/Summary.cc:1100
 #, c-format, boost-format
@@ -1528,7 +1531,7 @@ msgstr "PackageKit все еще запущен (возможно, занят)."
 msgid "Try again?"
 msgstr "Повторите попытку?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Неожиданное исключение."
 
@@ -1558,12 +1561,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Параметр %s здесь не действует, игнорируется."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Аргументы программы, не являющиеся параметрами: "
 
@@ -2322,17 +2325,17 @@ msgid "Commands:"
 msgstr "Команды:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Показать подробную сводку установки."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Тип пакета (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2340,11 +2343,17 @@ msgstr ""
 "Использовать подход \"наилучших действий\" для обновления. Обновления до не "
 "самых последних версий также приемлемы."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr ""
 "Использовать только исправления, которые влияют непосредственно на "
 "управление пакетами."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2426,7 +2435,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <подкоманда> [--параметры-команды] [аргументы]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Вывести справку"
 
@@ -2443,7 +2452,8 @@ msgstr "verify (ve) [параметры]"
 #. translators: command summary: install-new-recommends, inr
 #: src/commands/inrverify.cc:81
 msgid "Install newly added packages recommended by installed packages."
-msgstr "Установить добавленные пакеты, рекомендованные установленными пакетами."
+msgstr ""
+"Установить добавленные пакеты, рекомендованные установленными пакетами."
 
 #. translators: command summary: verify, ve
 #: src/commands/inrverify.cc:84
@@ -2513,8 +2523,8 @@ msgid ""
 "Remove packages with specified capabilities. A capability is NAME[.ARCH]"
 "[OP<VERSION>], where OP is one of <, <=, =, >=, >."
 msgstr ""
-"Удалить пакеты с указанными возможностями. Возможность — это ИМЯ"
-"[.АРХИТЕКТУРА][ОП<ВЕРСИЯ>], где ОП — один из операторов <, <=, =, >=, >."
+"Удалить пакеты с указанными возможностями. Возможность — это "
+"ИМЯ[.АРХИТЕКТУРА][ОП<ВЕРСИЯ>], где ОП — один из операторов <, <=, =, >=, >."
 
 #: src/commands/installremove.cc:104 src/commands/installremove.cc:234
 #: src/utils/messages.cc:53
@@ -2647,22 +2657,22 @@ msgstr ""
 "зависимых пакетов их официальными версиями обновлений."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [ПАРАМЕТРЫ]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Вывести список доступных исправлений."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Вывести список всех применимых исправлений."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Вывести список всех исправлений, не только применимых."
 
@@ -2717,35 +2727,39 @@ msgstr ""
 "всех доступных локалей можно с помощью команды %s."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [ПАРАМЕТРЫ] [ЛОКАЛЬ] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Получение списка запрошенных локалей (языковых кодов)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Получение списка запрошенных локалей и соответствующих пакетов."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Показ соответствующих пакетов."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Список всех доступных локалей."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr "Позиционные аргументы игнорируются, так как указан аргумент --all."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "Локали, для которых будет выведена информация."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2753,16 +2767,16 @@ msgstr ""
 "Получение всех локалей с языковым кодом en, у которых есть собственный код "
 "страны, кроме резервного кода en:"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 "Получение всех локалей с языковым кодом en независимо от наличия кода страны:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "Получение локали, в точности соответствующей аргументу: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "Получение списка пакетов, доступных для кодов de и en:"
 
@@ -2875,11 +2889,11 @@ msgstr[2] "Удалено %lu блокировок."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Имя"
 
@@ -2889,8 +2903,8 @@ msgstr "Соответствия"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Тип"
@@ -2898,7 +2912,7 @@ msgstr "Тип"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Репозиторий"
@@ -3169,8 +3183,8 @@ msgid ""
 "Automatically accept product licenses only. See 'man zypper' for more "
 "details."
 msgstr ""
-"Автоматически принимать только лицензии продуктов. Подробнее см. "
-"\"man zypper\"."
+"Автоматически принимать только лицензии продуктов. Подробнее см. \"man "
+"zypper\"."
 
 #. translators: --replacefiles
 #: src/commands/optionsets.cc:264
@@ -3365,7 +3379,7 @@ msgid "Command"
 msgstr "Команда"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Сервис"
 
@@ -3535,22 +3549,22 @@ msgid "Show detailed information for products."
 msgstr "Показать подробную информацию о продуктах."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [параметры] [репозиторий] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Вывести список доступных пакетов."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Вывести все пакеты из указанных репозиториев."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
@@ -3558,19 +3572,20 @@ msgstr ""
 "разрешителем."
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
-msgstr "Показать установленные пакеты, которые были явно выбраны пользователем."
+msgstr ""
+"Показать установленные пакеты, которые были явно выбраны пользователем."
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 "Показать установленные пакеты, которые не предоставляются ни одним "
 "репозиторием."
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
@@ -3579,82 +3594,82 @@ msgstr ""
 "без кандидата на обновление)."
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Показывать предлагаемые пакеты."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Показывать рекомендованные пакеты."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Показывать ненужные пакеты."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Сортировать по названиям."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Сортировать по репозиториям."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [репозиторий] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Вывести список доступных исправлений."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Вывести список всех доступных исправлений в указанных репозиториях."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [параметры] [репозиторий] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Вывести список доступных шаблонов."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Вывести список всех шаблонов, доступных в указанных репозиториях."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [параметры] [репозиторий] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Вывести список доступных продуктов."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Вывести список всех продуктов, доступных в указанных репозиториях."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr "Только XML-вывод: вывести только теги XML из файла продукта."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "Парамет %1% не имеет никакого эффекта без глобального параметра %2%."
@@ -3697,13 +3712,13 @@ msgstr ""
 "Тип репозитория всегда определяется автоматически. Этот параметр "
 "игнорируется."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 "Невозможно использовать %s вместе с %s. Будет использована настройка %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3749,112 +3764,116 @@ msgstr "Очистить кэш необработанных метаданны�
 msgid "Clean both metadata and package caches."
 msgstr "Очистить и кэш метаданных, и кэш пакетов."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Псевдоним"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Включен"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Проверка GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Приоритет"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Автоматическое обновление"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Вкл."
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Выкл."
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Сохранять пакеты"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI ключа GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Префикс пути"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Родительский сервис"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Ключевые слова"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Путь к сведениям о репозитории"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Путь кэша MD"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [параметры] [репозиторий]…"
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Вывести список всех определенных репозиториев."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 "Экспортировать все определенные репозитории в один локальный файл .repo."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Ошибка чтения репозиториев:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Невозможно открыть %s для записи."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Возможно, у вас нет прав на запись?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Репозитории успешно экспортированы в %s."
@@ -3862,24 +3881,24 @@ msgstr "Репозитории успешно экспортированы в %s
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Обновление"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "Оставить"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Репозитории не определены."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
-"Чтобы добавить один или несколько репозиториев, используйте команду "
-"\"zypper addrepo\"."
+"Чтобы добавить один или несколько репозиториев, используйте команду \"zypper "
+"addrepo\"."
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/repos/modify.cc:24
@@ -3984,7 +4003,7 @@ msgstr "Общий параметр \"%s\" здесь не действует."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "При использовании \"%s\" аргументы не разрешены."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Указанные репозитории: "
 
@@ -3993,7 +4012,7 @@ msgstr "Указанные репозитории: "
 msgid "Refreshing repository '%s'."
 msgstr "Обновление репозитория \"%s\"."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Сканирование содержимого отключенного репозитория \"%s\"."
@@ -4003,7 +4022,7 @@ msgstr "Сканирование содержимого отключенного
 msgid "Skipping disabled repository '%s'"
 msgstr "Пропуск отключенного репозитория \"%s\""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Репозиторий \"%s\" пропускается из-за указанной выше ошибки."
@@ -4032,7 +4051,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "Не удалось обновить репозитории из-за ошибок."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Некоторые репозитории не обновлены из-за ошибки."
 
@@ -4087,13 +4106,13 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Репозиторий \"%s\" переименован в \"%s\"."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 "Репозиторий с именем \"%s\" уже существует. Используйте другой псевдоним."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Ошибка при изменении репозитория:"
 
@@ -4235,7 +4254,8 @@ msgstr "Сокращение для \"%1%\"."
 
 #: src/commands/reposerviceoptionsets.cc:143
 msgid "Enable GPG check but allow the repository metadata to be unsigned."
-msgstr "Включить проверку GPG, но разрешить метаданные репозитория без подписи."
+msgstr ""
+"Включить проверку GPG, но разрешить метаданные репозитория без подписи."
 
 #: src/commands/reposerviceoptionsets.cc:144
 msgid ""
@@ -4556,28 +4576,28 @@ msgid ""
 "Like --details, with additional information where the search has matched "
 "(useful for search in dependencies)."
 msgstr ""
-"Аналогично --details, с дополнительными сведениями о месте совпадения ("
-"полезно для поиска в зависимостях)."
+"Аналогично --details, с дополнительными сведениями о месте совпадения "
+"(полезно для поиска в зависимостях)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Указанный репозиторий \"%s\" отключен."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Соответствий не найдено."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Возникла проблема при инициализации или выполнении поискового запроса"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Рекомендация имеется в выданном ранее сообщении."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 "Запуск \"zypper refresh\" от имени суперпользователя может решить проблему."
@@ -4671,7 +4691,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Проблема получения индексного файла репозитория для сервиса \"%s\":"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Пропуск сервиса \"%s\" из-за указанной выше ошибки."
@@ -4690,24 +4710,28 @@ msgstr "Удаление сервиса \"%s\":"
 msgid "Service '%s' has been removed."
 msgstr "Сервис \"%s\" удален."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [параметры]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Вывести список всех определенных сервисов."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Вывести список сервисов."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Сервисы не определены. Используйте команду \"%s\" для добавления одного или "
 "нескольких сервисов."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4829,7 +4853,8 @@ msgid ""
 "Repository '%s' has been removed from enabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been removed from enabled repositories of service '%s'"
-msgstr[0] "\"%s\" репозиторий был удален из включенных репозиториев сервиса \"%s\""
+msgstr[0] ""
+"\"%s\" репозиторий был удален из включенных репозиториев сервиса \"%s\""
 msgstr[1] ""
 "Репозитории \"%s\" были удалены из включенных репозиториев сервиса \"%s\""
 msgstr[2] ""
@@ -5304,7 +5329,8 @@ msgstr ""
 #: src/commands/utils/download.cc:129 src/commands/utils/source-download.cc:212
 #, c-format, boost-format
 msgid "Insufficient privileges to use download directory '%s'."
-msgstr "Недостаточно привилегий для использования загрузочного каталога \"%s\"."
+msgstr ""
+"Недостаточно привилегий для использования загрузочного каталога \"%s\"."
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/utils/download.cc:142
@@ -5599,7 +5625,8 @@ msgstr ""
 
 #: src/commands/utils/targetos.cc:36
 msgid "Show the baseproducts distribution and short label instead."
-msgstr "Вместо этого показать распределение базовых продуктов и короткую метку."
+msgstr ""
+"Вместо этого показать распределение базовых продуктов и короткую метку."
 
 #: src/commands/utils/targetos.cc:49
 msgid "XML output not implemented for this command."
@@ -5666,15 +5693,15 @@ msgstr "%s старее, чем %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Версия"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Архитектура"
 
@@ -5811,13 +5838,13 @@ msgstr "(пусто)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "С"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Зависимость"
 
@@ -5854,7 +5881,7 @@ msgid "Flavor"
 msgstr "Особенность"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Базовый"
 
@@ -6117,57 +6144,57 @@ msgstr[2] "%1% репозиториев"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Проверка, обновлять ли метаданные для %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Репозиторий \"%s\" актуален."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Проверка \"%s\" на актуальность отложена."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Принудительное обновление необработанных метаданных"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Получение метаданных репозитория \"%s\""
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Вы действительно хотите навсегда отключить репозиторий %s?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Ошибка при отключении репозитория \"%s\"."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Проблемы при получении файлов из \"%s\"."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Рекомендация имеется в выданном ранее сообщении об ошибке."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Не определен URI для \"%s\"."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -6176,16 +6203,16 @@ msgstr ""
 "Добавьте одну или более записей основных URI-адресов (baseurl=URI) в %s для "
 "репозитория \"%s\"."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Псевдоним для этого репозитория не определен."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Репозиторий \"%s\" недействителен."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -6193,22 +6220,22 @@ msgstr ""
 "Проверьте, что URI-адреса, определенные для этого репозитория, указывают на "
 "допустимый репозиторий."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Ошибка при получении метаданных для \"%s\":"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Принудительная сборка кэша репозитория"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Ошибка анализе синтаксиса метаданных для \"%s\":"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6220,42 +6247,42 @@ msgstr ""
 "отправьте отчёт об ошибке, выполнив указания на странице http://"
 "en.opensuse.org/Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Метаданные для репозитория \"%s\" не найдены в локальном кэше."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Ошибка при построении кэша:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 "Репозиторий \"%s\" не найден по своему псевдониму, номеру или URI-адресу."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Используйте \"%s\" для получения списка определенных репозиториев."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Отключенный репозиторий \"%s\" игнорируется"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr "Общий параметр \"%s\" позволяет временно включить репозитории."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Игнорирую репозиторий \"%s\" из-за параметра \"%s\"."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Временное включение репозитория \"%s\"."
@@ -6263,7 +6290,7 @@ msgstr "Временное включение репозитория \"%s\"."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6272,7 +6299,7 @@ msgstr ""
 "Репозиторий \"%s\" устарел. Чтобы обновить его, запустите \"zypper refresh\" "
 "от имени суперпользователя."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6281,81 +6308,81 @@ msgstr ""
 "Необходимо собрать кэш для репозитория \"%s\". Для этого можно запустить "
 "\"zypper refresh\" от имени суперпользователя."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Репозиторий \"%s\" отключен."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Инициализация цели"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Сбой инициализации цели:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Очистка кэша метаданных для \"%s\"."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Очистка кэша необработанных метаданных для \"%s\"."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Сохранение кэша необработанных метаданных для %s \"%s\"."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Удаление кэшированных пакетов \"%s\"."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Невозможно очистить репозиторий \"%s\" из-за ошибки."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Очистка кэша установленных пакетов."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Невозможно очистить кэш установленных пакетов из-за ошибки."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Не удалось очистить репозитории из-за ошибок."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Некоторые репозитории не очищены из-за ошибки."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Указанные репозитории очищены."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Все репозитории очищены."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Это сменный носитель, доступный только для чтения (CD/DVD), отключение "
 "автоматического обновления."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Недопустимый псевдоним репозитория: \"%s\""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6363,25 +6390,25 @@ msgstr ""
 "Не удалось определить тип репозитория. Проверьте, указывают ли введенные URI-"
 "адреса (смотрите ниже) на допустимый репозиторий:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Невозможно найти допустимый репозиторий в данном месте:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Проблема передачи данных репозитория с указанного URI-адреса:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Проверьте, доступен ли указанный URI-адрес."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Неизвестная проблема при добавлении репозитория:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6390,135 +6417,135 @@ msgstr ""
 "Проверка GPG отключена в конфигурации репозитория \"%1%\". Невозможно "
 "проверить целостность и происхождение пакетов."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Репозиторий \"%s\" успешно добавлен"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Чтение данных с носителя \"%s\""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Проблема при чтении данных с носителя \"%s\""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Убедитесь в том, что ваш установочный носитель допустим и читается."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Чтение данных с носителя \"%s\" отложено до следующего обновления."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Чтение данных с носителя \"%s\""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Проблема при чтении данных с носителя \"%s\""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Убедитесь в том, что ваш установочный носитель допустим и читается."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Проблема при доступе к файлу по указанному URI-адресу"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Убедитесь в том, что URI-адрес допустим и доступен."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Проблема при анализе синтаксиса файла по указанному URI-адресу"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Это файл .repo?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Произошла ошибка при попытке прочитать файл по указанному URI-адресу"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "В файле найден репозиторий без указания псевдонима, пропуск."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Для репозитория \"%s\" не определен URI-адрес, пропуск."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Репозиторий \"%s\" удален."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Приоритет репозитория \"%s\" не изменен (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Репозиторий \"%s\" успешно включен."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Репозиторий \"%s\" успешно отключен."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Включено автоматическое обновление репозитория \"%s\"."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Отключено автоматическое обновление репозитория \"%s\"."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Включено кэширование файлов RPM репозитория \"%s\"."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Отключено кэширование файлов RPM репозитория \"%s\"."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Включена проверка GPG для репозитория \"%s\"."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Отключена проверка GPG для репозитория \"%s\"."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Приоритет репозитория \"%s\" установлен равным %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Репозиторию \"%s\" присвоено имя \"%s\"."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Нечего изменять для репозитория \"%s\"."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Репозиторий %s не изменен."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Загрузка данных о репозиториях..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6526,79 +6553,79 @@ msgstr ""
 "Репозитории не определены. Работа ведется только с установленными объектами "
 "разрешения зависимостей. Нельзя ничего установить."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Получение данных о репозитории \"%s\"..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Репозиторий \"%s\" не кэширован. Кэширование..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Проблема загрузки данных из \"%s\""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "Невозможно обновить репозиторий \"%s\". Используется старый кэш."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 "Объекты разрешения зависимостей из \"%s\" не были загружены из-за ошибки."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "Метаданные репозитория '%1%' устарели с %2%."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Попробуйте \"%s\" или даже \"%s\" перед тем, как делать это."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
 "not solve the issue, it could be that you are using a broken mirror or the "
 "server has actually discontinued to support the repository."
 msgstr ""
-"Метаданные репозитория устарели: Проверьте, что включено «автообновление» ("
-"zypper lr), либо обновите репозиторий вручную (zypper ref). Если это не "
+"Метаданные репозитория устарели: Проверьте, что включено «автообновление» "
+"(zypper lr), либо обновите репозиторий вручную (zypper ref). Если это не "
 "решит проблему, то вы, возможно, используете сломанное зеркало или сервер "
 "прекратил поддержку репозитория."
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Чтение установленных пакетов..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Произошла ошибка при чтении установленных пакетов:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "\"%s\" выглядит как файл RPM. Попробую загрузить его."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Проблема с файлом RPM, указанным как \"%s\", пропуск."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Проблема с чтением заголовка RPM файла %s. Это файл RPM?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Кэш простых файлов RPM"
 
@@ -6606,25 +6633,25 @@ msgstr "Кэш простых файлов RPM"
 msgid "System Packages"
 msgstr "Системные пакеты"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Не найдено необходимых исправлений."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Не найдено шаблонов."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Пакеты не найдены."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Внутреннее имя"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Не найдено продуктов."
 
@@ -7037,7 +7064,7 @@ msgid "Updatestack"
 msgstr "Стек обновлений"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Исправления"
 
@@ -7061,7 +7088,7 @@ msgid "Needed software management updates will be installed first:"
 msgstr ""
 "Необходимые обновления управления ПО будут установлены в первую очередь:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Не найдено обновлений."
 
@@ -7070,50 +7097,50 @@ msgstr "Не найдено обновлений."
 msgid "The following updates are also available:"
 msgstr "Также доступны следующие обновления:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Обновления пакетов"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Обновления шаблонов"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Обновления продуктов"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Текущая версия"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Доступная версия"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Соответствия не найдены."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Были найдены следующие совпадения в номерах выпусков:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "Были найдены совпадения в описаниях следующих исправлений:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr "Исправление для выпуска bugzilla номер %s не найдено или не нужно."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "Исправление для выпуска CVE номер %s не найдено или не нужно."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "Исправление для выпуска %s номер %s не найдено или не нужно."
@@ -7641,8 +7668,8 @@ msgid ""
 "If nothing else works enter '#1' to select the 1st option, '#2' for the 2nd "
 "one, ..."
 msgstr ""
-"Если больше ничего не работает, введите #1, чтобы выбрать первый параметр, #"
-"2 — второй и т. д."
+"Если больше ничего не работает, введите #1, чтобы выбрать первый параметр, "
+"#2 — второй и т. д."
 
 #. TranslatorExplanation These are reasons for various failures.
 #: src/utils/prompt.h:95

--- a/po/si.po
+++ b/po/si.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Sinhala <https://l10n.opensuse.org/projects/zypper/master/si/>"
-"\n"
+"Language-Team: Sinhala <https://l10n.opensuse.org/projects/zypper/master/si/"
+">\n"
 "Language: si\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1353,7 +1353,7 @@ msgstr ""
 msgid "Try again?"
 msgstr ""
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr ""
 
@@ -1381,12 +1381,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2066,24 +2066,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2153,7 +2159,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2334,22 +2340,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2400,49 +2406,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2543,11 +2553,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr ""
 
@@ -2557,8 +2567,8 @@ msgstr ""
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr ""
@@ -2566,7 +2576,7 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr ""
@@ -2980,7 +2990,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr ""
 
@@ -3140,120 +3150,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3292,12 +3302,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3339,111 +3349,115 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr ""
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr ""
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr ""
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr ""
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr ""
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr ""
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3451,20 +3465,20 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr ""
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr ""
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3565,7 +3579,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr ""
 
@@ -3574,7 +3588,7 @@ msgstr ""
 msgid "Refreshing repository '%s'."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr ""
@@ -3584,7 +3598,7 @@ msgstr ""
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3611,7 +3625,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3664,12 +3678,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr ""
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr ""
 
@@ -4095,25 +4109,25 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr ""
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr ""
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4203,7 +4217,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr ""
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4222,21 +4236,25 @@ msgstr ""
 msgid "Service '%s' has been removed."
 msgstr ""
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5106,15 +5124,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr ""
 
@@ -5248,13 +5266,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr ""
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -5291,7 +5309,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5545,94 +5563,94 @@ msgstr[1] ""
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr ""
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr ""
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr ""
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr ""
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr ""
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr ""
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr ""
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr ""
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr ""
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr ""
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5640,41 +5658,41 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr ""
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr ""
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr ""
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr ""
@@ -5682,294 +5700,294 @@ msgstr ""
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr ""
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr ""
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr ""
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr ""
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr ""
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr ""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr ""
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr ""
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr ""
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr ""
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr ""
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr ""
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr ""
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr ""
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr ""
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr ""
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -5977,30 +5995,30 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr ""
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr ""
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6008,25 +6026,25 @@ msgstr ""
 msgid "System Packages"
 msgstr ""
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr ""
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr ""
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr ""
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr ""
 
@@ -6397,7 +6415,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr ""
 
@@ -6420,7 +6438,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr ""
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr ""
 
@@ -6429,50 +6447,50 @@ msgstr ""
 msgid "The following updates are also available:"
 msgstr ""
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr ""
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr ""
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr ""
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr ""
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr ""
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/sk.po
+++ b/po/sk.po
@@ -5,11 +5,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Slovak <https://l10n.opensuse.org/projects/zypper/master/sk/>"
-"\n"
+"Language-Team: Slovak <https://l10n.opensuse.org/projects/zypper/master/sk/"
+">\n"
 "Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -226,7 +226,8 @@ msgstr "Ignorovať neznáme balíky."
 #: src/Config.cc:373
 msgid ""
 "Terse output for machine consumption. Implies --no-abbrev and --no-color."
-msgstr "Stručný výstup pre spotrebu stroja. Naznačuje --no-abbrev a --no-color."
+msgstr ""
+"Stručný výstup pre spotrebu stroja. Naznačuje --no-abbrev a --no-color."
 
 #. translators: --reposd-dir, -D <DIR>
 #: src/Config.cc:397
@@ -1019,7 +1020,8 @@ msgid_plural ""
 "The following %d products are recommended, but will not be installed:"
 msgstr[0] "Nasledujúci produkt je odporúčaný, ale nebude sa inštalovať:"
 msgstr[1] "Nasledujúce %d produkty sú odporúčané, ale nebudú sa inštalovať:"
-msgstr[2] "Nasledujúcich %d produktov je odporúčaných, ale nebudú sa inštalovať:"
+msgstr[2] ""
+"Nasledujúcich %d produktov je odporúčaných, ale nebudú sa inštalovať:"
 
 #: src/Summary.cc:1195
 #, c-format, boost-format
@@ -1028,7 +1030,8 @@ msgid_plural ""
 "The following %d applications are recommended, but will not be installed:"
 msgstr[0] "Nasledujúca aplikácia je odporúčaná, ale nebude sa inštalovať:"
 msgstr[1] "Nasledujúce %d aplikácie sú odporúčané, ale nebudú sa inštalovať:"
-msgstr[2] "Nasledujúcich %d aplikácií je odporúčaných, ale nebudú sa inštalovať:"
+msgstr[2] ""
+"Nasledujúcich %d aplikácií je odporúčaných, ale nebudú sa inštalovať:"
 
 #: src/Summary.cc:1228
 #, c-format, boost-format
@@ -1064,7 +1067,8 @@ msgid_plural ""
 "The following %d products are suggested, but will not be installed:"
 msgstr[0] "Nasledujúci produkt je navrhovaný, ale nebude sa inštalovať:"
 msgstr[1] "Nasledujúce %d produkty sú navrhované, ale nebudú sa inštalovať:"
-msgstr[2] "Nasledujúcich %d produktov je navrhovaných, ale nebudú sa inštalovať:"
+msgstr[2] ""
+"Nasledujúcich %d produktov je navrhovaných, ale nebudú sa inštalovať:"
 
 #: src/Summary.cc:1249
 #, c-format, boost-format
@@ -1073,7 +1077,8 @@ msgid_plural ""
 "The following %d applications are suggested, but will not be installed:"
 msgstr[0] "Nasledujúca aplikácia je navrhovaná, ale nebude sa inštalovať:"
 msgstr[1] "Nasledujúce %d aplikácie sú navrhované, ale nebudú sa inštalovať:"
-msgstr[2] "Nasledujúcich %d aplikácií je navrhovaných, ale nebudú sa inštalovať:"
+msgstr[2] ""
+"Nasledujúcich %d aplikácií je navrhovaných, ale nebudú sa inštalovať:"
 
 #: src/Summary.cc:1274
 #, c-format, boost-format
@@ -1204,7 +1209,8 @@ msgid ""
 msgid_plural ""
 "The following %d packages were discontinued and have been superseded by a "
 "new packages with different names."
-msgstr[0] "Nasledujúci balík bol ukončený a nahradil ho nový balík s iným názvom."
+msgstr[0] ""
+"Nasledujúci balík bol ukončený a nahradil ho nový balík s iným názvom."
 msgstr[1] ""
 "Nasledujúce %d balíky boli ukončené a nahradené novými balíkmi s inými "
 "názvami."
@@ -1519,7 +1525,7 @@ msgstr "PackageKit stále beží (pravdepodobne je zaneprázdnený)."
 msgid "Try again?"
 msgstr "Skúsiť znova?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Neočakávaná výnimka."
 
@@ -1550,12 +1556,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Voľba %s tu nemá žiadny vplyv, bude ignorovaná."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Argumenty programu (okrem volieb): "
 
@@ -1785,7 +1791,8 @@ msgstr "Ignorujem zlyhanie overenia podpisu pre súbor '%s'!"
 #, c-format, boost-format
 msgid ""
 "Ignoring failed signature verification for file '%s' from repository '%s'!"
-msgstr "Ignorovanie zlyhania overenia podpisu pre súbor '%s' z repozitára '%s'!"
+msgstr ""
+"Ignorovanie zlyhania overenia podpisu pre súbor '%s' z repozitára '%s'!"
 
 #: src/callbacks/keyring.h:376
 msgid "Double-check this is not caused by some malicious changes in the file!"
@@ -2066,8 +2073,8 @@ msgid ""
 "Authentication required to access %s. You need to be root to be able to read "
 "the credentials from %s."
 msgstr ""
-"Autentifikácia požadovaná pre prístup k %s. Musíte byť správca systému (root)"
-", aby ste boli schopní čítať prihlasovacie údaje z %s."
+"Autentifikácia požadovaná pre prístup k %s. Musíte byť správca systému "
+"(root), aby ste boli schopní čítať prihlasovacie údaje z %s."
 
 #: src/callbacks/media.cc:314 src/callbacks/media.cc:321
 msgid "User Name"
@@ -2303,17 +2310,17 @@ msgid "Commands:"
 msgstr "Príkazy:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Zobraziť podrobný súhrn inštalácie."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Typ balíka (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2321,9 +2328,15 @@ msgstr ""
 "Urobiť aktualizáciu najlepším možným spôsobom. Aktualizácia na nižšiu "
 "verziu, aj keď existuje vyššia je tiež prijateľná."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "Uvažovať iba opravy, ktoré ovplyvňujú samotnú správu balíčkov."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2404,7 +2417,7 @@ msgstr "zypper [--globálne-voľby] <príkaz> [--voľby-príkazu] [argumenty]"
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <podpríkaz> [--voľby-príkazu] [argumenty]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Tlačiť pomocníka"
 
@@ -2620,22 +2633,22 @@ msgstr ""
 "aktualizovanými verziami."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [VOĽBY]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Vypísať zoznam dostupných opráv."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Zoznam všetkých použiteľných opráv."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Zoznam všetkých opráv, nielen použiteľných."
 
@@ -2690,36 +2703,40 @@ msgstr ""
 "všetkých dostupných lokalizácií volaním '%s'."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [VOĽBY] [LOKALIZÁCIA] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Zoznam požadovaných lokalizácií (kódy jazykov)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Zoznam požadovaných lokalizácií a zodpovedajúcich balíkov."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Ukázať zodpovedajúce balíky."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Zoznam všetkých dostupných lokalizácií."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 "Ignorovanie pozičných argumentov, pretože bol poskytnutý argument --all."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "Lokalizácia(e), pre ktoré majú byť vytlačené informácie."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2727,15 +2744,16 @@ msgstr ""
 "Získať všetky lokalizácie s kódom jazyka 'en' , ktoré majú svoj vlastný kód "
 "krajiny, okrem núdzového 'en':"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
-msgstr "Získať všetky lokalizácie s kódom jazyka 'en' s alebo bez kódu krajiny:"
+msgstr ""
+"Získať všetky lokalizácie s kódom jazyka 'en' s alebo bez kódu krajiny:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "Získať lokalizáciu, ktorá presne zodpovedá argumentu: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "Získať zoznam balíkov, ktoré sú k dispozícii pre 'de' a 'en':"
 
@@ -2847,11 +2865,11 @@ msgstr[2] "Odstránených %lu zámkov."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Názov"
 
@@ -2861,8 +2879,8 @@ msgstr "Zhoduje sa"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Typ"
@@ -2870,7 +2888,7 @@ msgstr "Typ"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Repozitár"
@@ -3331,7 +3349,7 @@ msgid "Command"
 msgstr "Príkaz"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Služba"
 
@@ -3501,40 +3519,40 @@ msgid "Show detailed information for products."
 msgstr "Zobrazí podrobné informácie o produktoch."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [voľby] [repozitár] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Zoznam dostupných balíkov."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Zoznam všetkých dostupných balíkov v zadaných repozitároch."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 "Zobraziť nainštalované balíky, ktoré boli automaticky vybrané riešiteľom."
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr "Zobraziť nainštalované balíky, ktoré používateľ výslovne vybral."
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 "Zobraziť nainštalované balíky, ktoré nie sú poskytované žiadnym repozitárom."
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
@@ -3543,82 +3561,83 @@ msgstr ""
 "na aktualizáciu)."
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Ukázať balíky, ktoré sú navrhované."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Ukázať balíky, ktoré sú odporúčané."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Ukázať balíky, ktoré sú nepotrebné."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Triediť zoznam podľa názvu balíka."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Trieď zoznam podľa repozitárov."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [repozitár] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Zoznam dostupných opráv."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Zoznam všetkých opráv v zadaných repozitároch."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [voľby] [repozitár] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Zoznam dostupných šablón."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Vypíše zoznam všetkých dostupných šablón v zdaných repozitároch."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [voľby] [repozitár] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Zoznam dostupných produktov."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Vypíše zoznam všetkých dostupných produktov v zdaných repozitároch."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
-msgstr "Iba výstup XML: Doslova preposlať značky XML nájdené v súbore produktu."
+msgstr ""
+"Iba výstup XML: Doslova preposlať značky XML nájdené v súbore produktu."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "Voľba %1% nemá žiadny účinok bez globálnej voľby %2%."
@@ -3659,12 +3678,12 @@ msgstr "Nekontrolovať URI, skontrolovať neskôr počas obnovenia."
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr "Typ repozitára je vždy automaticky zistený. Táto voľba je ignorovaná."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "Nie je možné použiť %s spolu s %s. Použijem %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr "Ak je použitý iba jeden argument, musí to byť URI adresa .repo súboru."
@@ -3706,111 +3725,115 @@ msgstr "Vyčistiť vyrovnávaciu pamäť surových metadát."
 msgid "Clean both metadata and package caches."
 msgstr "Vyčistiť vyrovnávacie pamäte pre metadáta aj balíky."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Zapnutý"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Overovanie GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Priorita"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Automatická obnova"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Zapnuté"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Vypnuté"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Ponechávať balíky"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI GPG kľúča"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Prefix cesty"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Rodičovská služba"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Kľúčové slová"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Cesta pre Repo Info"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Cesta k MD vyrovnávacej pamäti"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [voľby] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Zoznam definovaných repozitárov."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "Exportovať všetky definované repozitáre do jedného .repo súboru."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Chyba pri čítaní repozitárov:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Nemôžem otvoriť súbor %s pre zápis."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Pravdepodobne nemáte práva na zápis?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Všetky repozitáre boli úspešne vyexportované do súboru '%s'."
@@ -3818,20 +3841,20 @@ msgstr "Všetky repozitáre boli úspešne vyexportované do súboru '%s'."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Obnoviť"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "Ponechať"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Žiadne repozitáre definované."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 "Použiť príkaz 'zypper addrepo' na pridanie jedného alebo viacerých "
@@ -3940,7 +3963,7 @@ msgstr "Globálna voľba '%s' tu nemá žiadny vplyv."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Argumenty príkazu nie sú povolené ak je použitá voľba '%s'."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Zadané repozitáre: "
 
@@ -3949,7 +3972,7 @@ msgstr "Zadané repozitáre: "
 msgid "Refreshing repository '%s'."
 msgstr "Obnovenie repozitára '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Prehľadávanie obsahu vypnutého repozitára '%s'."
@@ -3959,7 +3982,7 @@ msgstr "Prehľadávanie obsahu vypnutého repozitára '%s'."
 msgid "Skipping disabled repository '%s'"
 msgstr "Vynechanie vypnutého repozitára '%s'"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Vynechávam repozitár '%s' kvôli vyššie uvedenej chybe."
@@ -3980,13 +4003,14 @@ msgstr "Nie sú definované žiadne zapnuté repozitáre."
 #: src/commands/repos/refresh.cc:331
 #, c-format, boost-format
 msgid "Use '%s' or '%s' commands to add or enable repositories."
-msgstr "Použite príkaz '%s' alebo '%s' pre pridanie alebo zapnutie repozitárov."
+msgstr ""
+"Použite príkaz '%s' alebo '%s' pre pridanie alebo zapnutie repozitárov."
 
 #: src/commands/repos/refresh.cc:337
 msgid "Could not refresh the repositories because of errors."
 msgstr "Nepodarilo sa obnoviť repozitáre kvôli chybám."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Niektoré repozitáre neboli obnovené kvôli chybe."
 
@@ -4042,12 +4066,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Repozitár '%s' bol premenovaný na '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "Repozitár nazvaný '%s' už existuje. Prosím, použite iný alias."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Chyba pri zmene repozitára:"
 
@@ -4509,28 +4533,28 @@ msgid ""
 "Like --details, with additional information where the search has matched "
 "(useful for search in dependencies)."
 msgstr ""
-"Ako --details, s ďalšími informáciami, kde bolo hľadanie vyhovujúce ("
-"užitočné pre hľadanie v závislostiach)."
+"Ako --details, s ďalšími informáciami, kde bolo hľadanie vyhovujúce "
+"(užitočné pre hľadanie v závislostiach)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Zadaný repozitár '%s' je vypnutý."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Neboli nájdené žiadne odpovedajúce položky."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Nastal problém pri inicializácii alebo spustení vyhľadávania"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Pozrite predchádzajúcu správu. Poskytne vám tip o príčine chyby."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 "Spustenie 'zypper refresh' pod správcom systému (root) by mohlo vyriešiť "
@@ -4624,7 +4648,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Problém pri načítaní indexu repozitárov zo služby '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Vynechávam službu '%s' kvôli vyššie uvedenej chybe."
@@ -4643,24 +4667,28 @@ msgstr "Odstraňujem službu '%s':"
 msgid "Service '%s' has been removed."
 msgstr "Služba '%s' bola odstránená."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [voľby]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Zoznam všetkých definovaných služieb."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Zoznam definovaných služieb."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Nie sú definované žiadne služby. Pridajte jednu alebo viac služieb pomocou "
 "príkazu '%s'."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4892,7 +4920,8 @@ msgstr "Odstráni indexovú službu zadaného repozitára zo systému.."
 #: src/commands/services/remove.cc:76
 #, c-format, boost-format
 msgid "Service '%s' not found by alias, number or URI."
-msgstr "Služba '%s' nebola nájdená podľa zadaného aliasu, čísla ani URI adresy."
+msgstr ""
+"Služba '%s' nebola nájdená podľa zadaného aliasu, čísla ani URI adresy."
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/shell.cc:20
@@ -5595,15 +5624,15 @@ msgstr "%s je staršia ako %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Verzia"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arch"
 
@@ -5740,13 +5769,13 @@ msgstr "(prázdny)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Závislosť"
 
@@ -5783,7 +5812,7 @@ msgid "Flavor"
 msgstr "Druh"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Základný"
 
@@ -6045,57 +6074,57 @@ msgstr[2] "%1% repozitárov"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Zisťujem či je potrebné obnoviť metadáta pre %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Repozitár '%s' je aktuálny."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Kontrola aktuálnosti repozitára '%s' bola odložená."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Vynútenie obnovy surových metadát"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Načítavanie metadát repozitára '%s'"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Chcete vypnúť repozitár %s natrvalo?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Chyba počas vypínania repozitára '%s'."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Problém pri sťahovaní súborov z '%s'."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Pozrite vyššie vypísanú chybu pre informáciu o jej príčine."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Pre '%s' nie sú definované žiadne URI adresy."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -6104,16 +6133,16 @@ msgstr ""
 "Prosím, pridajte jednu alebo viac základných URI adries (baseurl=URI) do %s "
 "pre repozitár '%s'."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Pre tento repozitár nie je definovaný alias."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Repozitár '%s' je neplatný."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -6121,22 +6150,22 @@ msgstr ""
 "Prosím, overte, či URI adresy definované pre tento repozitár odkazujú na "
 "platný repozitár."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Chyba pri čítaní metadát pre '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Vytváram vyrovnávaciu pamäť repozitára (vynútené)"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Chyba pri čítaní metadát pre '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6148,41 +6177,41 @@ msgstr ""
 "prosím chybu podľa inštrukcií na adrese http://en.opensuse.org/Zypper/"
 "Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Metadáta pre '%s' neboli nájdené v lokálnej vyrovnávacej pamäti."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Chyba pri vytváraní vyrovnávacej pamäte:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Repozitár '%s' nebol nájdený podľa zadaného aliasu, čísla, ani URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Pre získanie zoznamu definovaných repozitárov použite príkaz '%s'."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Vynechanie vypnutého repozitára '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr "Globálna voľba '%s' sa môže použiť pre dočasné povolenie repozitárov."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Ignorovanie repozitára '%s' kvôli voľbe '%s'."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Dočasne zapnutie repozitára '%s'."
@@ -6190,7 +6219,7 @@ msgstr "Dočasne zapnutie repozitára '%s'."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6199,7 +6228,7 @@ msgstr ""
 "Repozitár '%s' nie je aktuálny. Môžete ho aktualizovať spustením príkazu "
 "'zypper refresh' ako správca systému (root)."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6208,82 +6237,82 @@ msgstr ""
 "Je potrebné vytvoriť vyrovnávaciu pamäť pre repozitár '%s'. Môžete to urobiť "
 "spustením príkazu 'zypper refresh' ako správca systému (root)."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Repozitár '%s' zostáva vypnutý."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Inicializujem cieľovú databázu"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Zlyhala inicializácia cieľa:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Čistenie vyrovnávacej pamäti metadát pre '%s'."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Čistenie vyrovnávacej pamäti surových metadát pre '%s'."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Ponechanie vyrovnávacej pamäti surových metadát pre %s '%s'."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Mažem uložené RPM súbory pre '%s'."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Nemôžem vyčistiť repozitár '%s' kvôli vyššie uvedenej chybe."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Čistenie vyrovnávacej pamäte nainštalovaných balíkov."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 "Nemožno vyčistiť vyrovnávaciu pamäť nainštalovaných balíkov kvôli chybe."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Nepodarilo sa vyčistiť repozitáre kvôli chybe."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Niektoré repozitáre neboli vyčistené kvôli chybe."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Zadané repozitáre boli vyčistené."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Všetky repozitáre boli vyčistené."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Toto je vymeniteľné médium len na čítanie (CD/DVD), vypnutie automatickej "
 "obnovy."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Nepovolený alias pre repozitár: '%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6291,25 +6320,25 @@ msgstr ""
 "Nemôžem určiť typ repozitára. Prosím overte, či definované URI adresy (viď "
 "nižšie) ukazujú na platný repozitár:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Nemôžem nájsť platný repozitár na zadanej adrese:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Problém pri prenášaní údajov repozitára zo zadanej URI adresy:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Prosím, overte, či je zadaná URI adresa prístupná."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Neznáma chyba pri pridávaní repozitára:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6318,135 +6347,135 @@ msgstr ""
 "Overovanie GPG je vypnuté v konfigurácii repozitára '%1%'. Integritu a pôvod "
 "balíkov nemožno overiť."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Repozitár '%s' bol úspešne pridaný"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Čítanie údajov z média '%s'"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Problém pri čítaní údajov z média '%s'"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Prosím, overte či sú vaše inštalačné médiá správne a čitateľné."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Čítanie údajov z média '%s' je odložené až do ďalšej obnovy."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Čítanie údajov z média '%s'"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Problém pri čítaní údajov z média '%s'"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Prosím, overte či sú vaše inštalačné médiá správne a čitateľné."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Problém pri prístupe k súboru na zadanej URI adrese"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Prosím, overte, či je zadaná URI adresa platná a prístupná."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Problém pri analyzovaní súboru na zadanej URI adrese"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Je to súbor .repo?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Nastal problém pri pokuse o čítanie súboru na zadanej URI adrese"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "V súbore bol nájdený repozitár bez definovaného aliasu, preskakujem."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Repozitár '%s' nemá definované žiadne URI adresy, preskakujem."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Repozitár '%s' bol odstránený."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Priorita repozitára '%s' zostáva nezmenená (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Repozitár '%s' bol úspešne zapnutý."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Repozitár '%s' bol úspešne vypnutý."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Automatická obnova repozitára '%s' bola zapnutá."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Automatická obnova repozitára '%s' bola vypnutá."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Uchovávanie RPM súborov pre repozitár '%s' bolo zapnuté."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Uchovávanie RPM súborov pre repozitár '%s' bolo vypnuté."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Overovanie GPG bolo zapnuté pre repozitár '%s'."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Overovanie GPG bolo vypnuté pre repozitár '%s'."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Priorita repozitára '%s' bola nastavená na %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Názov repozitára '%s' bol nastavený na '%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Na repozitári '%s' nie je potrebné nič meniť."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Ponechanie repozitára %s bez zmeny."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Načítavam údaje repozitárov..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6454,44 +6483,44 @@ msgstr ""
 "Nie sú definované žiadne repozitáre. Prevádzka len s nainštalovanými "
 "riešeniami. Nič nemôže byť nainštalované."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Načítavam údaje repozitára '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Repozitár '%s' nie je uchovávaný. Uchovávanie..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Problém pri sťahovaní údajov z '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 "Repozitár '%s' nemohol byť obnovený. Použitie starej vyrovnávacej pamäte."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Riešenia z repozitára '%s' neboli kvôli chybe načítané."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "Platnosť metadát repozitára '%1%' uplynula od %2%."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Vyskúšajte '%s' alebo dokonca '%s' než tak urobíte."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6499,35 +6528,35 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 "Platnosť metadát repozitára vypršala: Skontrolujte, či je zapnutá "
-"'automatická obnova' (zypper lr), v opačnom prípade obnovte repozitár ručne ("
-"zypper ref). Ak to problém nevyrieši, môže to byť spôsobené tým, že "
+"'automatická obnova' (zypper lr), v opačnom prípade obnovte repozitár ručne "
+"(zypper ref). Ak to problém nevyrieši, môže to byť spôsobené tým, že "
 "používate nefunkčné zrkadlo alebo server skutočne prestal podporovať "
 "repozitár."
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Načítavam nainštalované balíky..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Chyba pri čítaní nainštalovaných balíkov:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' vyzerá ako RPM súbor. Pokúsim sa ho stiahnuť."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Nastal problém s RPM súborom zadaným ako '%s', preskakujem."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Nastal problém pri čítaní RPM hlavičky balíka %s. Je to RPM súbor?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Vyrovnávacie pamäť RPM súborov"
 
@@ -6535,25 +6564,25 @@ msgstr "Vyrovnávacie pamäť RPM súborov"
 msgid "System Packages"
 msgstr "Balíky v systéme"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Neboli nájdené žiadne potrebné opravy."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Neboli nájdené žiadne šablóny."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Neboli nájdené žiadne balíky."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Interný názov"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Neboli nájdené žiadne produkty."
 
@@ -6965,7 +6994,7 @@ msgid "Updatestack"
 msgstr "Updatestack"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Opravy"
 
@@ -6988,7 +7017,7 @@ msgstr "Zahrnuté kategórie"
 msgid "Needed software management updates will be installed first:"
 msgstr "Potrebné aktualizácie správcu softvéru sa nainštalujú prednostne:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Neboli nájdené žiadne aktualizácie."
 
@@ -6997,50 +7026,51 @@ msgstr "Neboli nájdené žiadne aktualizácie."
 msgid "The following updates are also available:"
 msgstr "Nasledujúce aktualizácie sú taktiež dostupné:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Aktualizácie balíkov"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Aktualizácie šablón"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Aktualizácie produktov"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Súčasná verzia"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Dostupná verzia"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Neboli nájdené žiadne odpovedajúce problémy."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Našli sa nasledujúce zhody v číslach problémov:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "Našli sa zhody v popisoch týchto opráv:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
-msgstr "Oprava bugzilla problému číslo %s nebola nájdená alebo nie je potrebná."
+msgstr ""
+"Oprava bugzilla problému číslo %s nebola nájdená alebo nie je potrebná."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "Oprava CVE problému číslo %s nebola nájdená alebo nie je potrebná."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "Oprava %s problému číslo %s nebola nájdená alebo nie je potrebná."

--- a/po/sl.po
+++ b/po/sl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Slovenian <https://l10n.opensuse.org/projects/zypper/master/"
@@ -970,7 +970,8 @@ msgstr[3] "Naslednjih %d priporočenih izdelkov je bilo izbranih samodejno:"
 msgid "The following recommended source package was automatically selected:"
 msgid_plural ""
 "The following %d recommended source packages were automatically selected:"
-msgstr[0] "Naslednji %d priporočeni paket z izvorno kodo je bil izbran samodejno:"
+msgstr[0] ""
+"Naslednji %d priporočeni paket z izvorno kodo je bil izbran samodejno:"
 msgstr[1] ""
 "Naslednja %d priporočena paketa z izvorno kodo sta bila izbrana samodejno:"
 msgstr[2] ""
@@ -1241,10 +1242,14 @@ msgstr[3] "Naslednjih %d programov bo spremenilo izdelovalca:"
 msgid "The following package has no support information from its vendor:"
 msgid_plural ""
 "The following %d packages have no support information from their vendor:"
-msgstr[0] "Naslednji %d paket nima podatkov o podpori od njegovega izdelovalca:"
-msgstr[1] "Naslednja %d paketa nimata podatkov o podpori od njihovega izdelovalca:"
-msgstr[2] "Naslednji %d paketi nimajo podatkov o podpori od njihovega izdelovalca:"
-msgstr[3] "Naslednjih %d paketov nima podatkov o podpori od njihovega izdelovalca:"
+msgstr[0] ""
+"Naslednji %d paket nima podatkov o podpori od njegovega izdelovalca:"
+msgstr[1] ""
+"Naslednja %d paketa nimata podatkov o podpori od njihovega izdelovalca:"
+msgstr[2] ""
+"Naslednji %d paketi nimajo podatkov o podpori od njihovega izdelovalca:"
+msgstr[3] ""
+"Naslednjih %d paketov nima podatkov o podpori od njihovega izdelovalca:"
 
 #: src/Summary.cc:1382
 #, c-format, boost-format
@@ -1261,10 +1266,14 @@ msgid ""
 "The following package needs additional customer contract to get support:"
 msgid_plural ""
 "The following %d packages need additional customer contract to get support:"
-msgstr[0] "Naslednji %d paket za podporo potrebuje dodatno uporabniško pogodbo:"
-msgstr[1] "Naslednja %d paketa za podporo potrebujeta dodatno uporabniško pogodbo:"
-msgstr[2] "Naslednji %d paketi za podporo potrebujejo dodatno uporabniško pogodbo:"
-msgstr[3] "Naslednjih %d paketov za podporo potrebuje dodatno uporabniško pogodbo:"
+msgstr[0] ""
+"Naslednji %d paket za podporo potrebuje dodatno uporabniško pogodbo:"
+msgstr[1] ""
+"Naslednja %d paketa za podporo potrebujeta dodatno uporabniško pogodbo:"
+msgstr[2] ""
+"Naslednji %d paketi za podporo potrebujejo dodatno uporabniško pogodbo:"
+msgstr[3] ""
+"Naslednjih %d paketov za podporo potrebuje dodatno uporabniško pogodbo:"
 
 #: src/Summary.cc:1417
 msgid "was superseded by"
@@ -1628,7 +1637,7 @@ msgstr "PackageKit še vedno teče (verjetno je zaposlen)."
 msgid "Try again?"
 msgstr "Ali želite poskusiti znova?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Nepričakovana izjema."
 
@@ -1659,12 +1668,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Možnost %s tu nima učinka in bo prezrta."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Argumenti programa, ki niso možnosti: "
 
@@ -1776,10 +1785,14 @@ msgstr "Datoteka »%1%« za podpisovanje s ključem GPG je potekla."
 #, boost-format
 msgid "The gpg key signing file '%1%' will expire in %2% day."
 msgid_plural "The gpg key signing file '%1%' will expire in %2% days."
-msgstr[0] "Datoteka »%1%« za podpisovanje s ključem GPG bo potekla čez %2% dan."
-msgstr[1] "Datoteka »%1%« za podpisovanje s ključem GPG bo potekla čez %2% dneva."
-msgstr[2] "Datoteka »%1%« za podpisovanje s ključem GPG bo potekla čez %2% dni."
-msgstr[3] "Datoteka »%1%« za podpisovanje s ključem GPG bo potekla čez %2% dni."
+msgstr[0] ""
+"Datoteka »%1%« za podpisovanje s ključem GPG bo potekla čez %2% dan."
+msgstr[1] ""
+"Datoteka »%1%« za podpisovanje s ključem GPG bo potekla čez %2% dneva."
+msgstr[2] ""
+"Datoteka »%1%« za podpisovanje s ključem GPG bo potekla čez %2% dni."
+msgstr[3] ""
+"Datoteka »%1%« za podpisovanje s ključem GPG bo potekla čez %2% dni."
 
 #: src/callbacks/keyring.h:152
 #, c-format, boost-format
@@ -2422,17 +2435,17 @@ msgid "Commands:"
 msgstr "Ukazi:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Prikaže podroben povzetek namestitve."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Vrsta paketa (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2440,9 +2453,15 @@ msgstr ""
 "Izvede posodobitev »po najboljših močeh«. Sprejemljive so posodobitve na "
 "različice, ki niso najnovejše."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "Upošteva le popravke, ki vplivajo na samo upravljanje paketov."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2523,7 +2542,7 @@ msgstr "zypper [SPLOŠNE_MOŽNOSTI] <UKAZ> [MOŽNOSTI_UKAZA] [ARGUMENTI]"
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <PODUKAZ> [MOŽNOSTI_UKAZA] [ARGUMENTI]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Izpiše pomoč za zypper"
 
@@ -2628,8 +2647,8 @@ msgid ""
 "Patches are not installed in sense of copied files, database records,\n"
 "or similar."
 msgstr ""
-"Stanje nameščenosti popravka je določeno samo na osnovi njegovih odvisnosti."
-"\n"
+"Stanje nameščenosti popravka je določeno samo na osnovi njegovih "
+"odvisnosti.\n"
 "Popravki niso nameščeni v smislu skopiranih datotek, zapisov v podatkovnih\n"
 "zbirkah ali podobno."
 
@@ -2738,22 +2757,22 @@ msgstr ""
 "njihovimi uradnimi posodobitvenimi različicami."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [MOŽNOSTI]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Izpiše razpoložljive popravke."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Izpiše seznam popravkov, ki jih je mogoče uveljaviti."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Izpiše vse popravke, ne samo tistih, ki jih je mogoče uveljaviti."
 
@@ -2808,36 +2827,40 @@ msgstr ""
 "razpoložljivih jezikov dobite z ukazom »%s«."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [MOŽNOSTI] [JEZIK] …"
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Izpiše zahtevane jezike (kode jezikov)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Izpiše zahtevane jezike in povezane pakete."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Prikaže povezane pakete."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Prikaže vse razpoložljive jezike."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 "Položajni argumenti bodo prezrti, ker je bil uporabljen argument »--all«."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "Jeziki, za katere naj bodo izpisani podatki."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2845,15 +2868,15 @@ msgstr ""
 "Dobi vse jezike s kodo »en«, ki imajo tudi svojo kodo države in brez "
 "splošnega »en«:"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr "Dobi vse jezike s kodo »en« s kodo države ali brez nje:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "Dobi jezik, ki se natančno ujema z argumentom: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "Dobi seznam paketov, ki so na voljo za »de« in »en«:"
 
@@ -2968,11 +2991,11 @@ msgstr[3] "Odstranjenih %lu zaklepov."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Ime"
 
@@ -2982,8 +3005,8 @@ msgstr "Ujemanja"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Vrsta"
@@ -2991,7 +3014,7 @@ msgstr "Vrsta"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Vir"
@@ -3273,8 +3296,8 @@ msgid ""
 "download-as-needed disables the fileconflict check."
 msgstr ""
 "Namesti pakete, čeprav nadomestijo datoteke iz drugih paketov, ki so že "
-"nameščeni. Privzeto se spore med datotekama obravnava kot napake. Možnost "
-"»--download-as-needed« onemogoči preverjanje sporov med datotekama."
+"nameščeni. Privzeto se spore med datotekama obravnava kot napake. Možnost »--"
+"download-as-needed« onemogoči preverjanje sporov med datotekama."
 
 #. translators: -y, --no-confirm
 #: src/commands/optionsets.cc:291
@@ -3457,7 +3480,7 @@ msgid "Command"
 msgstr "Ukaz"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Storitev"
 
@@ -3628,38 +3651,38 @@ msgid "Show detailed information for products."
 msgstr "Prikaže podrobne podatke o izdelkih."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [MOŽNOSTI] [VIR] …"
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Izpiše vse razpoložljive pakete."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Izpiše vse pakete, ki so na voljo v navedenih virih."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr "Prikaže nameščene pakete, ki jih je samodejno izbral razreševalnik."
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr "Prikaže nameščene pakete, ki jih je izrecno izbral uporabnik."
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr "Prikaže nameščene pakete, ki jih ne ponuja noben vir."
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
@@ -3668,83 +3691,83 @@ msgstr ""
 "posodobitev)."
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Prikaže pakete, ki so predlagani."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Prikaže pakete, ki so priporočeni."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Prikaže pakete, ki niso potrebni."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Seznam razvrsti po imenu paketa."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Seznam razvrsti po viru."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [VIR] …"
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Izpiše vse razpoložljive popravke."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Izpiše vse popravke, ki so na voljo v navedenih virih."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [MOŽNOSTI] [VIR] …"
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Izpiše vse razpoložljive vzorce."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Izpiše vse vzorce, ki so na voljo v navedenih virih."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [MOŽNOSTI] [VIR] …"
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Izpiše vse razpoložljive izdelke."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Izpiše vse izdelke, ki so na voljo v navedenih virih."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Samo izhod XML: dobesedno posreduje vse oznake XML, ki so v datoteki izdelka."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "Možnost »%1%« nima učinka brez splošne možnosti »%2%«."
@@ -3785,19 +3808,19 @@ msgstr "Ne preveri URI-ja, preveri kasneje med osvežitvijo."
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr "Vrsto vira se vedno zazna samodejno. Ta možnost bo prezrta."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 "Možnosti »%s« ni mogoče uporabiti skupaj z »%s«. Uporabljena bo nastavitev "
 "iz %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
-"Če je uporabljen samo en argument, mora to biti URI, ki kaže na datoteko "
-".repo."
+"Če je uporabljen samo en argument, mora to biti URI, ki kaže na "
+"datoteko .repo."
 
 #: src/commands/repos/add.cc:130
 msgid "Specified type is not a valid repository type:"
@@ -3836,111 +3859,115 @@ msgstr "Počisti pomnilnik neobdelanih metapodatkov."
 msgid "Clean both metadata and package caches."
 msgstr "Počisti predpomnilnika metapodatkov in paketov."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Drugo ime"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Omogočeno"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Preverjanje GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Prednost"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Samoosvežitev"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Omogočen"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Onemogočen"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Obdrži pakete"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI ključa GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Predpona poti"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Nadrejena storitev"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Ključne besede"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Pot podatkov o viru"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Pot predpom. MP"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [MOŽNOSTI] [VIR] …"
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Izpiše vse določene vire."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "Izvozi vse določene vire v eno krajevno datoteko .repo."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Napaka branja virov:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Datoteke %s ni moč odpreti za pisanje."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Morda nimate dovoljenja za pisanje?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Viri so bili uspešno izvoženi v datoteko %s."
@@ -3948,20 +3975,20 @@ msgstr "Viri so bili uspešno izvoženi v datoteko %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Osvežitev"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "Obdrži"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Določen ni noben vir."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr "Za dodajanje enega ali več virov uporabite ukaz »zypper addrepo«."
 
@@ -4068,7 +4095,7 @@ msgstr "Splošna možnost »%s« tu nima vpliva."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Če je uporabljena možnost »%s«, argumenti niso dovoljeni."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Navedeni viri: "
 
@@ -4077,7 +4104,7 @@ msgstr "Navedeni viri: "
 msgid "Refreshing repository '%s'."
 msgstr "Osveževanje vira »%s«."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Pregledovanje vsebine onemogočenega vira »%s«."
@@ -4087,7 +4114,7 @@ msgstr "Pregledovanje vsebine onemogočenega vira »%s«."
 msgid "Skipping disabled repository '%s'"
 msgstr "Onemogočen vir »%s« bo preskočen"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Zaradi napake zgoraj bo vir »%s« preskočen."
@@ -4114,7 +4141,7 @@ msgstr "Za dodajanje ali omogočanje virov uporabite ukaza »%s« ali »%s«."
 msgid "Could not refresh the repositories because of errors."
 msgstr "Zaradi napak virov ni bilo moč osvežiti."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Zaradi napake nekateri izmed virov niso bili osveženi."
 
@@ -4170,12 +4197,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Vir »%s« je bil preimenovan v »%s«."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "Vir z imenom »%s« že obstaja. Uporabite drugačno drugo ime."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Napaka med spreminjanjem vira:"
 
@@ -4634,28 +4661,29 @@ msgid ""
 "Like --details, with additional information where the search has matched "
 "(useful for search in dependencies)."
 msgstr ""
-"Kot možnost »--details«, a z dodatnimi informacijami, kje je bilo ujemanje ("
-"uporabno za iskanja po odvisnostih)."
+"Kot možnost »--details«, a z dodatnimi informacijami, kje je bilo ujemanje "
+"(uporabno za iskanja po odvisnostih)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Navedeni vir »%s« je onemogočen."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Najden ni bil noben predmet."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
-msgstr "Med pripravljanjem ali izvajanjem iskalne poizvedbe je prišlo do napake"
+msgstr ""
+"Med pripravljanjem ali izvajanjem iskalne poizvedbe je prišlo do napake"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Za namig glejte zgornje sporočilo."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "Težav morda razreši izvedba ukaza »zypper refresh« kot uporabnik root."
 
@@ -4749,7 +4777,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Težava pridobivanja datoteke kazala za vir za storitev »%s«:"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Zaradi zgornje napake bo storitev »%s« preskočena."
@@ -4768,24 +4796,28 @@ msgstr "Odstranjevanje storitve »%s«:"
 msgid "Service '%s' has been removed."
 msgstr "Storitev »%s« je bila odstranjena."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [MOŽNOSTI]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Izpiše vse določene storitve."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Izpiše določene storitve."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Določene ni nobene storitve. Za dodajanje ene ali več storitev uporabite "
 "ukaz »%s«."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5552,8 +5584,8 @@ msgstr "Nameščen paket"
 #: src/commands/utils/source-download.cc:368
 msgid "Use '--verbose' option for a full list of required source packages."
 msgstr ""
-"Za celoten seznam zahtevanih paketov z izvorno kodo uporabite možnost "
-"»--verbose«."
+"Za celoten seznam zahtevanih paketov z izvorno kodo uporabite možnost »--"
+"verbose«."
 
 #: src/commands/utils/source-download.cc:377
 msgid "Deleting superfluous source packages"
@@ -5721,15 +5753,15 @@ msgstr "%s je starejša od %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Različica"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arhitektura"
 
@@ -5867,13 +5899,13 @@ msgstr "(prazno)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Odvisnosti"
 
@@ -5910,7 +5942,7 @@ msgid "Flavor"
 msgstr "Inačica"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Je osnovni"
 
@@ -6173,57 +6205,57 @@ msgstr[3] "%1% virov"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Preverjanje, ali je potrebno osvežiti metapodatke za %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Vir »%s« je ažuren."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Preverjanje ažurnosti »%s« je bilo odloženo."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Vsiljevanje osvežitve surovih metapodatkov"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Pridobivanje metapodatkov za vir »%s«"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Ali želite za vedno onemogočiti vir »%s«?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Napaka med onemogočanjem vira »%s«."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Težava pridobivanja datotek iz »%s«."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Za namig glejte zgornje sporočilo napake."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Za »%s« ni določenega nobenega URI-ja."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -6231,38 +6263,38 @@ msgid ""
 msgstr ""
 "V %s dodajte enega ali več vnosov osnovnih URI-jev (baseurl=URI) za vir »%s«."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Za ta vir ni določeno nobeno drugo ime."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Vir »%s« ni veljaven."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 "Preverite, ali URI-ji, ki so določeni za ta vir, kažejo na veljaven vir."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Napaka pridobivanja metapodatkov za »%s«:"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Vsiljevanje izgradnje predpomnilnika za vir"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Napaka razčlenjevanja metapodatkov za »%s«:"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6274,41 +6306,41 @@ msgstr ""
 "poročajte o napaki s sledenjem navodilom na http://en.opensuse.org/Zypper/"
 "Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Metapodatkov za vir »%s« v krajevnem predpomnilniku ni bilo moč najti."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Napaka izgrajevanja predpomnilnika:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Vir »%s« po njegovem drugem imenu, številki ali URI-ju ni bil najden."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Da dobite seznam virov, ki so določeni, uporabite ukaz »%s«."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Onemogočen vir »%s« bo prezrt"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr "Splošno možnost »%s« lahko uporabite za začasno omogočanje virov."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Vir »%s« bo zaradi možnosti »%s« prezrt."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Vir »%s« bo začasno omogočen."
@@ -6316,16 +6348,16 @@ msgstr "Vir »%s« bo začasno omogočen."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
-"Vir »%s« ni ažuren. Da ga osvežite, lahko kot uporabnik root zaženete ukaz »"
-"zypper refresh«."
+"Vir »%s« ni ažuren. Da ga osvežite, lahko kot uporabnik root zaženete ukaz "
+"»zypper refresh«."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6334,107 +6366,107 @@ msgstr ""
 "Predpomnilnik metapodatkov za vir »%s« mora biti izgrajen. Da to storite, "
 "lahko kot uporabnik root zaženete ukaz »zypper refresh«."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Vir »%s« bo ostal onemogočen."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Pripravljanje cilja"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Pripravljanje cilja ni uspelo:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Čiščenje predpomnilnika metapodatkov za »%s«."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Čiščenje predpomnilnika surovih metapodatkov za »%s«."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Predpomnilnik surovih metapodatkov za %s »%s« bo obdržan."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Čiščenje paketov za »%s«."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Vira »%s« ni moč očistiti zaradi napake."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Čiščenje predpomnilnika nameščenih paketov."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Predpomnilnika nameščenih paketov ni moč očistiti zaradi napake."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Virov ni bilo moč očistiti zaradi napak."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Nekateri viri niso bili očiščeni zaradi napake."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Navedeni viri so bili očiščeni."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Vsi viri so bili očiščeni."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "To je zamenljiv nosilec samo za branje (CD/DVD). Samoosvežitev bo "
 "onemogočena."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Neveljavno drugo ime vira: »%s«"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
-"Ni bilo moč določiti vrste vira. Preverite, ali URI-ji, ki so določeni ("
-"glejte spodaj), kažejo na veljaven vir:"
+"Ni bilo moč določiti vrste vira. Preverite, ali URI-ji, ki so določeni "
+"(glejte spodaj), kažejo na veljaven vir:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Na danem mestu ni moč najti veljavnega vira:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Težava prenašanja podatkov vira z URI-ja, ki je določen:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Preverite, ali je URI, ki je določen, dosegljiv."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Neznana težava med dodajanjem vira:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6443,136 +6475,136 @@ msgstr ""
 "Preverjanje GPG je v nastavitvah vira »%1%« onemogočeno. Celovitosti in "
 "izvora paketov ni mogoče potrditi."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Vir »%s« je bil uspešno dodan"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Branje podatkov z nosilca »%s«"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Težava branja podatkov z nosilca »%s«"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Preverite, ali je namestitveni nosilec berljiv in veljaven."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Branje podatkov z nosilca »%s« je odloženo do naslednje osvežitve."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Branje podatkov z nosilca »%s«"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Težava branja podatkov z nosilca »%s«"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Preverite, ali je namestitveni nosilec berljiv in veljaven."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Težava dostopanja do datoteke na navedenem URI-ju"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Preverite, ali je URI dostopen in veljaven."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Težava razčlenjevanja datoteke na navedenem URI-ju"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Ali je to datoteka .repo?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Med poskusom branja datoteke na navedenem URI-ju je prišlo do težave"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 "V datoteki je bil najden vir brez določenega drugega imena. Preskočen bo."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Vir »%s« nima določenega URI-ja. Preskočen bo."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Vir »%s« je bil odstranjen."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Prednost vira »%s« bo ostala nespremenjena (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Vir »%s« je bil uspešno omogočen."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Vir »%s« je bil uspešno onemogočen."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Samoosvežitev za vir »%s« je bila omogočena."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Samoosvežitev za vir »%s« je bila onemogočena."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Predpomnjenje datotek RPM za vir »%s« je bilo omogočeno."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Predpomnjenje datotek RPM za vir »%s« je bilo onemogočeno."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Preverjanje GPG za vir »%s« je bilo omogočeno."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Preverjanje GPG za vir »%s« je bilo onemogočeno."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Prednost vira »%s« je bila nastavljena na %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Ime vira »%s« je bilo nastavljeno na »%s«."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Za vir »%s« ni sprememb."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Vir »%s« bo ostal nespremenjen."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Nalaganje podatkov vira …"
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6580,43 +6612,43 @@ msgstr ""
 "Določen ni noben vir. Upoštevane bodo samo nameščene rešitve. Nič ne bo "
 "moglo biti nameščeno."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Prejemanje podatkov vira »%s« …"
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Vir »%s« ni predpomnjen. Predpomnjene …"
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Težava nalaganja podatkov iz »%s«"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "Vira »%s« ni bilo moč osvežiti. Uporabljen bo star predpomnilnik."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Rešitve iz »%s« zaradi napake niso bile naložene."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "Metapodatki vira »%1%« so potekli %2%."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Preden to storite, poskusite z ukazom »%s« ali celo »%s«."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6627,30 +6659,30 @@ msgstr ""
 "ali pa ročno osvežite vir (zypper ref). Če to ne odpravi težave, morda "
 "uporabljate ne-ažuren zrcalni strežnik, ali pa strežnik vira ne podpira več."
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Branje nameščenih paketov …"
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Med branjem nameščenih paketov je prišlo do težave:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "Videti je, da je »%s« datoteka RPM. Poskusilo se jo bo prejeti."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Težava z datoteko RPM, ki je določena kot »%s«. Preskočena bo."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Težava branja glave RPM od %s. Ali je to datoteka RPM?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Predpomnilnik navadnih datotek RPM"
 
@@ -6658,25 +6690,25 @@ msgstr "Predpomnilnik navadnih datotek RPM"
 msgid "System Packages"
 msgstr "Sistemski paketi"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Najden ni bil noben potreben popravek."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Najden ni bil noben vzorec."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Najden ni bil noben paket."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Notranje ime"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Najden ni bil noben izdelek."
 
@@ -6723,7 +6755,8 @@ msgstr[3] ""
 #: src/solve-commit.cc:145
 msgid "Choose the above solution using '1' or cancel using 'c'"
 msgid_plural "Choose from above solutions by number or cancel"
-msgstr[0] "Izberite zgornjo rešitev z vnosom »1« ali pa prekličite z vnosom »r«"
+msgstr[0] ""
+"Izberite zgornjo rešitev z vnosom »1« ali pa prekličite z vnosom »r«"
 msgstr[1] ""
 "Izberite zgornjo rešitev z vnosom »1« ali »2« ali pa prekličite z vnosom »r«"
 msgstr[2] ""
@@ -6919,7 +6952,8 @@ msgstr "d/n/t/r/a/v/i/p/s"
 #: src/solve-commit.cc:822
 msgid ""
 "Yes, accept the summary and proceed with installation/removal of packages."
-msgstr "Da, sprejmi povzetek in nadaljuj z nameščanjem/odstranjevanjem paketov."
+msgstr ""
+"Da, sprejmi povzetek in nadaljuj z nameščanjem/odstranjevanjem paketov."
 
 #. translators: help text for 'n' option in the 'Continue?' prompt
 #: src/solve-commit.cc:824
@@ -7102,7 +7136,7 @@ msgid "Updatestack"
 msgstr "Posodobitveni sklad"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Popravki"
 
@@ -7125,7 +7159,7 @@ msgstr "Vključene kategorije"
 msgid "Needed software management updates will be installed first:"
 msgstr "Potrebne posodobitve upravljalnika programov bodo nameščene najprej:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Najdena ni bila nobena posodobitev."
 
@@ -7134,46 +7168,46 @@ msgstr "Najdena ni bila nobena posodobitev."
 msgid "The following updates are also available:"
 msgstr "Na voljo so tudi naslednje posodobitve:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Posodobitve paketov"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Posodobitve vzorcev"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Posodobitve izdelkov"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Trenutna različica"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Razpoložljiva različica"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Najdeno ni bilo nobeno ujemajoče poročilo o napaki."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Najdene so bile naslednje ujemajoče številke poročil o napakah:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "Najdeni so bili ujemajoči opisi v naslednjih popravkih:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "Popravek za številko poročila Bugzilla o napaki %s ni bil najden ali pa ni "
 "potreben."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
@@ -7181,7 +7215,7 @@ msgstr ""
 "potreben."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -8,11 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Serbian <https://l10n.opensuse.org/projects/zypper/master/sr/>"
-"\n"
+"Language-Team: Serbian <https://l10n.opensuse.org/projects/zypper/master/sr/"
+">\n"
 "Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Try again?"
 msgstr ""
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr ""
 
@@ -1482,13 +1482,13 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
 # bug: string composition
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 #, fuzzy
 msgid "Non-option program arguments: "
 msgstr " без додатних аргумената"
@@ -2187,24 +2187,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2274,7 +2280,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2459,22 +2465,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2525,49 +2531,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2673,11 +2683,11 @@ msgstr[2] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Ime"
 
@@ -2688,8 +2698,8 @@ msgstr "Закрпе"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Tip"
@@ -2697,7 +2707,7 @@ msgstr "Tip"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr ""
@@ -3119,7 +3129,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "Server"
@@ -3283,120 +3293,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3435,12 +3445,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3483,115 +3493,119 @@ msgid "Clean both metadata and package caches."
 msgstr ""
 
 #  Translators: table column headings
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alijas"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr ""
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr ""
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 #, fuzzy
 msgid "Autorefresh"
 msgstr "XF86Refresh"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Укључено"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Искључено"
 
 #  progress stages
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Keep Packages"
 msgstr "Одабери све пакете"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "Server"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr ""
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Can't run %s.  Exiting."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3599,22 +3613,22 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 #, fuzzy
 msgid "Refresh"
 msgstr "XF86Refresh"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "XF86Refresh"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3715,7 +3729,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr ""
 
@@ -3724,7 +3738,7 @@ msgstr ""
 msgid "Refreshing repository '%s'."
 msgstr "XF86Refresh"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "XF86Refresh"
@@ -3734,7 +3748,7 @@ msgstr "XF86Refresh"
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3761,7 +3775,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3814,12 +3828,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr ""
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr ""
 
@@ -4247,25 +4261,25 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "XF86Refresh"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr ""
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4356,7 +4370,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr ""
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4375,21 +4389,25 @@ msgstr "Izbaci"
 msgid "Service '%s' has been removed."
 msgstr "Сервис уклоњен"
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5281,15 +5299,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Verzija"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Арх."
 
@@ -5434,13 +5452,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr ""
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 #, fuzzy
 msgid "Dependency"
 msgstr "Međuzavisnosti"
@@ -5480,7 +5498,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5743,95 +5761,95 @@ msgstr[2] "Verzija"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr ""
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr ""
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr ""
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr ""
 
 #  progress stages
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "&Instaliraj pakete"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr ""
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr ""
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr ""
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr ""
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr ""
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5839,42 +5857,42 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr ""
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr ""
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr ""
 
 #  progress stages
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "&Instaliraj pakete"
@@ -5882,297 +5900,297 @@ msgstr "&Instaliraj pakete"
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "XF86Refresh"
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr ""
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 #, fuzzy
 msgid "Target initialization failed:"
 msgstr "Инсталација — ACPI искључен"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr ""
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
 #  progress stages
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 #, fuzzy
 msgid "Cleaning installed packages cache."
 msgstr "&Instaliraj pakete"
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr ""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr ""
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr ""
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr ""
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr ""
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr ""
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "XF86Refresh"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "XF86Refresh"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr ""
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr ""
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr ""
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr ""
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr ""
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6181,33 +6199,33 @@ msgid ""
 msgstr ""
 
 #  progress stages
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "&Instaliraj pakete"
 
 #  progress stages
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "&Instaliraj pakete"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6217,26 +6235,26 @@ msgstr ""
 msgid "System Packages"
 msgstr "Одабери све пакете"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr ""
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr ""
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "Назив догађаја"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr ""
 
@@ -6620,7 +6638,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Закрпе"
 
@@ -6643,7 +6661,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr ""
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr ""
 
@@ -6652,53 +6670,53 @@ msgstr ""
 msgid "The following updates are also available:"
 msgstr ""
 
-#: src/update.cc:700
+#: src/update.cc:707
 #, fuzzy
 msgid "Package updates"
 msgstr "Paket"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr ""
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr ""
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "Корисник:"
 
-#: src/update.cc:795
+#: src/update.cc:801
 #, fuzzy
 msgid "Available Version"
 msgstr "Ажурирања"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr ""
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -11,11 +11,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Swedish <https://l10n.opensuse.org/projects/zypper/master/sv/>"
-"\n"
+"Language-Team: Swedish <https://l10n.opensuse.org/projects/zypper/master/sv/"
+">\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1016,7 +1016,8 @@ msgid "The following product is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d products are suggested, but will not be installed:"
 msgstr[0] "Följande produkt är föreslagen, men kommer inte att installeras:"
-msgstr[1] "Följande %d produkter är föreslagna, men kommer inte att installeras:"
+msgstr[1] ""
+"Följande %d produkter är föreslagna, men kommer inte att installeras:"
 
 #: src/Summary.cc:1249
 #, c-format, boost-format
@@ -1178,7 +1179,8 @@ msgstr[1] "Följande %d programuppdateringar kommer INTE att installeras:"
 msgid "The following item is locked and will not be changed by any action:"
 msgid_plural ""
 "The following %d items are locked and will not be changed by any action:"
-msgstr[0] "Följande objekt är låst och kommer inte att påverkas av någon åtgärd:"
+msgstr[0] ""
+"Följande objekt är låst och kommer inte att påverkas av någon åtgärd:"
 msgstr[1] ""
 "Följande %d objekt är låsta och kommer inte att påverkas av någon åtgärd:"
 
@@ -1421,7 +1423,7 @@ msgstr "PackageKit körs fortfarande (troligen upptaget)."
 msgid "Try again?"
 msgstr "Vill du försöka igen?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Oväntat undantag."
 
@@ -1446,19 +1448,19 @@ msgid ""
 "The /etc/products.d/baseproduct symlink is dangling or missing!\n"
 "The link must point to your core products .prod file in /etc/products.d.\n"
 msgstr ""
-"/etc/products.d/-basproduktens symboliska länk är verkningslös eller saknas!"
-"\n"
-"Länken måste referera till din .prod-fil för kärnprodukter i /etc/products.d."
-"\n"
+"/etc/products.d/-basproduktens symboliska länk är verkningslös eller "
+"saknas!\n"
+"Länken måste referera till din .prod-fil för kärnprodukter i /etc/"
+"products.d.\n"
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Alternativet %s har ingen effekt här och kommer att ignoreras."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Programargument som inte är alternativ: "
 
@@ -1697,7 +1699,8 @@ msgstr "Ignorerar felaktig signatur för filen '%s' från lagringsplatsen '%s'!"
 
 #: src/callbacks/keyring.h:376
 msgid "Double-check this is not caused by some malicious changes in the file!"
-msgstr "Kontrollera att det inte beror på att filen har ändrats med ont uppsåt!"
+msgstr ""
+"Kontrollera att det inte beror på att filen har ändrats med ont uppsåt!"
 
 #. translator: %1% is a file name
 #: src/callbacks/keyring.h:386
@@ -2202,17 +2205,17 @@ msgid "Commands:"
 msgstr "Kommandon:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Visa detaljerad installationsöversikt."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Typ av paket (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2220,9 +2223,15 @@ msgstr ""
 "Gör den bästa möjliga uppdateringen. Uppdateringar till en tidigare version "
 "än den senaste godkänns också."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "Överväg endast korrigeringar som påverkar själva pakethanteringen."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2303,7 +2312,7 @@ msgstr "zypper [--global-options] <kommando> [--command-options] [arguments]"
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <underkommando> [--command-options] [arguments]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Skriv ut hjälpen"
 
@@ -2457,7 +2466,8 @@ msgstr ""
 
 #: src/commands/installremove.cc:203
 msgid "Silently install unsigned rpm packages given as commandline parameters."
-msgstr "Installera osignerade rpm-paket i bakgrunden som kommandoradparametrar."
+msgstr ""
+"Installera osignerade rpm-paket i bakgrunden som kommandoradparametrar."
 
 #. translators: -f, --force
 #: src/commands/installremove.cc:208
@@ -2521,22 +2531,22 @@ msgstr ""
 "uppdateringsversioner."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [ALTERNATIV]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Lista tillgängliga patchar."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Lista alla tillgängliga programfixar."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Lista alla programfixar, inte bara de som är tillgängliga."
 
@@ -2591,35 +2601,39 @@ msgstr ""
 "tillgängliga språkversioner genom att anropa '%s'."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [ALTERNATIV] [SPRÅKVERSION] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Lista över begärda språkversioner (språkkoder)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Lista begärda språkversioner och motsvarande paket."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Visa motsvarande paket."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Lista alla tillgängliga språkversioner."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr "Ignorerar positionsargument efter mottagning av --all argument."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "Språkversion(er) för vilka informationen ska skrivas ut."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2627,15 +2641,15 @@ msgstr ""
 "Hämta alla språkversioner med språkkoden 'en' som har sin egen landskod, "
 "exklusive grundspråket 'en':"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr "Hämta alla språkversioner med språkkoden 'en' med eller utan landskod:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "Hämta språkversionen som exakt matchar argumentet: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "Hämta listan över paket som är tillgängliga för 'de' och 'en':"
 
@@ -2745,11 +2759,11 @@ msgstr[1] "Tog bort %lu lås."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Namn"
 
@@ -2759,8 +2773,8 @@ msgstr "Matchningar"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Typ"
@@ -2768,7 +2782,7 @@ msgstr "Typ"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Förråd"
@@ -3229,7 +3243,7 @@ msgid "Command"
 msgstr "Kommando"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Tjänst"
 
@@ -3399,38 +3413,39 @@ msgid "Show detailed information for products."
 msgstr "Visa detaljerad information om produkter."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "paket (pa) [alternativ] [arkiv] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Visa alla tillgängliga paket."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Lista alla paket som är tillgängliga i angivna arkiv."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr "Visa installerade paket som valdes automatiskt av upplösaren."
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr "Visa installerade paket som uttryckligen valts ut av användaren."
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
-msgstr "Visa installerade paket som inte tillhandahålls av någon lagringsplats."
+msgstr ""
+"Visa installerade paket som inte tillhandahålls av någon lagringsplats."
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
@@ -3439,84 +3454,84 @@ msgstr ""
 "uppdateringskandidat)."
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Visa paket som föreslås."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Visa paket som rekommenderas."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Visa paket som inte behövs."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Sortera listan efter paketnamn."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Sortera listan efter arkiv."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [arkiv] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Visa alla tillgängliga programfixar."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Visa alla tillgängliga programfixar i de angivna arkiven."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [alternativ] [arkiv] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Visa alla tillgängliga mönster."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Visa alla tillgängliga mönster i de angivna arkiven."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [alternativ] [arkiv] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Visa alla tillgängliga produkter."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Visa alla tillgängliga produkter i de angivna arkiven."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Endast XML-utdata: Vidarebefordra helt enkelt de XML-taggar som hittas i en "
 "produktfil."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "Alternativ %1% har ingen effekt utan det globala alternativet %2%."
@@ -3559,13 +3574,13 @@ msgstr ""
 "Den här arkivtypen detekteras alltid automatiskt. Det här alternativet "
 "ignoreras."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 "Det går inte att använda %s tillsammans med %s. Inställningen %s används."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3608,112 +3623,116 @@ msgstr "Rensa raw-metadata i cacheminnet."
 msgid "Clean both metadata and package caches."
 msgstr "Rensa både metadata och paket i cacheminnet."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Alias"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "uri"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Aktiverad"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "GPG-kontroll"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Prioritet"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Automatisk uppdatering"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "På"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Av"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Behåll paket"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI för GPG-nyckel"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Prefix för sökväg"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Överordnad tjänst"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Nyckelord"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Sökväg till arkivinfo"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Sökväg för MD-cache"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [ALTERNATIV] [REPO] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Visa en lista över alla definierade lagringsplatser."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 "Exportera alla definierade lagringsplatser som en enskild lokal .repo-fil."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Fel vid läsning av förråd:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Det gick inte att öppna %s för skrivning."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Du kanske inte har skrivbehörighet?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Förråden har exporterats till %s."
@@ -3721,20 +3740,20 @@ msgstr "Förråden har exporterats till %s."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Uppdatera"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "Behåll"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Inga arkiv definierade."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 "Använd kommandot zypper addrepo för att lägga till ett eller flera arkiv."
@@ -3842,7 +3861,7 @@ msgstr "Det globala alternativet %s har ingen effekt här."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Det går inte att använda argument om %s används."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Angivna förråd: "
 
@@ -3851,7 +3870,7 @@ msgstr "Angivna förråd: "
 msgid "Refreshing repository '%s'."
 msgstr "Uppdaterar förrådet '%s'."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Hoppar över inaktiverat arkiv '%s'."
@@ -3861,7 +3880,7 @@ msgstr "Hoppar över inaktiverat arkiv '%s'."
 msgid "Skipping disabled repository '%s'"
 msgstr "Hoppar över inaktiverat förråd '%s'"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Förrådet %s ignoreras på grund av felet ovan."
@@ -3888,7 +3907,7 @@ msgstr "Lägg till eller aktivera arkiv med hjälp av kommandona %s eller %s."
 msgid "Could not refresh the repositories because of errors."
 msgstr "Det gick inte att uppdatera förrådet på grund av fel."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Några av arkiven har inte uppdaterats på grund av ett fel."
 
@@ -3943,12 +3962,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Förrådet '%s' har bytt namn till '%s'."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "Förrådet '%s' finns redan. Använd ett annat alias."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Ett fel uppstod när förrådet skulle ändras:"
 
@@ -4400,7 +4419,8 @@ msgstr "Genomför skiftlägeskänslig sökning."
 #. translators: -s, --details
 #: src/commands/search/search.cc:201
 msgid "Show each available version in each repository on a separate line."
-msgstr "Visa varje tillgänglig version i varje lagringsplats på en separat rad."
+msgstr ""
+"Visa varje tillgänglig version i varje lagringsplats på en separat rad."
 
 #. translators: -v, --verbose
 #: src/commands/search/search.cc:205
@@ -4411,25 +4431,25 @@ msgstr ""
 "Som --details, med ytterligare information där sökningen har gett "
 "matchningar (användbart för sökning i beroenden)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Den angivna lagringsplatsen \"%s\" är inaktiverad."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Inga matchande objekt hittades."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Ett problem uppstod när sökfrågan initierades eller kördes"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Mer information finns i meddelandet ovan."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 "Problemet kan eventuellt lösas genom att köra \"zypper refresh\" som root."
@@ -4447,7 +4467,8 @@ msgstr "Välj korrigeringar med angiven allvarlighetsgrad."
 #. translators: --date <YYYY-MM-DD>
 #: src/commands/selectpatchoptionset.cc:32
 msgid "Select patches issued up to, but not including, the specified date"
-msgstr "Välj korrigeringar som utfärdas till, men inte inklusive, angivet datum"
+msgstr ""
+"Välj korrigeringar som utfärdas till, men inte inklusive, angivet datum"
 
 #. translators: -b, --bugzilla
 #: src/commands/selectpatchoptionset.cc:36
@@ -4525,7 +4546,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Det gick inte att hämta förrådsindexfilen för tjänsten '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Hoppar över tjänsten %s på grund av felet ovan."
@@ -4544,24 +4565,28 @@ msgstr "Tjänsten %s tas bort:"
 msgid "Service '%s' has been removed."
 msgstr "Tjänsten %s har tagits bort."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [ALTERNATIV]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Visa alla angivna tjänster."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Visa en lista över definierade tjänster."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Inga tjänster har definierats. Lägg till en eller flera tjänster med hjälp "
 "av kommandot %s."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4658,16 +4683,20 @@ msgstr "Tjänsten %s har fått namnet %s."
 msgid "Repository '%s' has been added to enabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been added to enabled repositories of service '%s'"
-msgstr[0] "Förrådet '%s' har lagts till de aktiverade förråden för tjänsten '%s'"
-msgstr[1] "Förråden '%s' har lagts till de aktiverade förråden för tjänsten '%s'"
+msgstr[0] ""
+"Förrådet '%s' har lagts till de aktiverade förråden för tjänsten '%s'"
+msgstr[1] ""
+"Förråden '%s' har lagts till de aktiverade förråden för tjänsten '%s'"
 
 #: src/commands/services/modify.cc:262
 #, c-format, boost-format
 msgid "Repository '%s' has been added to disabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been added to disabled repositories of service '%s'"
-msgstr[0] "Förrådet '%s' har lagts till de inaktiverade förråden för tjänsten '%s'"
-msgstr[1] "Förråden '%s' har lagts till de inaktiverade förråden för tjänsten '%s'"
+msgstr[0] ""
+"Förrådet '%s' har lagts till de inaktiverade förråden för tjänsten '%s'"
+msgstr[1] ""
+"Förråden '%s' har lagts till de inaktiverade förråden för tjänsten '%s'"
 
 #: src/commands/services/modify.cc:269
 #, c-format, boost-format
@@ -4878,7 +4907,8 @@ msgstr ""
 
 #: src/commands/solveroptionset.cc:93
 msgid "Whether to allow changing the vendor of installed resolvables."
-msgstr "Om det ska vara tillåtet att ändra leverantör av installerade resurser."
+msgstr ""
+"Om det ska vara tillåtet att ändra leverantör av installerade resurser."
 
 #. translators: -u, --clean-deps
 #: src/commands/solveroptionset.cc:117
@@ -5046,8 +5076,8 @@ msgid ""
 "Using zypper subcommands available from elsewhere on your $PATH is disabled "
 "in zypper.conf."
 msgstr ""
-"Att använda zypper-underkommandon tillgängliga från någon annanstans på din $"
-"SÖKVÄG är inaktiverat i zypper.conf."
+"Att använda zypper-underkommandon tillgängliga från någon annanstans på din "
+"$SÖKVÄG är inaktiverat i zypper.conf."
 
 #. translators: helptext; %1% is a zypper command
 #: src/commands/subcommand.cc:485
@@ -5319,8 +5349,8 @@ msgstr "Installerat paket"
 #: src/commands/utils/source-download.cc:368
 msgid "Use '--verbose' option for a full list of required source packages."
 msgstr ""
-"Du kan visa hela listan med de källpaket som behövs med alternativet "
-"\"--verbose\"."
+"Du kan visa hela listan med de källpaket som behövs med alternativet \"--"
+"verbose\"."
 
 #: src/commands/utils/source-download.cc:377
 msgid "Deleting superfluous source packages"
@@ -5359,7 +5389,8 @@ msgstr "Det finns inga källpaket att hämta."
 #: src/commands/utils/source-download.cc:481
 #: src/commands/utils/source-download.cc:483
 msgid "Download source rpms for all installed packages to a local directory."
-msgstr "Hämta käll-RPM-filer för alla installerade paket till en lokal katalog."
+msgstr ""
+"Hämta käll-RPM-filer för alla installerade paket till en lokal katalog."
 
 #. translators: -d, --directory <DIR>
 #: src/commands/utils/source-download.cc:495
@@ -5488,15 +5519,15 @@ msgstr "%s är äldre %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Version"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Ark"
 
@@ -5633,13 +5664,13 @@ msgstr "(tom)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Beroende"
 
@@ -5676,7 +5707,7 @@ msgid "Flavor"
 msgstr "Smak"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Är bas"
 
@@ -5940,75 +5971,75 @@ msgstr[1] "%1% lagringsplatser"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Kontrollerar om metadata för %s måste uppdateras"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Förrådet \"%s\" är uppdaterat."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Aktualitetskontrollen av %s har försenats."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Tvingar uppdatering av rå metadata"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Hämtar metadata för förrådet \"%s\""
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Vill du inaktivera lagringsplatsen %s permanent?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Fel när lagringsplatsen %s inaktiverades."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Det gick inte att hämta filer från %s."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Mer information visas i felmeddelandet ovan."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Ingen URI har definierats för %s."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
-"Lägg till en eller flera bas-URI-poster (basurl=URI) i %s för förrådet \"%s\""
-"."
+"Lägg till en eller flera bas-URI-poster (basurl=URI) i %s för förrådet "
+"\"%s\"."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Inget alias har definierats för förrådet."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Förrådet \"%s\" är ogiltigt."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -6016,22 +6047,22 @@ msgstr ""
 "Kontrollera att URI:er som har definierats för förrådet pekar på ett giltigt "
 "förråd."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Ett fel uppstod när metadata för %s hämtades:"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Tvingar uppbyggnad av cache för förråd"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Ett fel uppstod när metadata för %s tolkades:"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6043,44 +6074,44 @@ msgstr ""
 "du en felrapport genom att följa instruktionerna på http://en.opensuse.org/"
 "Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 "Det gick inte att hitta förrådsmetadata för %s i det lokala cacheminnet."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Det uppstod ett fel när cachen skapades:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Kunde inte hitta förrådet \"%s\" med hjälp av alias, nummer eller URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Hämta listan över de definierade arkiven med hjälp av %s."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Hoppar över inaktiverad lagringsplats \"%s\""
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 "Det globala alternativet %s 1 kan användas för att tillfälligt aktivera "
 "lagringsplatser."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Ignorerar förrådet \"%s\" på grund av alternativet \"%s\"."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Inaktiverar arkivet %s."
@@ -6088,16 +6119,16 @@ msgstr "Inaktiverar arkivet %s."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
-"Förrådet \"%s\" är inaktuellt. Du kan uppdatera det genom att köra "
-"\"zypper refresh\" som root."
+"Förrådet \"%s\" är inaktuellt. Du kan uppdatera det genom att köra \"zypper "
+"refresh\" som root."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6106,83 +6137,83 @@ msgstr ""
 "Cacheminnet för metadata måste skapas för förrådet \"%s\". Gör det genom att "
 "köra \"zypper refresh\" som root."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Arkivet %s är ogiltigt."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Målet initieras"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Det gick inte att initiera mål:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Rensa cacheminnet för metadata för %s."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Rensar cacheminnet för raw-metadata för %s."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Behåll cacheminnet för raw-metadata för %s '%s'."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Rensar paket för %s."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Kan inte rensa förrådet '%s' på grund av ett fel."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Rensar installerade paketcache."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 "Det gick inte att rensa cacheminnet för de installerade paketen på grund av "
 "ett fel."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Det gick inte att rensa arkiven på grund av fel."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Några av arkiven har inte rensats på grund av ett fel."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "De angivna arkiven har rensats."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Alla arkiv har rensats."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Det här är en ändringsbar, skrivskyddad skiva (CD/DVD). Inaktivera "
 "automatisk uppdatering."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Ogiltigt arkivalias: %s"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6190,25 +6221,25 @@ msgstr ""
 "Kunde inte avgöra förrådets typ. Vänligen kontrollera att den angivna URI:en "
 "(se nedan) pekar på ett giltigt förråd:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Kan inte hitta ett giltigt förråd på angiven plats:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Det gick inte att överföra förråddata från den angivna URI:n:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Kontrollera att den angivna URI:n går att nå."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Ett okänt problem uppstod när förrådet lades till:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6217,135 +6248,135 @@ msgstr ""
 "GPG-kontroll har inaktiverats i konfigurationen för lagringsplatsen %1%. "
 "Paketets integritet och ursprung kan inte verifieras."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Förrådet '%s' har lagts till"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Läser data från '%s'-media"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Ett fel uppstod när data skulle läsas in från \"%s\"-media"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "Kontrollera att installationsskivan är giltig och läsbar."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Läsning av data från %s medier senareläggs till nästa uppdatering."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Läser data från '%s'-media"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Ett fel uppstod när data skulle läsas in från \"%s\"-media"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "Kontrollera att installationsskivan är giltig och läsbar."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Det gick inte att nå filen på den angivna URI:n"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Kontrollera att URI:n är giltig och går att öppna."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Det gick inte att tolka filen på den angivna URI:n"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Är det en REPO-fil?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Det gick inte att läsa filen på den angivna URI:n"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Ett förråd utan alias hittades i filen. Det hoppas över."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Förrådet '%s' har ingen URI. Det hoppas över."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Förrådet '%s' har tagits bort."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Prioriteten för förrådet '%s' är oförändrad (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Arkivet %s har aktiverats."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Arkivet %s har inaktiverats."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Automatisk uppdatering har aktiverats för förrådet '%s'."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Den automatiska uppdateringen har inaktiverats för förrådet '%s'."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Cachelagring av RPM-filer har aktiverats för förrådet '%s'."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Cachelagring av RPM-filer har inaktiverats för förrådet '%s'."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "GPG-kontroll har aktiverats för lagringsplatsen \"%s\"."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "GPG-kontroll har inaktiverats för lagringsplatsen \"%s\"."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Prioriteten för förrådet '%s' har satts till %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Förrådet '%s' har fått namnet '%s'."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Det finns inget att ändra för förrådet '%s'."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Förrådet '%s' lämnas oförändrat."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Läser in förrådsdata..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6353,44 +6384,44 @@ msgstr ""
 "Inga arkiv definierade. Endast de installerade resurserna används. Inget kan "
 "installeras."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Hämtar data för förrådet '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Förrådet '%s' är inte cachat. Cachar..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Ett problem uppstod när data skulle läsas in från '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 "Det gick inte att uppdatera lagringsplatsen '%s'. Använder gammal cache."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Resurser från \"%s\" har inte lästs in eftersom ett fel uppstod."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "Förråd '%1%' metadata löpt ut sedan %2%."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Prova '%s', eller till och med '%s', innan du gör så här."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6402,30 +6433,30 @@ msgstr ""
 "Om detta inte löser problemet kan det bero på att du använder en trasig "
 "spegel eller så har servern faktiskt slutat att stödja förrådet."
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Läser installerade paket..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Ett problem uppstod vid läsning av de installerade paketen:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "%s ser ut som en RPM-fil. Ett försök att hämta den görs."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Det uppstod ett problem med RPM-filen %s. Den hoppas över."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Det går inte att läsa RPM-huvudet i %s. Är det en RPM-fil?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Enkel RPM-filcache"
 
@@ -6433,25 +6464,25 @@ msgstr "Enkel RPM-filcache"
 msgid "System Packages"
 msgstr "Systempaket"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Det gick inte att hitta några programfixar som behövs."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Inga mönster har hittats."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Det gick inte att hitta några paket."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Internt namn"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Inga produkter har hittats."
 
@@ -6656,7 +6687,8 @@ msgstr ""
 
 #: src/solve-commit.cc:795
 msgid "Root privileges are required to fix broken package dependencies."
-msgstr "Det behövs root-behörighet för att kunna åtgärda brutna paketberoenden."
+msgstr ""
+"Det behövs root-behörighet för att kunna åtgärda brutna paketberoenden."
 
 #. translators: These are the "Continue?" prompt options corresponding to
 #. "Yes / No / show Problems / Versions / Arch / Repository /
@@ -6853,7 +6885,7 @@ msgid "Updatestack"
 msgstr "Uppdateringsstack"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Programfixar"
 
@@ -6876,7 +6908,7 @@ msgstr "Inkluderade kategorier"
 msgid "Needed software management updates will be installed first:"
 msgstr "Följande programhanteringsuppdateringar installeras först:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Det gick inte att hitta några uppdateringar."
 
@@ -6885,51 +6917,51 @@ msgstr "Det gick inte att hitta några uppdateringar."
 msgid "The following updates are also available:"
 msgstr "Följande uppdateringar är också tillgängliga:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Paketuppdateringar"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Mönsteruppdateringar"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Produktuppdateringar"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Aktuell version"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Tillgänglig version"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Inga matchande utgåvor hittades."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Följande matchande utgåvenummer har hittats:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "I följande programfixar har matchande programfixbeskrivningar hittats:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "Programfix för bugzilla, utgåva nummer %s, hittades inte eller behövs inte."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "Programfix för CVE, utgåva nummer %s, hittades inte eller behövs inte."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/ta.po
+++ b/po/ta.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nis\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Tamil <https://l10n.opensuse.org/projects/zypper/master/ta/>\n"
@@ -1367,7 +1367,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "நிறுவப்படுவதற்கு தயாராகிறது..."
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "எதிர்பாராத விதிவிலக்கு."
 
@@ -1395,12 +1395,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2118,24 +2118,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2205,7 +2211,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2390,22 +2396,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2456,49 +2462,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2602,11 +2612,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "பெயர்"
 
@@ -2617,8 +2627,8 @@ msgstr "பாட்ச்"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "வகை"
@@ -2626,7 +2636,7 @@ msgstr "வகை"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr ""
@@ -3052,7 +3062,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "சேவகன்"
@@ -3216,120 +3226,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3368,12 +3378,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3415,118 +3425,122 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "செயல்படுத்தப்பட்டது"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 #, fuzzy
 msgid "GPG Check"
 msgstr "DNS சோதனை"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 #, fuzzy
 msgid "Autorefresh"
 msgstr "தானியங்கு புதுப்பித்தல்"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 #, fuzzy
 msgid "On"
 msgstr "இல்லை"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Keep Packages"
 msgstr "சிஸ்டம் ஏரியாவின் பொருட்கள்"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 #, fuzzy
 msgid "Path Prefix"
 msgstr "டயல் முன்னொட்டு"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "சேவகன்"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 #, fuzzy
 msgid "Error reading repositories:"
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "எழுதுவதற்கு கோப்பைத் திறக்க முடியவில்லை."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3534,21 +3548,21 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "புதுப்பிக்கவும்"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "தானியங்கு புதுப்பித்தல்"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3649,7 +3663,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 #, fuzzy
 msgid "Specified repositories: "
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
@@ -3659,7 +3673,7 @@ msgstr "மூலங்கள் சேர்க்கப்படுகின�
 msgid "Refreshing repository '%s'."
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
@@ -3669,7 +3683,7 @@ msgstr "மூலங்கள் சேர்க்கப்படுகின�
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3699,7 +3713,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "குறிப்பிட்ட உள்ளிடுதலை நீக்க முடியவில்லை."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 #, fuzzy
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "குறிப்பிட்ட உள்ளிடுதலை நீக்க முடியவில்லை."
@@ -3753,12 +3767,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 #, fuzzy
 msgid "Error while modifying the repository:"
 msgstr "கோரிக்கையை விளக்கும்போது பிழை."
@@ -4191,26 +4205,26 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "தானியங்கு புதுப்பித்தல்"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "ஒலி"
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4301,7 +4315,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, fuzzy, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "குறிப்பிட்ட உள்ளிடுதலை நீக்க முடியவில்லை."
@@ -4321,21 +4335,25 @@ msgstr "&இணைப்பை நீக்கவும்"
 msgid "Service '%s' has been removed."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5227,15 +5245,15 @@ msgstr "%s, %sக்கு தேவைப்படுகிறது"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "பதிப்பு"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Arch"
 
@@ -5373,13 +5391,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -5417,7 +5435,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5684,96 +5702,96 @@ msgstr[1] "உள்ளீடு காணப்படவில்லை."
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, fuzzy, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "நீங்கள் அமைப்பை இப்போது நிறுத்த விரும்புகிறீர்களா?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, fuzzy, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "%sலிருந்து பொருள் படிக்கப்படுகிறது"
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, fuzzy, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "கோரிக்கையை விளக்கும்போது பிழை."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 #, fuzzy
 msgid "No alias defined for this repository."
 msgstr "கோரிக்கையை விளக்கும்போது பிழை."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, fuzzy, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "%sலிருந்து பொருள் படிக்கப்படுகிறது"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 #, fuzzy
 msgid "Forcing building of repository cache"
 msgstr "மூல தரவுதளம் உருவாக்கப்படுகிறது"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, fuzzy, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "%sலிருந்து பொருள் படிக்கப்படுகிறது"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5781,42 +5799,42 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, fuzzy, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 #, fuzzy
 msgid "Error building the cache:"
 msgstr "சான்றிதழை விளக்கும்போது பிழை."
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, fuzzy, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "குறிப்பிட்ட உள்ளிடுதலை நீக்க முடியவில்லை."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
@@ -5824,308 +5842,308 @@ msgstr "மூலங்கள் சேர்க்கப்படுகின�
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "இலக்கு துவக்கப்படுகிறது"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 #, fuzzy
 msgid "Target initialization failed:"
 msgstr "துவக்குதல் தோல்வியுற்றது"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, fuzzy, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "%sலிருந்து பொருள் படிக்கப்படுகிறது"
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, fuzzy, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "%sலிருந்து பொருள் படிக்கப்படுகிறது"
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, fuzzy, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "%sலிருந்து பொருள் படிக்கப்படுகிறது"
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, fuzzy, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "%sலிருந்து பேக்கேஜ்கள் படிக்கப்படுகின்றன"
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, fuzzy, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "குறிப்பிட்ட உள்ளிடுதலை நீக்க முடியவில்லை."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 #, fuzzy
 msgid "Cleaning installed packages cache."
 msgstr "பேக்கேஜ்களின் நிறுவுதலை நீக்குவதற்கான ஆணை"
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 #, fuzzy
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "குறிப்பிட்ட உள்ளிடுதலை நீக்க முடியவில்லை."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 #, fuzzy
 msgid "Could not clean the repositories because of errors."
 msgstr "குறிப்பிட்ட உள்ளிடுதலை நீக்க முடியவில்லை."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 #, fuzzy
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "குறிப்பிட்ட உள்ளிடுதலை நீக்க முடியவில்லை."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 #, fuzzy
 msgid "Specified repositories have been cleaned up."
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 #, fuzzy
 msgid "All repositories have been cleaned up."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, fuzzy, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 #, fuzzy
 msgid "Please check whether the specified URI is accessible."
 msgstr "உரைக் கோப்பை அணுக முடியவில்லை"
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 #, fuzzy
 msgid "Unknown problem when adding repository:"
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, fuzzy, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "%sலிருந்து பொருள் படிக்கப்படுகிறது"
-
-#: src/repos.cc:1275
-#, fuzzy, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "%sலிருந்து பொருள் படிக்கப்படுகிறது"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, fuzzy, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "%sலிருந்து பொருள் படிக்கப்படுகிறது"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, fuzzy, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "%sலிருந்து பொருள் படிக்கப்படுகிறது"
+
+#: src/repos.cc:1273
+#, fuzzy, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "%sலிருந்து பொருள் படிக்கப்படுகிறது"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 #, fuzzy
 msgid "Problem accessing the file at the specified URI"
 msgstr "%sலிருந்து பொருள் படிக்கப்படுகிறது"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 #, fuzzy
 msgid "Please check if the URI is valid and accessible."
 msgstr "உரைக் கோப்பை அணுக முடியவில்லை"
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 #, fuzzy
 msgid "Problem parsing the file at the specified URI"
 msgstr "%sலிருந்து பொருள் படிக்கப்படுகிறது"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 #, fuzzy
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, fuzzy, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, fuzzy, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, fuzzy, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 #, fuzzy
 msgid "Loading repository data..."
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "மூலங்கள் சேர்க்கப்படுகின்றன"
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, fuzzy, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "%sலிருந்து பொருள் படிக்கப்படுகிறது"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "உள்ளீடு காணப்படவில்லை."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6133,32 +6151,32 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "பேக்கேஜ்களின் நிறுவுதலை நீக்குவதற்கான ஆணை"
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "பேக்கேஜ்களின் நிறுவுதலை நீக்குவதற்கான ஆணை"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6167,28 +6185,28 @@ msgstr ""
 msgid "System Packages"
 msgstr "சிஸ்டம் ஏரியாவின் பொருட்கள்"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 #, fuzzy
 msgid "No patterns found."
 msgstr "ஒலி"
 
-#: src/search.cc:450
+#: src/search.cc:453
 #, fuzzy
 msgid "No packages found."
 msgstr "ஒலி"
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "உள் பிழை"
 
-#: src/search.cc:544
+#: src/search.cc:549
 #, fuzzy
 msgid "No products found."
 msgstr "ஒலி"
@@ -6577,7 +6595,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 #, fuzzy
 msgid "Patches"
 msgstr "பாட்ச்"
@@ -6602,7 +6620,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "பின்வரும் விபிஎன்சி விபிஎன் இணைப்பு உருவாக்கப்படும்"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 #, fuzzy
 msgid "No updates found."
 msgstr "ஒலி"
@@ -6613,56 +6631,56 @@ msgstr "ஒலி"
 msgid "The following updates are also available:"
 msgstr "பின்வரும் மூலங்கள் திருத்தியமைக்கப்பட்டுள்ளன"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 #, fuzzy
 msgid "Pattern updates"
 msgstr "பேட்டரி நிலை"
 
-#: src/update.cc:706
+#: src/update.cc:713
 #, fuzzy
 msgid "Product updates"
 msgstr "பொருளில் மாற்றம்"
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "நடப்பு இணைப்பு"
 
-#: src/update.cc:795
+#: src/update.cc:801
 #, fuzzy
 msgid "Available Version"
 msgstr "காலியாக உள்ள இடம்"
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "ஒலி"
 
-#: src/update.cc:978
+#: src/update.cc:986
 #, fuzzy
 msgid "The following matches in issue numbers have been found:"
 msgstr "பின்வரும் விபிஎன்சி விபிஎன் இணைப்பு உருவாக்கப்படும்"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Thai <https://l10n.opensuse.org/projects/zypper/master/th/>\n"
@@ -273,8 +273,7 @@ msgstr ""
 
 #: src/Config.cc:491
 msgid "Repositories disabled, using the database of installed packages only."
-msgstr ""
-"คลังแพกเกจถูกปิดการใช้งาน จะใช้ฐานข้อมูลของแพกเกจที่ถูกติดตั้งไว้แล้วเท่านั้น"
+msgstr "คลังแพกเกจถูกปิดการใช้งาน จะใช้ฐานข้อมูลของแพกเกจที่ถูกติดตั้งไว้แล้วเท่านั้น"
 
 #. translators: --disable-repositories
 #: src/Config.cc:495
@@ -1286,7 +1285,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "ลองอีกครั้งหรือไม่ ?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "เกิดข้อผิดพลาดยกเว้นที่ไม่ได้คาดไว้ "
 
@@ -1314,12 +1313,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "ตัวเลือก %s ไม่มีผลอะไรที่นี่ ไม่สนใจมัน"
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "อาร์กิวเมนต์ของโปรแกรมที่ไม่มีตัวเลือกใด: "
 
@@ -1449,8 +1448,7 @@ msgstr "ทำการยอมรับแฟ้ม '%s' ซึ่งถูก
 #, c-format, boost-format
 msgid ""
 "Accepting file '%s' from repository '%s' signed with an unknown key '%s'."
-msgstr ""
-"ทำการยอมรับแฟ้ม '%s' จากคลังแพกเกจ '%s' ซึ่งถูกเซ็นด้วยกุญแจที่ไม่รู้จัก '%s'"
+msgstr "ทำการยอมรับแฟ้ม '%s' จากคลังแพกเกจ '%s' ซึ่งถูกเซ็นด้วยกุญแจที่ไม่รู้จัก '%s'"
 
 #. translator: %1% is a file name, %2% is a gpg key ID
 #: src/callbacks/keyring.h:214
@@ -1535,13 +1533,11 @@ msgstr "ไม่สนใจต่อความล้มเหลวในก
 #, c-format, boost-format
 msgid ""
 "Ignoring failed signature verification for file '%s' from repository '%s'!"
-msgstr ""
-"ไม่สนใจต่อความล้มเหลวในการตรวจสอบลายเซ็นของแฟ้ม '%s' จากคลังแพกเกจ '%s' !"
+msgstr "ไม่สนใจต่อความล้มเหลวในการตรวจสอบลายเซ็นของแฟ้ม '%s' จากคลังแพกเกจ '%s' !"
 
 #: src/callbacks/keyring.h:376
 msgid "Double-check this is not caused by some malicious changes in the file!"
-msgstr ""
-"การดับเบิลคลิกที่นี่ไม่ได้เป็นผลให้มีความเปลี่ยนในส่วนประสงค์ร้ายของแฟ้ม !"
+msgstr "การดับเบิลคลิกที่นี่ไม่ได้เป็นผลให้มีความเปลี่ยนในส่วนประสงค์ร้ายของแฟ้ม !"
 
 #. translator: %1% is a file name
 #: src/callbacks/keyring.h:386
@@ -1553,8 +1549,7 @@ msgstr "ไม่สนใจต่อความล้มเหลวในก
 #: src/callbacks/keyring.h:389
 #, boost-format
 msgid "Signature verification failed for file '%1%' from repository '%2%'."
-msgstr ""
-"ไม่สนใจต่อความล้มเหลวในการตรวจสอบลายเซ็นของแฟ้ม '%1%' จากคลังแพกเกจ '%2%'"
+msgstr "ไม่สนใจต่อความล้มเหลวในการตรวจสอบลายเซ็นของแฟ้ม '%1%' จากคลังแพกเกจ '%2%'"
 
 #: src/callbacks/keyring.h:438
 msgid ""
@@ -1783,8 +1778,7 @@ msgstr ""
 msgid ""
 "Please insert medium [%s] #%d and type 'y' to continue or 'n' to cancel the "
 "operation."
-msgstr ""
-"โปรดใส่สื่อ [%s] #%d และพิมพ์ 'y' เพื่อทำต่อ หรือพิมพ์ 'n' เพื่อยกเลิกปฏิบัติการ"
+msgstr "โปรดใส่สื่อ [%s] #%d และพิมพ์ 'y' เพื่อทำต่อ หรือพิมพ์ 'n' เพื่อยกเลิกปฏิบัติการ"
 
 #. translators: a/r/i/u are replies to the "Abort, retry, ignore?" prompt
 #. Translate the a/r/i part exactly as you did the a/r/i string.
@@ -2023,24 +2017,30 @@ msgid "Commands:"
 msgstr "คำสั่ง:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2110,7 +2110,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "พิมพ์ความช่วยเหลือ"
 
@@ -2295,22 +2295,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2361,49 +2361,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2503,11 +2507,11 @@ msgstr[0] "เอาออกทั้งหมด"
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "ชื่อ"
 
@@ -2518,8 +2522,8 @@ msgstr "แพตช์"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "ประเภท"
@@ -2527,7 +2531,7 @@ msgstr "ประเภท"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "คลังแพกเกจ"
@@ -2951,7 +2955,7 @@ msgid "Command"
 msgstr "คำสั่ง:"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "บริการ"
 
@@ -3112,120 +3116,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "เรียกดูแพกเกจที่มีให้เลือกทั้งหมด"
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "เรียกดูแพตช์ที่มีให้เลือกทั้งหมด"
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "เรียกดูชุดรูปแบบที่มีให้เลือกทั้งหมด"
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "เรียกดูผลิตภัณฑ์ที่มีให้เลือกทั้งหมด"
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3265,16 +3269,15 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "ไม่สามารถใช้ %s ร่วมกับ %s ได้ ใช้การตั้งค่า %s"
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
-msgstr ""
-"หากใช้อาร์กิวเมนต์เพียงตัวเดียว มันจะต้องเป็นค่าที่อยู่ URI ที่ชี้ไปยังแฟ้ม .repo"
+msgstr "หากใช้อาร์กิวเมนต์เพียงตัวเดียว มันจะต้องเป็นค่าที่อยู่ URI ที่ชี้ไปยังแฟ้ม .repo"
 
 #: src/commands/repos/add.cc:130
 msgid "Specified type is not a valid repository type:"
@@ -3313,117 +3316,121 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "ชื่อเรียกอื่น"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "ที่อยู่ URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "เปิดใช้งาน"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 #, fuzzy
 msgid "GPG Check"
 msgstr "ตรวจสอบ"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "ความสำคัญ"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "เรียกปรับปรุงใหม่อัตโนมัติ"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "เปิด"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "ปิด"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Keep Packages"
 msgstr "แพกเกจ"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 #, fuzzy
 msgid "GPG Key URI"
 msgstr "ค่าประจำตัวกุญแจ GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 #, fuzzy
 msgid "Path Prefix"
 msgstr "เลขนำหน้าการหมุน"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "เครื่องให้บริการการพิมพ์"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 #, fuzzy
 msgid "MD Cache Path"
 msgstr "พาธของอุปกรณ์"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "เรียกดูคลังแพกเกจที่ถูกกำหนดไว้ทั้งหมด"
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "เกิดข้อผิดพลาดในการอ่านคลังแพกเกจ:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "ไม่สามารถเปิด %s เพื่อทำการเขียนได้"
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "เป็นไปได้หรือไม่ว่า คุณยังไม่ได้รับสิทธิ์อนุญาตในการเขียน ?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "ส่งออกคลังแพกเกจไปยัง %s เรียบร้อยแล้ว"
@@ -3431,21 +3438,21 @@ msgstr "ส่งออกคลังแพกเกจไปยัง %s เ�
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "เรียกปรับปรุงใหม่"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "คลังแพกเกจระยะไกล ถูกปิดการใช้งาน"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 #, fuzzy
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr "ยังไม่มีการกำหนดคลังแพกเกจ สั่งคำสั่ง 'zypper addrepo' เพื่อเพิ่มคลังแพกเกจ"
@@ -3547,7 +3554,7 @@ msgstr "ตัวเลือกทั่วไป '%s' ไม่มีผลท
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "หากมีการใช้ '%s' จะไม่อนุญาตให้มีอาร์กิวเมนต์"
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "คลังแพกเกจที่ระบุ: "
 
@@ -3556,7 +3563,7 @@ msgstr "คลังแพกเกจที่ระบุ: "
 msgid "Refreshing repository '%s'."
 msgstr "ทำการปิดการใช้งานคลังแพกเกจ '%s'"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "ทำการข้ามคลังแพกเกจ '%s' ซึ่งถูกปิดการใช้งาน"
@@ -3566,7 +3573,7 @@ msgstr "ทำการข้ามคลังแพกเกจ '%s' ซึ่
 msgid "Skipping disabled repository '%s'"
 msgstr "ทำการข้ามคลังแพกเกจ '%s' ซึ่งถูกปิดการใช้งาน"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "ทำการข้ามคลังแพกเกจ '%s' เนื่องจากข้อผิดพลาดทางด้านบน"
@@ -3594,7 +3601,7 @@ msgstr "ใช้คำสั่ง '%s' หรือ '%s' เพื่อเพ
 msgid "Could not refresh the repositories because of errors."
 msgstr "ไม่สามารถเรียกปรับปรุงคลังแพกเกจได้ เนื่องจากเกิดข้อผิดพลาดขึ้น"
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "คลังแพกเกจบางตัวยังไม่ถูกเรียกปรับปรุงใหม่ เนื่องจากเกิดข้อผิดพลาดขึ้น"
 
@@ -3649,12 +3656,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "คลังแพกเกจ '%s' ถูกเปลี่ยนชื่อเป็น '%s'"
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "มีคลังแพกเกจที่ชื่อ '%s' อยู่แล้ว โปรดเปลี่ยนไปใช้ชื่ออื่น"
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "เกิดข้อผิดพลาดระหว่างทำการแก้ไขคลังแพกเกจ:"
 
@@ -3679,8 +3686,7 @@ msgstr ""
 
 #: src/commands/repos/rename.cc:92
 msgid "Too few arguments. At least URI and alias are required."
-msgstr ""
-"มีอาร์กิวเมนต์น้อยเกินไป อย่างน้อยจะต้องกำหนดค่าที่อยู่ URI หรือชื่ออื่นมาให้"
+msgstr "มีอาร์กิวเมนต์น้อยเกินไป อย่างน้อยจะต้องกำหนดค่าที่อยู่ URI หรือชื่ออื่นมาให้"
 
 #: src/commands/repos/rename.cc:114
 #, c-format, boost-format
@@ -4092,26 +4098,26 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "คลังแพกเกจระยะไกล ถูกปิดการใช้งาน"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "ไม่พบแพตช์ที่เข้าคู่กับ '%s'"
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "เกิดปัญหาขึ้นในการเตรียมการหรือการประมวลผลการค้นข้อมูล"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "ดูข้อความด้านบนเพื่อช่วยแก้ปัญหา"
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "เรียกคำสั่ง 'zypper refresh' ด้วยสิทธิ์ผู้ใช้ root อาจจะแก้ปัญหานี้ได้"
 
@@ -4201,7 +4207,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "เกิดปัญหาในการรับแฟ้มดัชนีบนคลังแพกเกจสำหรับบริการ '%s':"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "ทำการข้ามบริการ '%s' มีจากข้อผิดพลาดทางด้านบน"
@@ -4220,22 +4226,26 @@ msgstr "เอาบริการ '%s' ออกไป:"
 msgid "Service '%s' has been removed."
 msgstr "เอาบริการ '%s' ออกไปแล้ว"
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "ดูบริการที่ถูกกำหนดไว้แล้วทั้งหมด"
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr "ยังไม่มีการกำหนดบริการ ใช้คำสั่ง '%s' เพื่อเพิ่มบริการ"
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4333,16 +4343,14 @@ msgstr "ชื่อของบริการ '%s' ถูกเปลี่ย
 msgid "Repository '%s' has been added to enabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been added to enabled repositories of service '%s'"
-msgstr[0] ""
-"คลังแพกเกจ '%s' ได้ถูกเพิ่มไปยังคลังแพกเกจที่เปิดใช้งานของบริการ '%s' แล้ว"
+msgstr[0] "คลังแพกเกจ '%s' ได้ถูกเพิ่มไปยังคลังแพกเกจที่เปิดใช้งานของบริการ '%s' แล้ว"
 
 #: src/commands/services/modify.cc:262
 #, c-format, boost-format
 msgid "Repository '%s' has been added to disabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been added to disabled repositories of service '%s'"
-msgstr[0] ""
-"คลังแพกเกจ '%s' ได้ถูกเพิ่มไปยังคลังแพกเกจที่ปิดการใช้งานของบริการ '%s' แล้ว"
+msgstr[0] "คลังแพกเกจ '%s' ได้ถูกเพิ่มไปยังคลังแพกเกจที่ปิดการใช้งานของบริการ '%s' แล้ว"
 
 #: src/commands/services/modify.cc:269
 #, c-format, boost-format
@@ -4360,8 +4368,7 @@ msgid ""
 msgid_plural ""
 "Repositories '%s' have been removed from disabled repositories of service "
 "'%s'"
-msgstr[0] ""
-"คลังแพกเกจ '%s' ได้ถูกเอาออกไปจากคลังแพกเกจที่ปิดการใช้งานของบริการ '%s' แล้ว"
+msgstr[0] "คลังแพกเกจ '%s' ได้ถูกเอาออกไปจากคลังแพกเกจที่ปิดการใช้งานของบริการ '%s' แล้ว"
 
 #: src/commands/services/modify.cc:285
 #, c-format, boost-format
@@ -4431,8 +4438,7 @@ msgstr "ไม่สามารถเรียกปรับปรุงบร
 
 #: src/commands/services/refresh.cc:251
 msgid "Some of the services have not been refreshed because of an error."
-msgstr ""
-"มีบางบริการที่ยังไม่ถูกเรียกปรับปรุงใหม่อีกครั้ง เนื่องจากเกิดข้อผิดพลาดขึ้น"
+msgstr "มีบางบริการที่ยังไม่ถูกเรียกปรับปรุงใหม่อีกครั้ง เนื่องจากเกิดข้อผิดพลาดขึ้น"
 
 #: src/commands/services/refresh.cc:255
 msgid "Specified services have been refreshed."
@@ -5121,15 +5127,15 @@ msgstr "%s เก่ากว่า %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "รุ่น"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "สถาปัตยกรรม"
 
@@ -5265,13 +5271,13 @@ msgstr "(ว่าง)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "สถานะ"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "ความเกี่ยวพันกัน"
 
@@ -5309,7 +5315,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5434,8 +5440,7 @@ msgstr "ทำการยอมรับข้อตกลงในสัญญ
 msgid ""
 "In order to install '%s'%s, you must agree to terms of the following license "
 "agreement:"
-msgstr ""
-"ในการติดตั้ง '%s'%s นั้น คุณจะต้องยอมรับข้อตกลงในสัญญาอนุญาตสิทธิ์ต่อไปนี้ก่อน:"
+msgstr "ในการติดตั้ง '%s'%s นั้น คุณจะต้องยอมรับข้อตกลงในสัญญาอนุญาตสิทธิ์ต่อไปนี้ก่อน:"
 
 #. lincense prompt
 #: src/misc.cc:187
@@ -5460,8 +5465,7 @@ msgstr ""
 #: src/misc.cc:209
 #, c-format, boost-format
 msgid "Aborting installation due to user disagreement with %s %s license."
-msgstr ""
-"ยุติการติดตั้ง เนื่องจากผู้ใช้ไม่ยอมรับข้อตกลงในสัญญาอนุญาตสิทธิ์ของ %s %s"
+msgstr "ยุติการติดตั้ง เนื่องจากผู้ใช้ไม่ยอมรับข้อตกลงในสัญญาอนุญาตสิทธิ์ของ %s %s"
 
 #: src/misc.cc:248
 msgid "License"
@@ -5574,57 +5578,57 @@ msgstr[0] "คลังแพกเกจ"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "ทำการตรวจสอบเพื่อปรับปรุงข้อมูลกำกับของ %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "คลังแพกเกจ '%s' ถูกปรับปรุงล่าสุดแล้ว"
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "การตรวจสอบการปรับปรุงของ '%s' ถูกหน่วงเอาไว้"
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "บังคับให้ปรับปรุงข้อมูลกำกับดิบ"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "กำลังรับข้อมูลกำกับของคลังแพกเกจ '%s'"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "เตรียมการใช้งานตัวจัดการคลังแพกเกจ"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "ทำการปิดการใช้งานคลังแพกเกจ '%s'"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "เกิดปัญหาในการรับแฟ้มจาก '%s'"
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "โปรดดูข้อความผิดพลาดด้านบนเพื่อช่วยในการแก้ปัญหา"
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "ยังไม่มีการกำหนดที่อยู่ URI ของ '%s'"
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -5633,38 +5637,38 @@ msgstr ""
 "โปรดเพิ่มรายการฐานของที่อยู่ URI (baseurl=URI) หนึ่งตัวหรือมากกว่า ไปยัง %s ของคลังแพกเกจ "
 "'%s'"
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "ยังไม่มีการกำหนดชื่อเรียกอื่น ๆ ของคลังแพกเกจนี้"
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "คลังแพกเกจ '%s' ใช้งานไม่ได้"
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 "โปรดตรวจสอบว่าได้กำหนดที่อยู่ URI ของคลังแพกเกจนี้ว่าชี้ไปยังคลังแพกเกจที่ใช้งานได้แล้วหรือยัง"
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "เกิดข้อผิดพลาดในการรับข้อมูลกำกับของ '%s':"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "บังคับให้ทำการสร้างแคชของคลังแพกเกจ"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "เกิดข้อผิดพลาดในการกระจายข้อมูลกำกับของ '%s':"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5675,42 +5679,41 @@ msgstr ""
 "หากเป็นกรณีหลังหรือไม่แน่ใจ โปรดทำการรายงานบั๊กตามวิธีการที่บอกไว้ที่ http://"
 "en.opensuse.org/Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "ไม่พบข้อมูลกำกับของคลังแพกเกจ '%s' ในแคชภายในระบบ"
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "เกิดข้อผิดพลาดในการสร้างแคช:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
-msgstr ""
-"ไม่พบคลังแพกเกจ '%s' ทั้งในส่วนชื่อเรียกอื่น, หมายเลข หรือที่อยู่ URI ของมัน"
+msgstr "ไม่พบคลังแพกเกจ '%s' ทั้งในส่วนชื่อเรียกอื่น, หมายเลข หรือที่อยู่ URI ของมัน"
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "ใช้ '%s' เพื่อเรียกดูคลังแพกเกจที่ได้กำหนดไว้แล้ว"
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "ทำการข้ามคลังแพกเกจ '%s' ซึ่งถูกปิดการใช้งาน"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, fuzzy, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr "ใช้คำสั่ง '%s' หรือ '%s' เพื่อเพิ่มหรือเปิดการใช้งานคลังแพกเกจ"
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "ไม่ใช้คลังแพกเกจ '%s' เนื่องจากตัวเลือก '%s'"
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "ทำการปิดการใช้งานคลังแพกเกจ '%s'"
@@ -5718,7 +5721,7 @@ msgstr "ทำการปิดการใช้งานคลังแพก
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -5727,7 +5730,7 @@ msgstr ""
 "คลังแพกเกจ '%s' ล้าสมัยแล้ว คุณสามารถเรียกคำสั่ง 'zypper refresh' ด้วยสิทธิ์ผู้ใช้ root "
 "เพื่อปรับปรุงมันได้"
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -5736,81 +5739,80 @@ msgstr ""
 "ต้องการใช้แคชข้อมูลกำกับเพื่อใช้ในการสร้างคลังแพกเกจ '%s' คุณสามารถสั่งคำสั่ง 'zypper "
 "refresh' ด้วยสิทธิ์ผู้ใช้ root เพื่อสร้างมันได้"
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "คลังแพกเกจ '%s' ใช้งานไม่ได้"
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "ทำการเตรียมเป้าหมาย"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "ล้มเหลวในการเตรียมเป้าหมาย:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "ทำการล้างแคชข้อมูลกำกับของ '%s'"
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "ทำการล้างแคชข้อมูลกำกับดิบของ '%s'"
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, fuzzy, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "ทำการล้างแคชข้อมูลกำกับดิบของ '%s'"
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "ทำการล้างแพกเกจของ '%s'"
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "ไม่สามารถล้างคลังแพกเกจ '%s' ได้ เนื่องจากเกิดข้อผิดพลาดขึ้น"
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "ทำการล้างแคชของแพกเกจที่ถูกติดตั้งแล้ว"
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
-msgstr ""
-"ไม่สามารถล้างแคชของแพกเกจที่ถูกติดตั้งแล้วได้ เนื่องจากเกิดข้อผิดพลาดขึ้น"
+msgstr "ไม่สามารถล้างแคชของแพกเกจที่ถูกติดตั้งแล้วได้ เนื่องจากเกิดข้อผิดพลาดขึ้น"
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "ไม่สามารถล้างคลังแพกเกจได้ เนื่องจากเกิดข้อผิดพลาดขึ้น"
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "มีบางคลังแพกเกจที่ยังไม่ถูกล้าง เนื่องจากเกิดข้อผิดพลาดขึ้น"
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "ล้างคลังแพกเกจที่ระบุไว้แล้ว"
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "ล้างคลังแพกเกจทั้งหมดแล้ว"
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "นี่เป็นสื่ออ่านได้อย่างเดียว (แผ่นซีดี/ดีวีดี) ที่ทำการเปลี่ยนได้เท่านั้น ทำการปิดการเรียกปรับปรุงใหม่"
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, fuzzy, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "ชื่อของคลังแพกเกจใช้งานไม่ได้"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -5818,161 +5820,160 @@ msgstr ""
 "ไม่สามารถตรวจหาชนิดของคลังแพกเกจได้ โปรดตรวจสอบว่าได้กำหนดที่อยู่ URIL (ดูด้านล่าง) "
 "ที่ชี้ไปยังคลังแพกเกจที่ใช้ได้แล้วหรือยัง:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "ไม่พบคลังแพกเกจที่ใช้งานได้ในตำแหน่งที่ให้มา:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "เกิดปัญหาในการถ่ายโอนข้อมูลของคลังแพกเกจจากที่อยู่ URI ที่ระบุ:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "โปรดตรวจสอบว่า ที่อยู่ URI ที่ระบุไว้ สามารถเข้าใช้งานได้จริงหรือไม่"
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "เกิดปัญหาที่ไม่ทราบขึ้นเมื่อทำการเพิ่มคลังแพกเกจ:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "เพิ่มคลังแพกเกจ '%s' เรียบร้อยแล้ว"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "ทำการอ่านข้อมูลจากสื่อการติดตั้ง '%s'"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "เกิดปัญหาในการอ่านข้อมูลจากสื่อการติดตั้ง '%s'"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "โปรดตรวจสอบว่าสื่อการติดตั้งของคุณยังใช้ได้และยังสามารถอ่านได้หรือไม่"
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, fuzzy, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "ทำการอ่านข้อมูลจากสื่อการติดตั้ง '%s'"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "ทำการอ่านข้อมูลจากสื่อการติดตั้ง '%s'"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "เกิดปัญหาในการอ่านข้อมูลจากสื่อการติดตั้ง '%s'"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "โปรดตรวจสอบว่าสื่อการติดตั้งของคุณยังใช้ได้และยังสามารถอ่านได้หรือไม่"
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "เกิดปัญหาในการเข้าถึงแฟ้มตามที่อยู่ URI ที่ระบุไว้"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "โปรดตรวจสอบว่า ที่อยู่ URI ที่ระบุไว้ สามารถเข้าใช้งานได้จริงหรือไม่"
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "เกิดปัญหาในการกระจายแฟ้มตามที่อยู่ URI ที่ระบุไว้"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "แน่ใจหรือว่ามันเป็นแฟ้มแบบ .repo ?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "เกิดปัญหาขึ้นระหว่างพยายามอ่านแฟ้มในที่อยู่ URI ที่ระบุไว้"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "มีคลังแพกเกจซึ่งยังไม่มีการกำหนดชื่อเรียกอื่นอยู่ในแฟ้ม, ทำการข้ามมัน"
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "ยังไม่มีการกำหนดที่อยู่ URI ให้กับคลังแพกเกจ '%s', ทำการข้ามมัน"
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "คลังแพกเกจ '%s' ถูกเอาออกไปแล้ว"
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
-msgstr ""
-"ระดับความสำคัญของคลังแพกเกจ '%s' ยังเหมือนเดิม (%d) โดยไม่มีการเปลี่ยนแปลง"
+msgstr "ระดับความสำคัญของคลังแพกเกจ '%s' ยังเหมือนเดิม (%d) โดยไม่มีการเปลี่ยนแปลง"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "คลังแพกเกจ '%s' ถูกเปิดใช้งานแล้ว"
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "คลังแพกเกจ '%s' ถูกปิดการใช้งานแล้ว"
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "การเรียกปรับปรุงใหม่อัตโนมัติถูกเปิดใช้งานกับคลังแพกเกจ '%s' แล้ว"
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "การเรียกปรับปรุงใหม่อัตโนมัติถูกปิดการใช้งานกับคลังแพกเกจ '%s' แล้ว"
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "การทำแคชของแฟ้ม RPM ถูกเปิดใช้งานกับคลังแพกเกจ '%s' แล้ว"
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "การทำแคชของแฟ้ม RPM ถูกปิดการใช้งานกับคลังแพกเกจ '%s' แล้ว"
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "การทำแคชของแฟ้ม RPM ถูกเปิดใช้งานกับคลังแพกเกจ '%s' แล้ว"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "การทำแคชของแฟ้ม RPM ถูกปิดการใช้งานกับคลังแพกเกจ '%s' แล้ว"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "ระดับความสำคัญของคลังแพกเกจ '%s' ถูกเปลี่ยนเป็นระดับ %d แล้ว"
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "ตั้งค่าชื่อของคลังแพกเกจ '%s' ไปเป็น '%s' แล้ว"
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "ไม่มีการเปลี่ยนแปลงใด ๆ กับคลังแพกเกจ '%s'"
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "ออกจากคลังแพกเกจ %s โดยไม่เปลี่ยนแปลงใด ๆ"
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "ทำการโหลดข้อมูลของคลังแพกเกจ..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 #, fuzzy
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
@@ -5981,43 +5982,43 @@ msgstr ""
 "แจ้งเตือน: ยังไม่มีการกำหนดคลังแพกเกจ "
 "จะทำปฏิบัติการกับส่วนที่ตรวจค้นได้จากตัวที่ติดตั้งไว้แล้วเท่าน้น และจะไม่สามารถติดตั้งอะไรเพิ่มได้"
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "ทำการรับข้อมูลของคลังแพกเกจ '%s'..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "คลังแพกเกจ '%s' ยังไม่ถูกทำแคช ทำแคชให้มัน..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "เกิดปัญหาในการโหลดข้อมูลจาก '%s'"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "ไม่พบข้อมูลกำกับของคลังแพกเกจ '%s' ในแคชภายในระบบ"
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "ไม่สามารถโหลดส่วนแก้ปัญหาจาก '%s' ได้ เนื่องจากมีข้อผิดพลาดเกิดขึ้น"
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "ลองใช้ '%s', หรือ '%s' ก่อนจะทำเช่นนั้น"
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6025,31 +6026,31 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "อ่านข้อมูลแพกเกจที่ติดตั้งไว้แล้ว..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "เกิดข้อผิดพลาดขึ้นระหว่างทำการอ่านแพกเกจที่ติดตั้งไว้แล้ว:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' ดูคล้ายแฟ้มแบบ RPM จะลองทำการดาวน์โหลดมันดู"
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "เกิดปัญหากับแฟ้ม RPM ที่ระบุไว้เป็น '%s', ทำการข้าม"
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "เกิดปัญหาในการอ่านส่วนหัว RPM ของ %s, แน่ใจหรือว่ามันเป็นแฟ้มแบบ RPM ?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "ทำแคชแฟ้ม RPM แบบธรรมดา"
 
@@ -6057,26 +6058,26 @@ msgstr "ทำแคชแฟ้ม RPM แบบธรรมดา"
 msgid "System Packages"
 msgstr "แพกเกจระบบ"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "ไม่พบแพตช์ที่จำเป็นต้องใช้ใด ๆ"
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "ไม่พบชุดรูปแบบใด ๆ"
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "ไม่พบแพกเกจใด ๆ"
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "ชื่อส่วนเชื่อมต่อ"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "ไม่พบผลิตภัณฑ์ใด ๆ"
 
@@ -6270,8 +6271,7 @@ msgstr ""
 
 #: src/solve-commit.cc:795
 msgid "Root privileges are required to fix broken package dependencies."
-msgstr ""
-"ต้องสิทธิ์ของผู้ใช้ Root เพื่อแก้ปัญหาความเกี่ยวพันกันที่ขัดแย้งกันของแพกเกจ"
+msgstr "ต้องสิทธิ์ของผู้ใช้ Root เพื่อแก้ปัญหาความเกี่ยวพันกันที่ขัดแย้งกันของแพกเกจ"
 
 #. translators: These are the "Continue?" prompt options corresponding to
 #. "Yes / No / show Problems / Versions / Arch / Repository /
@@ -6305,8 +6305,7 @@ msgstr "ยกเลิกปฏิบัติการ"
 msgid ""
 "Restart solver in no-force-resolution mode in order to show dependency "
 "problems."
-msgstr ""
-"เรียกตัวแก้ปัญหาในโหมด ไม่บังคับให้แก้ปัญหา เพื่อดูปัญหาความเกี่ยวพันกัน"
+msgstr "เรียกตัวแก้ปัญหาในโหมด ไม่บังคับให้แก้ปัญหา เพื่อดูปัญหาความเกี่ยวพันกัน"
 
 #. translators: help text for 'v' option in the 'Continue?' prompt
 #: src/solve-commit.cc:828
@@ -6372,8 +6371,8 @@ msgid ""
 "- use another installation medium (if e.g. damaged)\n"
 "- use another repository"
 msgstr ""
-"ล้มเหลวในการตรวจสอบความถูกต้องของแพกเกจ ซึ่งอาจเป็นปัญหามาจากคลังแพกเกจหรือจากสื่อที่ใช้ติดตั้"
-"ง โปรดลองแก้ปัญหาแบบใดแบบหนึ่งต่อไปนี้:\n"
+"ล้มเหลวในการตรวจสอบความถูกต้องของแพกเกจ "
+"ซึ่งอาจเป็นปัญหามาจากคลังแพกเกจหรือจากสื่อที่ใช้ติดตั้ง โปรดลองแก้ปัญหาแบบใดแบบหนึ่งต่อไปนี้:\n"
 "\n"
 "- เรียกคำสั่งที่ใช้ไปก่อนหน้านี้อีกครั้ง\n"
 "- เรียกปรับปรุงคลังแพกเกจอีกครั้ง ด้วยคำสั่ง 'zypper refresh'\n"
@@ -6459,7 +6458,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "แพตช์"
 
@@ -6483,7 +6482,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "ถ้าคุณเลือกที่จะทำต่อไป แพกเกจของซอฟต์แวร์ต่อไปนี้จะถูกติดตั้ง:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "ไม่พบรายการปรับรุ่นใด ๆ"
 
@@ -6493,54 +6492,54 @@ msgstr "ไม่พบรายการปรับรุ่นใด ๆ"
 msgid "The following updates are also available:"
 msgstr "รูปแบบต่อไปนี้ไม่สามารถติดตั้งได้"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "ปรับรุ่นแพกเกจ"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "ปรับรุ่นชุดรูปแบบ"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "ปรับรุ่นผลิตภัณฑ์"
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "ค่าปัจจุบัน"
 
-#: src/update.cc:795
+#: src/update.cc:801
 #, fuzzy
 msgid "Available Version"
 msgstr "รุ่นที่มีอยู่: %1 (%2)"
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "ไม่พบแพตช์ที่เข้าคู่กับ '%s'"
 
-#: src/update.cc:978
+#: src/update.cc:986
 #, fuzzy
 msgid "The following matches in issue numbers have been found:"
 msgstr "แพตช์เหล่านี้จะถูกปรับลดรุ่น:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""
@@ -6955,13 +6954,11 @@ msgstr "กด '%c' เพื่อออกจากเพจเจอร์"
 
 #: src/utils/pager.cc:42
 msgid "Use arrows or pgUp/pgDown keys to scroll the text by lines or pages."
-msgstr ""
-"ใช้ปุ่มพิมพ์กลุ่มลูกศร หรือปุ่มพิมพ์ pgUp/pgDown เพื่อเลื่อนข้อความทีละบรรทัดหรือทีละหน้า"
+msgstr "ใช้ปุ่มพิมพ์กลุ่มลูกศร หรือปุ่มพิมพ์ pgUp/pgDown เพื่อเลื่อนข้อความทีละบรรทัดหรือทีละหน้า"
 
 #: src/utils/pager.cc:44
 msgid "Use the Enter or Space key to scroll the text by lines or pages."
-msgstr ""
-"ใช้ปุ่มพิมพ์ Enter หรือปุ่มพิมพ์วรรค เพื่อเลื่อนข้อความทีละบรรทัดหรือทีละหน้า"
+msgstr "ใช้ปุ่มพิมพ์ Enter หรือปุ่มพิมพ์วรรค เพื่อเลื่อนข้อความทีละบรรทัดหรือทีละหน้า"
 
 #: src/utils/prompt.cc:43 src/utils/prompt.cc:94
 #, fuzzy, c-format, boost-format

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,11 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Turkish <https://l10n.opensuse.org/projects/zypper/master/tr/>"
-"\n"
+"Language-Team: Turkish <https://l10n.opensuse.org/projects/zypper/master/tr/"
+">\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1136,8 +1136,10 @@ msgid ""
 "The following package needs additional customer contract to get support:"
 msgid_plural ""
 "The following %d packages need additional customer contract to get support:"
-msgstr[0] "Aşağıdaki paket, destek almak için ek müşteri sözleşmesi gerektirir:"
-msgstr[1] "Aşağıdaki %d paket, destek almak için ek müşteri sözleşmesi gerektirir:"
+msgstr[0] ""
+"Aşağıdaki paket, destek almak için ek müşteri sözleşmesi gerektirir:"
+msgstr[1] ""
+"Aşağıdaki %d paket, destek almak için ek müşteri sözleşmesi gerektirir:"
 
 #: src/Summary.cc:1417
 msgid "was superseded by"
@@ -1453,7 +1455,7 @@ msgstr "PackageKit hala çalışıyor (muhtemelen meşgul)."
 msgid "Try again?"
 msgstr "Yeniden denemek istiyor musunuz?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Beklenmedik istisna."
 
@@ -1485,12 +1487,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "%s seçeneğinin burada etkisi yok, gözardı ediliyor."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Seçenek olmayan program argümanları: "
 
@@ -2247,17 +2249,17 @@ msgid "Commands:"
 msgstr "Komutlar:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Ayrıntılı kurulum özetini göster."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Paketin türü (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2265,9 +2267,15 @@ msgstr ""
 "Güncellemek için \"en iyi çaba\" yaklaşımını uygulayın. En son sürüme göre "
 "daha düşük bir sürümde yapılan güncellemeler de kabul edilebilir."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "Yalnızca paket yönetiminin kendisini etkileyen yamaları dikkate alın."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2348,7 +2356,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <ALTKOMUT> [--KOMUT-SEÇENEKLERİ] [ARGÜMANLAR]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Zypper yardımını yazdır"
 
@@ -2545,8 +2553,8 @@ msgid ""
 msgstr ""
 "Bağımlı paketleri kaldırmaktansa değiştirmeyi tercih eden bir kaldırma "
 "komutu. Aslında bu, düz argümanlarına (-) uygulanan kaldırma değiştiricisi "
-"ile tam özellikli bir yükleme komutudur. Yani 'removeptf foo', 'install -- -"
-"foo' ile aynıdır. Bu yüzden komut, yükleme komutuyla aynı seçenekleri kabul "
+"ile tam özellikli bir yükleme komutudur. Yani 'removeptf foo', 'install -- "
+"-foo' ile aynıdır. Bu yüzden komut, yükleme komutuyla aynı seçenekleri kabul "
 "eder. Bir PTF'yi (Program Geçici Düzeltmesi) kaldırmanın önerilen yoludur."
 
 #: src/commands/installremove.cc:317
@@ -2564,22 +2572,22 @@ msgstr ""
 "sürümleriyle değiştirmeyi hedefler."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [SEÇENEKLER]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Uygun yamaları listele."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Uygulanabilir tüm yamaları listele."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Yalnızca geçerli olanları değil, tüm yamaları listeleyin."
 
@@ -2634,35 +2642,39 @@ msgstr ""
 "mevcut tüm yerel ayarların bir listesini alın."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [SEÇENEKLER] [BÖLGE] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "İstenen bölge ayarlarını listeleyin (dil kodları)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "İstenen bölge ayarlarını ve ilgili paketleri listeleyin."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "İlgili paketleri göster."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Mevcut tüm bölge ayarlarını listeleyin."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr "Konumsal argümanlar yok sayılıyor çünkü --all argümanı sağlandı."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "Hakkında bilgilerin basılacağı bölge(ler)."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2670,17 +2682,17 @@ msgstr ""
 "Yedek 'en' haricinde, kendi ülke koduna sahip 'en' dil koduna sahip tüm "
 "yerel ayarları alın:"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 "Ülke kodu ile veya ülke kodu olmadan 'en' dil koduna sahip tüm bölge "
 "ayarlarını alın:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "Bağımsız değişkenle tam olarak eşleşen bölge ayarını alın: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "'de' ve 'en' için mevcut olan paketlerin listesini alın:"
 
@@ -2727,10 +2739,10 @@ msgid ""
 "have their KIND: string prepended (e.g. 'patch:foo') or use the commands --"
 "type option."
 msgstr ""
-"Kilit özelliği (LOCKSPEC), \"[TÜR:]İSİM[OP EDITION]\" tarafından oluşturulur;"
-" burada AD, * ve ? kullanan bir glob modeli de olabilir, joker karakterler "
-"de olabilir. Paket dışı türlerin başına KIND: dizesi eklenebilir (örneğin, "
-"'patch: foo') veya komutlar --type seçeneğini kullanabilir."
+"Kilit özelliği (LOCKSPEC), \"[TÜR:]İSİM[OP EDITION]\" tarafından "
+"oluşturulur; burada AD, * ve ? kullanan bir glob modeli de olabilir, joker "
+"karakterler de olabilir. Paket dışı türlerin başına KIND: dizesi eklenebilir "
+"(örneğin, 'patch: foo') veya komutlar --type seçeneğini kullanabilir."
 
 #: src/commands/locks/add.cc:36
 msgid ""
@@ -2791,11 +2803,11 @@ msgstr[1] "%lu kilit silindi."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Ad"
 
@@ -2805,8 +2817,8 @@ msgstr "Eşleşmeler"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Tür"
@@ -2814,7 +2826,7 @@ msgstr "Tür"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Depo"
@@ -3092,8 +3104,8 @@ msgid ""
 "download-as-needed disables the fileconflict check."
 msgstr ""
 "Paketleri, önceden kurulmuş olan diğer paketlerdeki dosyaları değiştirseler "
-"bile kurun. Varsayılan, dosya çakışmalarını bir hata olarak ele almaktır. "
-"`--download-as-needed` dosya çakışması denetimini devre dışı bırakır."
+"bile kurun. Varsayılan, dosya çakışmalarını bir hata olarak ele almaktır. `--"
+"download-as-needed` dosya çakışması denetimini devre dışı bırakır."
 
 #. translators: -y, --no-confirm
 #: src/commands/optionsets.cc:291
@@ -3275,7 +3287,7 @@ msgid "Command"
 msgstr "Komut"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Hizmet"
 
@@ -3447,38 +3459,38 @@ msgid "Show detailed information for products."
 msgstr "Ürünler ile ilgili ayrıntılı bilgiyi göster."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [SEÇENEKLER] [DEPO] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Mevcut tüm paketleri listele."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Belirtilen depodaki mevcut tüm paketleri listele."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr "Çözümleyici tarafından otomatik olarak seçilen yüklü paketleri göster."
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr "Kullanıcı tarafından açıkça seçilen yüklü paketleri göster."
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr "Herhangi bir depo tarafından sağlanmayan yüklü paketleri göster."
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
@@ -3486,84 +3498,84 @@ msgstr ""
 "Artık sistem paketlerini göster (depo olmadan ve güncelleme adayı olmadan)."
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Önerilen paketleri göster."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Önerilen paketleri göster."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Gerekli olmayan paketleri göster."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Listeyi paket adına göre sırala."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Listeyi depoya göre sırala."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [DEPO] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Mevcut tüm yamaları listele."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Belirtilen depodaki mevcut tüm yamaları listele."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [SEÇENEKLER] [DEPO] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Mevcut tüm örüntüleri listele."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Belirtilen depolardaki mevcut örüntülerin tamamını listele."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [SEÇENEKLER] [DEPO] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Mevcut tüm ürünleri listele."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Belirtilen depodaki mevcut tüm ürünleri listele."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Yalnızca XML çıkışı: Bir ürün dosyasında bulunan XML etiketlerini tam "
 "anlamıyla iletin."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "%1% seçeneği %2% evrensel seçeneği olmadan bir etkiye sahip değil."
@@ -3605,12 +3617,12 @@ msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 "Depo türü daima otomatik olarak tespit edilir. Bu seçenek göz ardı edildi."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "%s, %s ile birlikte kullanılamıyor. %s ayarı kullanılıyor."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3655,114 +3667,118 @@ msgstr "Meta veri önbelleğini değiştirilebilir."
 msgid "Clean both metadata and package caches."
 msgstr "Hem meta verileri hem de paket önbelleklerini temizleyin."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Takma ad"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Etkinleştirilmiş"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "GPG Kontrolü"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Öncelik"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Otomatik yenileme"
 
 # /usr/lib/YaST2/keyboard_raw.ycp:79
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Açık"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Kapat."
 
 # clients/inst_sw_single.ycp:1461 clients/inst_sw_single.ycp:1485
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Paketleri Tut"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "GPG Anahtarı URI'si"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Ön ek yolu."
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Ebeveyn Hizmeti"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Anahtar sözcükler"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Repo Bilgi Yolu"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "MD Önbellek Yolu"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [SEÇENEKLER] [DEPO] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Tanımlı depoların hepsini listele."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 "Tanımları depoların tamamını tek bir yerel .repo dosyası olarak dışa aktar."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Depolar okunurken hata:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "%s yazmak için açılamıyor."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Belki de yazma iznine sahip misiniz?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Depolar başarıyla %s konumuna aktarıldı."
@@ -3770,20 +3786,20 @@ msgstr "Depolar başarıyla %s konumuna aktarıldı."
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Yenile"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "Tut"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Kod deposu tanımlanmadı."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 "Bir ya da daha fazla depo eklemek için 'zypper addrepo' komutunu kullanın."
@@ -3892,7 +3908,7 @@ msgstr "'%s' evrensel seçeneğinin burada etkisi yok."
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "\"%s\" kullanılıyorsa bağımsız değişkenlere izin verilmez."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Belirtilen depolar: "
 
@@ -3901,7 +3917,7 @@ msgstr "Belirtilen depolar: "
 msgid "Refreshing repository '%s'."
 msgstr "'%s' deposu yenileniyor."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Devre dışı bırakılmış '%s' deposunun içeriği taranıyor."
@@ -3911,7 +3927,7 @@ msgstr "Devre dışı bırakılmış '%s' deposunun içeriği taranıyor."
 msgid "Skipping disabled repository '%s'"
 msgstr "Devre dışı olan '%s' deposu atlanıyor"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Üstteki hatadan dolayı '%s' deposu atlanıyor."
@@ -3940,7 +3956,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "Hatadan dolayı depoyu yenileyemezsiniz."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Bazı depolar bir hatadan dolayı yenilenemedi."
 
@@ -3997,12 +4013,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "'%s' deposunun adı '%s' olarak değiştirildi."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "'%s' isimli depo bulunmakta. Lütfen başka bir isim kullanın."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Depo üzerinde değişiklik yapılırken hata oluştu:"
 
@@ -4465,28 +4481,29 @@ msgstr ""
 "--details gibi, aramanın eşleştiği ek bilgilerle (bağımlılıklarda arama "
 "yapmak için kullanışlıdır)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Belirtilen '%s' deposu devre dışı."
 
 # clients/inst_rootpart.ycp:401
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Eşleşen öge bulunamadı."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Arama sorgusu başlatılırken ya da yürütülürken hata oluştu"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "İp uçları için üstteki mesaja balın."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
-msgstr "'zypper refresh' komutunu yönetici olarak çalıştırmak sorunu çözebilir."
+msgstr ""
+"'zypper refresh' komutunu yönetici olarak çalıştırmak sorunu çözebilir."
 
 #. translators: -g, --category <CATEGORY>
 #: src/commands/selectpatchoptionset.cc:24
@@ -4579,7 +4596,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "'%s' hizmeti için depo dizin dosyası alınırken sorun:"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "'%s' hizmeti yukarıdaki hatadan dolayı atlanıyor."
@@ -4598,24 +4615,28 @@ msgstr "'%s' hizmeti kaldırılıyor:"
 msgid "Service '%s' has been removed."
 msgstr "'%s' hizmeti kaldırıldı."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [SEÇENEKLER]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Tüm tanımlı hizmetleri listele."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Tanımlı hizmetleri listele."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Tanımlı hizmet yok. Bir ya da daha fazla hizmet eklemek için '%s' komutunu "
 "kullanın."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4721,8 +4742,10 @@ msgstr[1] "'%s' depoları '%s' hizmetinin etkin depolarına eklendi"
 msgid "Repository '%s' has been added to disabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been added to disabled repositories of service '%s'"
-msgstr[0] "'%s' deposu '%s' hizmetinin devre dışı bırakılmış depolarına eklendi"
-msgstr[1] "'%s' depoları '%s' hizmetinin devre dışı bırakılmış depolarına eklendi"
+msgstr[0] ""
+"'%s' deposu '%s' hizmetinin devre dışı bırakılmış depolarına eklendi"
+msgstr[1] ""
+"'%s' depoları '%s' hizmetinin devre dışı bırakılmış depolarına eklendi"
 
 #: src/commands/services/modify.cc:269
 #, c-format, boost-format
@@ -4730,8 +4753,10 @@ msgid ""
 "Repository '%s' has been removed from enabled repositories of service '%s'"
 msgid_plural ""
 "Repositories '%s' have been removed from enabled repositories of service '%s'"
-msgstr[0] "'%s' deposu '%s' hizmetinin etkinleştirilmiş depolarından kaldırıldı"
-msgstr[1] "'%s' depoları '%s' hizmetinin etkinleştirilmiş depolarından kaldırıldı"
+msgstr[0] ""
+"'%s' deposu '%s' hizmetinin etkinleştirilmiş depolarından kaldırıldı"
+msgstr[1] ""
+"'%s' depoları '%s' hizmetinin etkinleştirilmiş depolarından kaldırıldı"
 
 #: src/commands/services/modify.cc:276
 #, c-format, boost-format
@@ -4921,7 +4946,8 @@ msgstr "Uzman seçenekler"
 
 #: src/commands/solveroptionset.cc:87
 msgid "Whether to allow downgrading installed resolvables."
-msgstr "Yüklü çözümlenebilirlerin sürüm düşürmesine izin verilip verilmeyeceği."
+msgstr ""
+"Yüklü çözümlenebilirlerin sürüm düşürmesine izin verilip verilmeyeceği."
 
 #: src/commands/solveroptionset.cc:89
 msgid "Whether to allow changing the names of installed resolvables."
@@ -5216,8 +5242,8 @@ msgid ""
 msgstr ""
 "Komut satırında belirtilen RPM'leri yerel bir dizine indirin. Varsayılan "
 "paketler libzypp paket önbelleğine indirilir (/var/cache/zypp/packages; root "
-"olmayan kullanıcılar için $XDG_CACHE_HOME/zypp/packages), ancak bu genel "
-"`--pkg-cache-dir` seçeneği kullanılarak değiştirilebilir. ."
+"olmayan kullanıcılar için $XDG_CACHE_HOME/zypp/packages), ancak bu genel `--"
+"pkg-cache-dir` seçeneği kullanılarak değiştirilebilir. ."
 
 #. translators: command description
 #: src/commands/utils/download.cc:151
@@ -5553,15 +5579,15 @@ msgstr "'%s' daha eski '%s den'"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Sürüm"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Mimari"
 
@@ -5704,14 +5730,14 @@ msgstr "(boş)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 # clients/inst_sw_single.ycp:742
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Bağımlılık"
 
@@ -5749,7 +5775,7 @@ msgid "Flavor"
 msgstr "Nitelik"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Temeldir"
 
@@ -6013,77 +6039,77 @@ msgstr[1] "%1% depo"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "%s için meta verilerin yenilenip yenilenmeyeceği kontrol ediliyor"
 
 # clients/rc_config_step1.ycp:253
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "'%s' deposu güncel."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "'%s' deposunun güncelleme kontrolü ertelendi."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Ham meta verileri yenilemeye zorlama"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "'%s' deposunun üst verisi alınıyor"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "%s deposunu kalıcı olarak devre dışı bırakmak istiyor musunuz?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "'%s' deposu devre dışı bırakılırken hata oluştu."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "'%s' konumundan dosyaları almada sorun oluştu."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "Lütfen ipucu için yukarıdaki hata mesajına bakınız."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "\"%s\" için tanımlanmış URI yok."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
-"Lütfen '%s' kod deposu için %s'ye bir veya daha fazla temel URI (baseurl=URI)"
-" girişi ekleyin."
+"Lütfen '%s' kod deposu için %s'ye bir veya daha fazla temel URI "
+"(baseurl=URI) girişi ekleyin."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Bu depo için bir takma ad tanımlanmadı."
 
 # clients/rc_config_step1.ycp:253
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "'%s' deposu geçersiz."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -6091,22 +6117,22 @@ msgstr ""
 "Lütfen bu arşiv için tanımlanan URI'lerin geçerli bir arşive işaret edip "
 "etmediğini kontrol edin."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "\"%s\" için meta veriler alınırken hata oluştu:"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Depo önbelleği oluşturmaya zorlama"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "'%s' için meta veri ayrıştırılırken hata oluştu:"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6119,32 +6145,32 @@ msgstr ""
 "adresindeki talimatları izleyerek bir hata raporu gönderin"
 
 # clients/rc_config_step1.ycp:253
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "'%s' için depo meta verileri yerel önbellekte bulunamadı."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Önbellek oluşturulurken hata oluştu:"
 
 # clients/rc_config_step1.ycp:253
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Kod deposu '%s' takma adı, numarası veya URI'sine göre bulunamadı."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Tanımlı depoların listesi almak için '%s' komutunu kullanın."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Devre dışı bırakılan kod deposu '%s' yok sayılıyor"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
@@ -6152,12 +6178,12 @@ msgstr ""
 "kullanılabilir."
 
 # clients/rc_config_step1.ycp:253
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "'%s' deposu '%s' seçeneğinden dolayı gözardı ediliyor."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "'%s' deposu geçici olarak etkinleştiriliyor."
@@ -6165,7 +6191,7 @@ msgstr "'%s' deposu geçici olarak etkinleştiriliyor."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
@@ -6174,7 +6200,7 @@ msgstr ""
 "'%s' deposu güncel değil. Güncellemek için 'zypper refresh'  komutunu "
 "yönetici olarak çalıştırabilirsiniz."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6183,81 +6209,81 @@ msgstr ""
 "Meta veri önbelleğinin '%s' deposu için oluşturulması gerekiyor. Bunu yapmak "
 "için kök olarak 'zypper refresh' çalıştırabilirsiniz."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Depo '%s' devre dışı kalır."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Hedef Başlatılıyor"
 
 # clients/online_update_start.ycp:171
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Hedefin başlatılması başarısız oldu:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "'%s' için meta veri önbelleği siliniyor."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "\"%s\" için ham meta veri önbelleği temizleniyor."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "%s '%s' için ham meta veri önbelleği tutuluyor."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "'%s' için pakeler siliniyor."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Hatadan dolayı '%s' deposu temizlenemedi."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Yüklü paketlerin ön belleği temizleniyor."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Hatadan dolayı yükllenmiş paketler önbelleği silinemedi."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Hatadana dolayı depolar silinemedi."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Depoların bazıları bir hatadan dolayı temizlenmedi."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Belirtilen depolar temizlendi."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Tüm depolar temizlendi."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Değiitirilebilir ve salt okunur media(CD/DVD), otomatik yenileme devre dışı."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Geçersiz kod deposu takma adı: \"%s\""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6265,25 +6291,25 @@ msgstr ""
 "Deponun türü belirlenemedi. Lütfen tanımlanan URI'lerin (aşağıya bakın) "
 "geçerli bir depoya işaret edip etmediğini kontrol edin:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Belirtilen yerde geçerli bir depo bulunamadı:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Belirtilen URI'dan depo verisi aktarılırken hata oluştu:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Belirtilen URI'ın erişilebilir olup olmadığını lütfen kontrol edin."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Depo eklenirken bilinmeyen bir problem oluştu:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6292,138 +6318,138 @@ msgstr ""
 "'%1%' veri havuzunun yapılandırmasında GPG denetimi devre dışı bırakıldı. "
 "Paketlerin bütünlüğü ve menşei doğrulanamıyor."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "'%s' deposu başarıyla eklendi"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "'%s' ortamından veri okunuyor"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "'%s' medyasından veri okurken sorun oluştu"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-"Lütfen Yükleme medyasının geçerli ve okunabilir olup olmadığını kontrol edin."
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "'%s' medyasından veri okumak, bir sonraki yenilemeye kadar ertelenir."
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "'%s' ortamından veri okunuyor"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "'%s' medyasından veri okurken sorun oluştu"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+"Lütfen Yükleme medyasının geçerli ve okunabilir olup olmadığını kontrol edin."
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Dosyaya belirtilen URI'de erişim sorunu"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Lütfen URI nin geçerli ve erişilebilir olduğunu kontrol edin."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Belirtilen URI'deki dosyanın ayrıştırılmasında sorun oluştu"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Repo dosyası mı?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Dosyayı belirtilen URI'de okumaya çalışırken karşılaşılan sorun"
 
 # clients/rc_config_step1.ycp:253
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Dosyada tanımlı takma adı olmayan depo atlanıyor."
 
 # clients/rc_config_step1.ycp:253
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "'%s' kod deposunda tanımlanmış URI yok, atlanıyor."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "'%s' deposu kaldırıldı."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "'%s' deposunun önceliği değiştirilmeden bırakıldı (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "'%s' deposu başarıyla etkinleştirildi."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "'%s' deposu başarıyla devre dışı bırakıldı."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "'%s' deposu için otomatik yineleme etkinleştirildi."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Otomatik yenileme '%s' deposu için devre dışı bırakıldı."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "RPM dosyalarını önbelleğe alma, '%s' deposu için etkinleştirildi."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "RPM dosyalarını önbelleğe alma '%s' deposu için devre dışı bırakıldı."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "GPG kontrolü '%s' deposu için etkinleştirildi."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "GPG kontrolü '%s' deposu için devre dışı bırakıldı."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "'%s' deposunun önceliği %d olarak ayarlandı."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "'%s' deposunun adı '%s' olarak ayarlandı."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "'%s' deposu için değiştirilecek bir şey yok."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "%s deposu değiştirilmeden bırakılıyor."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Depo bilgisi yükleniyor..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6431,44 +6457,44 @@ msgstr ""
 "Kod deposu tanımlanmadı. Yalnızca kurulu çözümlerle çalışır. Hiçbir şey "
 "yüklenemez."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "'%s' depo verisi alınıyor."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Depo '%s' önbelleğe alınmadı. Önbelleğe almak..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "'%s' üzerinden veri yükleme sorunu"
 
 # clients/rc_config_step1.ycp:253
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "'%s' deposu yenilenemedi. Eski ön bellek kullanılıyor."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Hata nedeniyle '%s'den çözülebilirler yüklenmedi."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "Depo '%1%' meta verileri %2% tarihinden itibaren sona erdi."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Bunu yapmadan önce '%s', hatta '%s' komutunu deneyin."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6480,30 +6506,30 @@ msgstr ""
 "(zypper ref). Bu sorunu çözmezse, bozuk bir yansı kullanıyor olabilirsiniz "
 "veya sunucu deponun desteğini gerçekten kesmiş olabilir."
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Yüklenmiş paketler okunuyor..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Yüklü paketleri okurken bir sorun oluştu:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' bir RPM paketi gibi görünüyor. İndirmeye çalışılacak."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "RPM dosyasıyla ilgili sorun '%s' olarak belirtildi, atlanıyor."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "%s için RPM üstbilgisini okuma sorunu. RPM dosyası mı?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Düz RPM dosyaları önbelleği"
 
@@ -6512,28 +6538,28 @@ msgid "System Packages"
 msgstr "Sistem paketleri"
 
 # clients/inst_rootpart.ycp:401
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Gerekli bir yama bulunamadı."
 
 # clients/inst_rootpart.ycp:401
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Bir model bulunamadı."
 
 # clients/inst_rootpart.ycp:401
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Hiçbir paket bulunamadı."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "İç İsim"
 
 # clients/inst_rootpart.ycp:401
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Hiçbir ürün bulunamadı."
 
@@ -6946,7 +6972,7 @@ msgstr "Yığını Güncelle"
 
 # clients/online_update_details.ycp:88 clients/online_update_select.ycp:112
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Yamalar"
 
@@ -6970,7 +6996,7 @@ msgid "Needed software management updates will be installed first:"
 msgstr "Önce gerekli yazılım yöneticisi güncellemeleri yüklenecek:"
 
 # clients/inst_rootpart.ycp:401
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Güncelleme bulunamadı."
 
@@ -6980,55 +7006,55 @@ msgid "The following updates are also available:"
 msgstr "Aşağıdaki güncellemeler de mevcuttur:"
 
 # clients/inst_sw_single.ycp:1461 clients/inst_sw_single.ycp:1485
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Paket güncellemeleri"
 
 # clients/inst_sw_single.ycp:1623
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Örüntü güncellemeleri"
 
 # clients/inst_sw_single.ycp:1623
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Ürün güncellemeleri"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Şimdiki Sürüm"
 
 # include/ui/wizard_hw.ycp:48
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Mevcut Sürüm"
 
 # clients/inst_rootpart.ycp:401
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Eşleşen sorun bulunamadı."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Sayı numaralarında aşağıdaki eşleşmeler bulundu:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "Aşağıdaki yamaların yama açıklamalarındaki eşleşmeler bulundu:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "%s numaralı bugzilla sorunu için düzeltme bulunamadı veya gerekli değil."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "%s numaralı CVE sorunu için düzeltme bulunamadı veya gerekli değil."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "%s sorun numarası için düzeltme %s bulunamadı veya gerekli değil."

--- a/po/uk.po
+++ b/po/uk.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper.uk\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Ukrainian <https://l10n.opensuse.org/projects/zypper/master/"
@@ -379,7 +379,8 @@ msgstr "Не читати встановлені пакунки."
 
 #: src/Config.cc:717
 msgid "No config file is in use. Can not save options."
-msgstr "Не використовується конфігураційний файл. Неможливо зберегти параметри."
+msgstr ""
+"Не використовується конфігураційний файл. Неможливо зберегти параметри."
 
 #: src/Config.cc:728
 #, boost-format
@@ -941,9 +942,11 @@ msgstr[2] "Було автоматично вибрано наступних %d 
 msgid "The following recommended source package was automatically selected:"
 msgid_plural ""
 "The following %d recommended source packages were automatically selected:"
-msgstr[0] "Було автоматично вибрано наступний %d рекомендований сирцевий пакунок:"
+msgstr[0] ""
+"Було автоматично вибрано наступний %d рекомендований сирцевий пакунок:"
 msgstr[1] "Було автоматично вибрано наступні %d рекомендовані сирцеві пакунки:"
-msgstr[2] "Було автоматично вибрано наступних %d рекомендованих сирцевих пакунків:"
+msgstr[2] ""
+"Було автоматично вибрано наступних %d рекомендованих сирцевих пакунків:"
 
 #: src/Summary.cc:1100
 #, c-format, boost-format
@@ -1059,8 +1062,10 @@ msgid "The following patch is suggested, but will not be installed:"
 msgid_plural ""
 "The following %d patches are suggested, but will not be installed:"
 msgstr[0] "Була запропонована наступна %d латка, але її не буде встановлено:"
-msgstr[1] "Були запропоновані наступні %d латки, але вони не будуть встановлені:"
-msgstr[2] "Було запропоновано наступних %d латок, але вони не будуть встановлені:"
+msgstr[1] ""
+"Були запропоновані наступні %d латки, але вони не будуть встановлені:"
+msgstr[2] ""
+"Було запропоновано наступних %d латок, але вони не будуть встановлені:"
 
 #: src/Summary.cc:1238
 #, c-format, boost-format
@@ -1519,7 +1524,7 @@ msgstr "PackageKit досі запущений (ймовірно, зайняти
 msgid "Try again?"
 msgstr "Спробувати знову?"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Непередбачений виняток."
 
@@ -1549,12 +1554,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "Параметр %s у цьому випадку не працюватиме, його пропущено."
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "Аргументи програми (не-параметри): "
 
@@ -2055,8 +2060,8 @@ msgid ""
 "Please insert medium [%s] #%d and type 'y' to continue or 'n' to cancel the "
 "operation."
 msgstr ""
-"Будь ласка, вставте носій [%s] #%d та введіть «т» (y), щоб продовжити або «н»"
-" (n), щоб скасувати дію."
+"Будь ласка, вставте носій [%s] #%d та введіть «т» (y), щоб продовжити або "
+"«н» (n), щоб скасувати дію."
 
 #. translators: a/r/i/u are replies to the "Abort, retry, ignore?" prompt
 #. Translate the a/r/i part exactly as you did the a/r/i string.
@@ -2308,17 +2313,17 @@ msgid "Commands:"
 msgstr "Команди:"
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "Показувати детальний огляд встановлення."
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "Тип пакунка (%1%)."
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
@@ -2326,9 +2331,15 @@ msgstr ""
 "Використати підхід \"найменших зусиль\" для оновлення. Також прийнятне "
 "оновлення до версій які не є найостаннішими."
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "Розглядати лише ті латки які впливають на систему керування пакетами."
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2391,8 +2402,8 @@ msgid ""
 "for more information about this command."
 msgstr ""
 "Ви збираєтесь оновити дистрибутив за допомогою всіх увімкнених сховищ. Перед "
-"тим як продовжити переконайтесь, що ці сховища між собою сумісні. Див. \"%s\""
-" для більш детальнішої інформації про цю команду."
+"тим як продовжити переконайтесь, що ці сховища між собою сумісні. Див. "
+"\"%s\" для більш детальнішої інформації про цю команду."
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/help.cc:22
@@ -2405,7 +2416,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <ПІДКОМАНДА> [--ПАРАМЕТРИ-КОМАНДИ] [АРГУМЕНТИ]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "Показати довідку zypper"
 
@@ -2490,8 +2501,8 @@ msgid ""
 "Remove packages with specified capabilities. A capability is NAME[.ARCH]"
 "[OP<VERSION>], where OP is one of <, <=, =, >=, >."
 msgstr ""
-"Вилучити пакунки з вказаною здатністю. Здатність - це запис у вигляді НАЗВА"
-"[.АРХ][ДІЯ<ВЕРСІЯ>], де ДІЯ є одним з знаків порівняння <, <=, =, >=, >."
+"Вилучити пакунки з вказаною здатністю. Здатність - це запис у вигляді "
+"НАЗВА[.АРХ][ДІЯ<ВЕРСІЯ>], де ДІЯ є одним з знаків порівняння <, <=, =, >=, >."
 
 #: src/commands/installremove.cc:104 src/commands/installremove.cc:234
 #: src/utils/messages.cc:53
@@ -2604,8 +2615,8 @@ msgstr ""
 "видаленням. Насправді це повнофункціональна команда install з remove "
 "модифікатором (-) застосований до її звичайних аргументів. Тому 'removeptf "
 "foo' є таким самим як і 'install -- -foo'. Через це команда приймає ті ж "
-"самі опції як і команда install. Це пропонований спосіб для видалення ТВП ("
-"Тимчасові виправлення програми, або ж PTF)."
+"самі опції як і команда install. Це пропонований спосіб для видалення ТВП "
+"(Тимчасові виправлення програми, або ж PTF)."
 
 #: src/commands/installremove.cc:317
 msgid ""
@@ -2622,22 +2633,22 @@ msgstr ""
 "версії."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [ПАРАМЕТРИ]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "Список наявних латок."
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "Список усіх застосовних латок."
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "Список усіх латок, не тільки застосовних."
 
@@ -2692,35 +2703,39 @@ msgstr ""
 "усіх наявних локалей виконавши запит \"%s\"."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [ПАРАМЕТРИ] [ЛОКАЛЬ] …"
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "Список запитаних локалей (мовних кодів)."
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "Список запитаних локалей та відповідних пакунків."
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "Показати відповідні пакунки."
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "Список всіх наявних локалей."
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr "Ігнорування позиції аргументів через використання аргументу --all."
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "Локаль(і) щодо якої буде показано інформацію."
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
@@ -2728,15 +2743,15 @@ msgstr ""
 "Отримати всі локалі які мають код \"en\" разом з кодом власної країни, за "
 "винятком резервної \"en\":"
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr "Отримати всі локалі які мають код \"en\" разом або без коду країни:"
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "Отримати локаль яка точно відповідає аргументу: "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "Отримати список наявних пакунків для \"de\" та \"en\":"
 
@@ -2849,11 +2864,11 @@ msgstr[2] "Вилучено %lu блокувань."
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Назва"
 
@@ -2863,8 +2878,8 @@ msgstr "Відповідники"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Тип"
@@ -2872,7 +2887,7 @@ msgstr "Тип"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Сховище"
@@ -3156,8 +3171,8 @@ msgid ""
 "Don't require user interaction. Alias for the --non-interactive global "
 "option."
 msgstr ""
-"Не потрібна взаємодія із користувачем. Псевдонім для глобального параметра "
-"--non-interactive."
+"Не потрібна взаємодія із користувачем. Псевдонім для глобального параметра --"
+"non-interactive."
 
 #: src/commands/optionsets.cc:309
 msgid ""
@@ -3330,7 +3345,7 @@ msgid "Command"
 msgstr "Команда"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "Сервіс"
 
@@ -3498,121 +3513,121 @@ msgid "Show detailed information for products."
 msgstr "Показати докладну інформацію про продукти."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [ПАРАМЕТРИ] [СХОВИЩЕ] …"
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "Надати список всіх наявних пакунків."
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "Надати список всіх пакунків, які наявні у вказаних сховищах."
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "Показати запропоновані пакунки."
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "Показати рекомендовані пакунки."
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "Показувати непотрібні пакунки."
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "Впорядкувати список за назвами пакунків."
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "Впорядкувати список за сховищами."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [СХОВИЩЕ] …"
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "Надати список всіх наявних латок."
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "Список всіх наявних латок у конкретних сховищах."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [ПАРАМЕТРИ] [СХОВИЩЕ] …"
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "Надати список всіх наявних шаблонів."
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "Надати список всіх наявних шаблонів у вказаних сховищах."
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [ПАРАМЕТРИ] [СХОВИЩЕ] …"
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "Надати список всіх наявних продуктів."
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "Надати список всіх наявних продуктів у вказаних сховищах."
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 "Лише виведення XML: Буквально пересилати XML-теги, знайдені у файлі продукту."
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "Параметр %1% не має впливу без глобального параметра %2%."
@@ -3653,17 +3668,17 @@ msgstr "Не зондувати URI, прозондувати його під ч
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr "Тип сховища завжди автоматично виявляється. Цей параметр нехтується."
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "Неможливо використати %s разом з %s. Використовуйте параметри з %s."
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
-"Якщо використано лише один аргумент, це має бути URI, що вказує на файл "
-".repo."
+"Якщо використано лише один аргумент, це має бути URI, що вказує на "
+"файл .repo."
 
 #: src/commands/repos/add.cc:130
 msgid "Specified type is not a valid repository type:"
@@ -3703,111 +3718,115 @@ msgstr "Очистити кеш сирих метаданих."
 msgid "Clean both metadata and package caches."
 msgstr "Очистити кеші метаданих та пакунків."
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "Псевдонім"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Увімкнено"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "Перевірка GPG"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "Пріоритет"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "Самооновлення"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "Увімк."
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "Вимк."
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "Залишити пакунки"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "URI ключа GPG"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "Префікс шляху"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "Батьківській Сервіс"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "Ключові слова"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "Шлях до відомостей про сховища"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "Шлях кешу MD"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [ПАРАМЕТРИ] [СХОВИЩЕ] …"
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "Надає список всіх визначених сховищ."
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "Експортувати всі визначені сховища до одного локального файла .repo."
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "Помилка читання сховищ:"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Неможливо відкрити %s для запису."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "Можливо ви не маєте прав запису?"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "Сховища було успішно експортовано до %s."
@@ -3815,22 +3834,23 @@ msgstr "Сховища було успішно експортовано до %s.
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Оновити"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "Не визначено жодного сховища."
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
-msgstr "Вживайте команду \"zypper addrepo\", щоб додати одне або більше сховищ."
+msgstr ""
+"Вживайте команду \"zypper addrepo\", щоб додати одне або більше сховищ."
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/repos/modify.cc:24
@@ -3933,7 +3953,7 @@ msgstr "Глобальний параметр \"%s\" тут не працюва�
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "Аргументи не дозволені, якщо використовується \"%s\"."
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "Вказані сховища: "
 
@@ -3942,7 +3962,7 @@ msgstr "Вказані сховища: "
 msgid "Refreshing repository '%s'."
 msgstr "Оновлення сховища \"%s\"."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Сканування вмісту вимкненого сховища \"%s\"."
@@ -3952,7 +3972,7 @@ msgstr "Сканування вмісту вимкненого сховища \"
 msgid "Skipping disabled repository '%s'"
 msgstr "Пропускається вимкнене сховище \"%s\""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "Пропускається сховище \"%s\" через помилку вище."
@@ -3980,7 +4000,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr "Через помилки не вдалось оновити сховища."
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "Деякі сховища не було оновлено через помилку."
 
@@ -4035,12 +4055,13 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Сховище \"%s\" перейменоване на \"%s\"."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
-msgstr "Вже існує сховище з назвою \"%s\". Будь ласка, введіть інший псевдонім."
+msgstr ""
+"Вже існує сховище з назвою \"%s\". Будь ласка, введіть інший псевдонім."
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "Помилка під час зміни сховища:"
 
@@ -4514,25 +4535,25 @@ msgstr ""
 "Аналогічно --details, з додатковими відомостями про місце збігу (корисно для "
 "пошуку в залежностях)."
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Віддалене сховище \"%s\" вимкнено."
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "Збігів не знайдено."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "Під час започаткування та виконання пошукового запиту сталася помилка"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "Дивись підказку у вищенаведеному повідомленні."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 "Виконання команди \"zypper refresh\" від адміністратора може зарадити "
@@ -4626,7 +4647,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Проблема отримання файлу індексу сховища для сервісу \"%s\":"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "Пропуск сервісу \"%s\" через помилку вище."
@@ -4645,24 +4666,28 @@ msgstr "Вилучення сервісу \"%s\":"
 msgid "Service '%s' has been removed."
 msgstr "Сервіс \"%s\" було вилучено."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [ПАРАМЕТРИ]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "Список всіх визначених сервісів."
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "Список визначених сервісів."
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr ""
 "Не визначено жодного сервісу. Вживайте команду \"%s\", щоб додати один або "
 "більше сервісів."
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -5591,15 +5616,15 @@ msgstr "%s старіший за %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Версія"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Арх."
 
@@ -5734,13 +5759,13 @@ msgstr "(порожній)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "Залежність"
 
@@ -5777,7 +5802,7 @@ msgid "Flavor"
 msgstr "Вид"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "Базується"
 
@@ -6041,60 +6066,60 @@ msgstr[2] "%1% сховищ"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "Перевірка чи освіжати метадані для %s"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Сховище \"%s\" не потребує оновлення."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Перевірку сховища \"%s\" на відповідність було відкладено."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "Примусове оновлення сирих метаданих"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Отримання метаданих сховища \"%s\""
 
 # power-off message
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Хочете назавжди вимкнути сховище %s?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Помилка вимикання сховища \"%s\"."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Проблема зі звантаженням файлів з \"%s\"."
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 "Будь ласка, прочитайте повідомлення про помилку, розміщене вище, щоб краще "
 "зрозуміти ситуацію."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Не визначено жодної адреси URI для \"%s\"."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
@@ -6103,16 +6128,16 @@ msgstr ""
 "Будь ласка, додайте один або декілька записів базових URI (baseurl=URI) до "
 "%s для сховища \"%s\"."
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "Для цього сховища немає псевдоніму."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Сховище \"%s\" недійсне."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
@@ -6120,22 +6145,22 @@ msgstr ""
 "Будь ласка, перевірте чи адреси URI, які визначені для цього сховища, "
 "вказують на існуюче сховище."
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Помилка отримання метаданих для \"%s\":"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "Примусово створюється кеш сховища"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Помилка аналізу метаданих для \"%s\":"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -6147,41 +6172,41 @@ msgstr ""
 "ласка, надішліть звіт про помилку згідно до вказівок на сторінці http://"
 "en.opensuse.org/Zypper/Troubleshooting"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Метадані сховища \"%s\" не знайдено в локальному кешу."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "Помилка створення кешу:"
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Сховище \"%s\" не знайдено за його псевдонімом або URI."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "Вживайте \"%s\", щоб отримати список визначених сховищ."
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Нехтується вимкнене сховище \"%s\""
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr "Глобальний параметр \"%s\" дозволяє тимчасово увімкнути сховища."
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Ігнорується сховище \"%s\" через параметр \"%s\"."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Тимчасове вмикання сховища \"%s\"."
@@ -6189,16 +6214,16 @@ msgstr "Тимчасове вмикання сховища \"%s\"."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
-"Сховище \"%s\" — застаріле. Щоб його оновити, можете виконати "
-"\"zypper refresh\"."
+"Сховище \"%s\" — застаріле. Щоб його оновити, можете виконати \"zypper "
+"refresh\"."
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
@@ -6207,80 +6232,80 @@ msgstr ""
 "Для сховища \"%s\" слід спочатку побудувати кеш метаданих. Ви можете "
 "виконати цю дію командою \"zypper refresh\", відданою адміністратором."
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Сховище \"%s\" досі вимкнене."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Започаткування цілі"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "Не вдалося започаткувати ціль:"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Очищення кешу метаданих для \"%s\"."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Очищення кешу сирих метаданих для \"%s\"."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Збереження кешу сирих метаданих для %s \"%s\"."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Очищення пакунків з \"%s\"."
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "Неможливо очистити сховище \"%s\" через помилку."
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "Очищення кешу встановлених пакунків."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "Неможливо очистити кеш встановлених пакунків через помилку."
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "Через помилки не вдалось очистити сховища."
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "Деякі сховища не було очищено через помилку."
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "Вказані сховища було очищено."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "Всі сховища було очищено."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 "Це змінний носій тільки для читання (CD/DVD), автооновлення буде вимкнено."
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Недійсний псевдонім сховища: \"%s\""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
@@ -6288,25 +6313,25 @@ msgstr ""
 "Не вдалося визначити тип сховища. Будь ласка, перевірте чи зазначені адреси "
 "URI (див. нижче) вказують на чинне сховище:"
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "Не вдається знайти в цьому місці чинне сховище:"
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Помилка перенесення даних сховища з вказаної адреси URI:"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "Будь ласка, перевірте чи доступна вказана адреса URI."
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "Виникла невідома проблема при додаванні сховища:"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
@@ -6315,139 +6340,140 @@ msgstr ""
 "Перевірка GPG вимкнена у конфігурації сховища \"%1%\". Цілісність та "
 "походження пакунків не можна перевірити."
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "Сховище \"%s\" успішно додано"
 
-#: src/repos.cc:1269
+#: src/repos.cc:1262
+#, c-format, boost-format
+msgid "Reading data from '%s' media is delayed until next refresh."
+msgstr "Читання даних з носія \"%s\" відкладено до наступного оновлення."
+
+#: src/repos.cc:1267
 #, c-format, boost-format
 msgid "Reading data from '%s' media"
 msgstr "Читання даних з носія \"%s\""
 
-#: src/repos.cc:1275
+#: src/repos.cc:1273
 #, c-format, boost-format
 msgid "Problem reading data from '%s' media"
 msgstr "Проблема з читанням даних з носія \"%s\""
 
-#: src/repos.cc:1276
+#: src/repos.cc:1274
 msgid "Please check if your installation media is valid and readable."
 msgstr ""
 "Перевірте чи носій, з якого проводилося встановлення, правильно записаний і "
 "придатний до читання."
 
-#: src/repos.cc:1283
-#, c-format, boost-format
-msgid "Reading data from '%s' media is delayed until next refresh."
-msgstr "Читання даних з носія \"%s\" відкладено до наступного оновлення."
-
-#: src/repos.cc:1352
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "Помилка доступу до файла за вказаною адресою URI"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "Будь ласка, перевірте чи чинна і доступна вказана адреса URI."
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "Помилка аналізу файла за вказаною адресою URI"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "Чи це файл .repo?"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
-msgstr "Трапилась проблема під час спроби читання файла за вказаною адресою URI"
+msgstr ""
+"Трапилась проблема під час спроби читання файла за вказаною адресою URI"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 "У файлі знайдено запис для сховища без встановленого псевдоніма, його "
 "пропущено."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Сховище \"%s\" не має визначеного URI, його пропущено."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Сховище \"%s\" було вилучено."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Пріоритет сховища \"%s\" було залишено без змін (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Сховище \"%s\" було успішно увімкнено."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Сховище \"%s\" було успішно вимкнено."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "Для сховища \"%s\" було увімкнено автоматичне оновлення."
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "Для сховища \"%s\" було вимкнено автоматичне оновлення."
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Для сховища \"%s\" було увімкнено кешування файлів RPM."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Для сховища \"%s\" було вимкнено кешування файлів RPM."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Для сховища \"%s\" було увімкнено перевірку GPG."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Для сховища \"%s\" було вимкнено перевірку GPG."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Пріоритет сховища \"%s\" було встановлено у значення %d."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Назву сховища \"%s\" було встановлено у значення \"%s\"."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Нічого не змінено для сховища \"%s\"."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Сховище %s буде залишене без змін."
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "Завантаження даних сховища..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
@@ -6455,78 +6481,78 @@ msgstr ""
 "Немає визначених сховищ. Дії тільки з встановленими об'єктами розв'язання "
 "залежностей. Нічого неможливо встановити."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Отримання даних сховища \"%s\"..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "Сховище \"%s\" відсутнє у кеші. Кешування…"
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Проблема завантаження даних з \"%s\""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "Неможливо оновити сховище \"%s\". Використовується старий кеш."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "Потрібні пакунки з \"%s\" не завантажено через помилку."
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "Репозиторій '%1%' метадані застаріли з %2%."
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "Спробуйте \"%s\" або, навіть, \"%s\" перш, ніж це робити."
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
 "not solve the issue, it could be that you are using a broken mirror or the "
 "server has actually discontinued to support the repository."
 msgstr ""
-"Метадані репозиторія застаріли: Перевірте чи 'autorefresh' ввімкнений ("
-"zypper lr), інакше вручну оновіть репозиторії (zypper ref). Якщо це не "
+"Метадані репозиторія застаріли: Перевірте чи 'autorefresh' ввімкнений "
+"(zypper lr), інакше вручну оновіть репозиторії (zypper ref). Якщо це не "
 "вирішує проблему, можливо те, що ви використовуєте несправне дзеркало або "
 "сервер припинив підтримку репозиторія."
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "Читання встановлених пакунків..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Під час читання встановлених пакунків виникла проблема:"
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "\"%s\" схожий на файл RPM. Спробуємо його звантажити."
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "Проблема з файлом RPM, заданим як \"%s\", його пропущено."
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "Проблема під час читання заголовка RPM %s. Можливо, це не файл RPM?"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "Кеш простих файлів RPM"
 
@@ -6534,25 +6560,25 @@ msgstr "Кеш простих файлів RPM"
 msgid "System Packages"
 msgstr "Системні пакунки"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "Не знайдено потрібних латок."
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "Не знайдено шаблонів."
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "Не знайдено пакунків."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "Внутрішня назва"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "Не знайдено продуктів."
 
@@ -6968,7 +6994,7 @@ msgid "Updatestack"
 msgstr "Стек оновлень"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Латки"
 
@@ -6991,7 +7017,7 @@ msgstr "Включені категорії"
 msgid "Needed software management updates will be installed first:"
 msgstr "Спочатку будуть встановлені оновлення керування ПЗ:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "Не знайдено оновлень."
 
@@ -7000,53 +7026,53 @@ msgstr "Не знайдено оновлень."
 msgid "The following updates are also available:"
 msgstr "Також наявні наступні оновлення:"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "Оновлення пакунків"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "Оновлення шаблона"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "Оновлення продукту"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "Поточна версія"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "Наявна Версія"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "Збігів не знайдено."
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "Знайдено наступні збіги номерів:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "Було знайдено збіги в описах наступних пакунків:"
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 "Не було знайдено (або не потрібне) виправлення для питання bugzilla, номер "
 "%s."
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 "Не було знайдено (або не потрібне) виправлення для питання CVE, номер %s."
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "Виправлення для %s проблеми номер %s не знайдено або не потрібне."

--- a/po/wa.po
+++ b/po/wa.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lcn memory\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
-"Language-Team: Walloon <https://l10n.opensuse.org/projects/zypper/master/wa/>"
-"\n"
+"Language-Team: Walloon <https://l10n.opensuse.org/projects/zypper/master/wa/"
+">\n"
 "Language: wa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1369,7 +1369,7 @@ msgstr ""
 msgid "Try again?"
 msgstr ""
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 #, fuzzy
 msgid "Unexpected exception."
 msgstr "&Tchuze tchoezeye"
@@ -1398,12 +1398,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -2103,24 +2103,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2190,7 +2196,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2374,22 +2380,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2440,49 +2446,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2586,11 +2596,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "No"
 
@@ -2601,8 +2611,8 @@ msgstr "Coridjaedjes"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Sôre"
@@ -2610,7 +2620,7 @@ msgstr "Sôre"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "Depot"
@@ -3034,7 +3044,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "Éndjin"
@@ -3198,120 +3208,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3351,12 +3361,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3398,118 +3408,122 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Mete en alaedje"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 #, fuzzy
 msgid "GPG Check"
 msgstr "Verifiaedje DNS"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 #, fuzzy
 msgid "Autorefresh"
 msgstr "&Ritcherdjî"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 #, fuzzy
 msgid "On"
 msgstr "Nonna"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Keep Packages"
 msgstr "Cayets des plaeces do sistinme"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 #, fuzzy
 msgid "Path Prefix"
 msgstr "Betchete do limero d' telefone"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "Sierveu d' imprimaedje"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 #, fuzzy
 msgid "Error reading repositories:"
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Can't run %s.  Exiting."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, fuzzy, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "L' uzeu a bén stî radjouté a zmd"
@@ -3517,22 +3531,22 @@ msgstr "L' uzeu a bén stî radjouté a zmd"
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 #, fuzzy
 msgid "Refresh"
 msgstr "&Ritcherdjî"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "&Ritcherdjî"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3633,7 +3647,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 #, fuzzy
 msgid "Specified repositories: "
 msgstr "Aroke e scrijhant l' fitchî '%1'"
@@ -3643,7 +3657,7 @@ msgstr "Aroke e scrijhant l' fitchî '%1'"
 msgid "Refreshing repository '%s'."
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Aroke e scrijhant l' fitchî '%1'"
@@ -3653,7 +3667,7 @@ msgstr "Aroke e scrijhant l' fitchî '%1'"
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3680,7 +3694,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3733,12 +3747,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Li siervice n' est nén enondé"
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 #, fuzzy
 msgid "Error while modifying the repository:"
 msgstr "Ene aroke s' a passêye tins ki dj' lijheve li djournå."
@@ -4171,27 +4185,27 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "&Ritcherdjî"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "Rén trové ki coresponde"
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 #, fuzzy
 msgid "See the above message for a hint."
 msgstr "Mostrer ç' messaedje eyet cwiter."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4282,7 +4296,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4301,21 +4315,25 @@ msgstr "Dji oistêye li programe..."
 msgid "Service '%s' has been removed."
 msgstr "L' uzeu a bén stî radjouté a zmd"
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5203,15 +5221,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Modêye"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Årtch"
 
@@ -5353,13 +5371,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr ""
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 #, fuzzy
 msgid "Dependency"
 msgstr "Aloyances"
@@ -5398,7 +5416,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5662,97 +5680,97 @@ msgstr[1] "Depot"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Li siervice n' est nén enondé"
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, fuzzy, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "L' uzeu a bén stî radjouté a zmd"
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Voloz vs accepter cisse sinateure do depot?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, fuzzy, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Aroke e scrijhant l' lisse des pakets a pårti d' %1"
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 #, fuzzy
 msgid "Please see the above error message for a hint."
 msgstr "Mostrer ç' messaedje eyet cwiter."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, fuzzy, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Ene aroke s' a passêye tins ki dj' lijheve li djournå."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 #, fuzzy
 msgid "No alias defined for this repository."
 msgstr "Ene aroke s' a passêye tins ki dj' lijheve li djournå."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Li siervice n' est nén enondé"
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, fuzzy, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 #, fuzzy
 msgid "Forcing building of repository cache"
 msgstr "Dj' ahive l' imådje ISO..."
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, fuzzy, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5760,42 +5778,42 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, fuzzy, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Li siervice n' est nén enondé"
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 #, fuzzy
 msgid "Error building the cache:"
 msgstr "Ene aroke s' a passêye tins ki dj' lijheve li djournå."
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Li siervice n' est nén enondé"
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, fuzzy, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Li siervice n' est nén enondé"
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Aroke e scrijhant l' fitchî '%1'"
@@ -5803,306 +5821,306 @@ msgstr "Aroke e scrijhant l' fitchî '%1'"
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Li siervice n' est nén enondé"
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 #, fuzzy
 msgid "Initializing Target"
 msgstr "Inicialijhaedje"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 #, fuzzy
 msgid "Target initialization failed:"
 msgstr "Astalaedje fini"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, fuzzy, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, fuzzy, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, fuzzy, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, fuzzy, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Aroke e scrijhant l' lisse des pakets a pårti d' %1"
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 #, fuzzy
 msgid "Cleaning installed packages cache."
 msgstr "Dji verifeye des pakets RPM astalés..."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 #, fuzzy
 msgid "Specified repositories have been cleaned up."
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 #, fuzzy
 msgid "All repositories have been cleaned up."
 msgstr "L' uzeu a bén stî radjouté a zmd"
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, fuzzy, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 #, fuzzy
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 #, fuzzy
 msgid "Unknown problem when adding repository:"
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "L' uzeu a bén stî radjouté a zmd"
 
-#: src/repos.cc:1269
-#, fuzzy, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Aroke e scrijhant l' lisse des pakets a pårti d' %1"
-
-#: src/repos.cc:1275
-#, fuzzy, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Aroke e scrijhant l' lisse des pakets a pårti d' %1"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, fuzzy, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Aroke e scrijhant l' lisse des pakets a pårti d' %1"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, fuzzy, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Aroke e scrijhant l' lisse des pakets a pårti d' %1"
+
+#: src/repos.cc:1273
+#, fuzzy, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Aroke e scrijhant l' lisse des pakets a pårti d' %1"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 #, fuzzy
 msgid "Problem accessing the file at the specified URI"
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 #, fuzzy
 msgid "Problem parsing the file at the specified URI"
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 #, fuzzy
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 #, fuzzy
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Li siervice n' est nén enondé"
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Li siervice n' est nén enondé"
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "L' uzeu a bén stî radjouté a zmd"
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "L' uzeu a bén stî radjouté a zmd"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "L' uzeu a bén stî radjouté a zmd"
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "L' uzeu a bén stî radjouté a zmd"
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "L' uzeu a bén stî radjouté a zmd"
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, fuzzy, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "L' uzeu a bén stî radjouté a zmd"
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, fuzzy, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, fuzzy, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 #, fuzzy
 msgid "Loading repository data..."
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Aroke e scrijhant l' fitchî '%1'"
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, fuzzy, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Aroke e scrijhant l' lisse des pakets a pårti d' %1"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "Li siervice n' est nén enondé"
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6110,32 +6128,32 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "Dji verifeye des pakets RPM astalés..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Dji verifeye des pakets RPM astalés..."
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6144,29 +6162,29 @@ msgstr ""
 msgid "System Packages"
 msgstr "Cayets des plaeces do sistinme"
 
-#: src/search.cc:261
+#: src/search.cc:262
 #, fuzzy
 msgid "No needed patches found."
 msgstr "Rén trové ki coresponde"
 
-#: src/search.cc:342
+#: src/search.cc:344
 #, fuzzy
 msgid "No patterns found."
 msgstr "Rén trové ki coresponde"
 
-#: src/search.cc:450
+#: src/search.cc:453
 #, fuzzy
 msgid "No packages found."
 msgstr "Rén trové ki coresponde"
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "Divintrinne aroke"
 
-#: src/search.cc:544
+#: src/search.cc:549
 #, fuzzy
 msgid "No products found."
 msgstr "Rén trové ki coresponde"
@@ -6547,7 +6565,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "Coridjaedjes"
 
@@ -6571,7 +6589,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "Ces pakets divèt esse astalés:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 #, fuzzy
 msgid "No updates found."
 msgstr "Rén trové ki coresponde"
@@ -6582,57 +6600,57 @@ msgstr "Rén trové ki coresponde"
 msgid "The following updates are also available:"
 msgstr "Des metaedjes a djoû des programes sont disponibes."
 
-#: src/update.cc:700
+#: src/update.cc:707
 #, fuzzy
 msgid "Package updates"
 msgstr "Groupes di pakets"
 
-#: src/update.cc:704
+#: src/update.cc:711
 #, fuzzy
 msgid "Pattern updates"
 msgstr "Rindjmint des modeles"
 
-#: src/update.cc:706
+#: src/update.cc:713
 #, fuzzy
 msgid "Product updates"
 msgstr "No d' prodût "
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "Raloyaedje do moumint"
 
-#: src/update.cc:795
+#: src/update.cc:801
 #, fuzzy
 msgid "Available Version"
 msgstr "Metaedje a djoû d' disponibes"
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "Rén trové ki coresponde"
 
-#: src/update.cc:978
+#: src/update.cc:986
 #, fuzzy
 msgid "The following matches in issue numbers have been found:"
 msgstr "Ces pakets divèt esse astalés:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/xh.po
+++ b/po/xh.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Xhosa <https://l10n.opensuse.org/projects/zypper/master/xh/>\n"
@@ -1367,7 +1367,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "Kulungiselelwa ukuhlohla..."
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Isinxaxhi esingalindelekanga."
 
@@ -1395,12 +1395,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 #, fuzzy
 msgid "Non-option program arguments: "
 msgstr "Isikhethwa-esingekho seNkqubo Yeempikiswano:"
@@ -2112,24 +2112,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2199,7 +2205,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2385,22 +2391,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2451,49 +2457,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2597,11 +2607,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Igama"
 
@@ -2612,8 +2622,8 @@ msgstr "lungisa"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Uhlobo"
@@ -2621,7 +2631,7 @@ msgstr "Uhlobo"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 #, fuzzy
 msgid "Repository"
@@ -3054,7 +3064,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "Iseva"
@@ -3219,120 +3229,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3371,12 +3381,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3418,118 +3428,122 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Yenziwe yasebenza"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 #, fuzzy
 msgid "GPG Check"
 msgstr "Qwalasela i-DNS"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 #, fuzzy
 msgid "Autorefresh"
 msgstr "Iyazihlaziya"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 #, fuzzy
 msgid "On"
 msgstr "hayi"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Keep Packages"
 msgstr "Amanqaku endawo yesixokelelwano"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 #, fuzzy
 msgid "Path Prefix"
 msgstr "Nxibelelanisa Isimaphambili"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "Iseva"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 #, fuzzy
 msgid "Error reading repositories:"
 msgstr "Ifayili yokubhala imposiso '%1'"
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Ayikwazi kuvula ifayili ukuze kubhalwe."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3537,21 +3551,21 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Hlaziya"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "Iyazihlaziya"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3652,7 +3666,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 #, fuzzy
 msgid "Specified repositories: "
 msgstr "Ifayili yokubhala imposiso '%1'"
@@ -3662,7 +3676,7 @@ msgstr "Ifayili yokubhala imposiso '%1'"
 msgid "Refreshing repository '%s'."
 msgstr "Ifayili yokubhala imposiso '%1'"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Ifayili yokubhala imposiso '%1'"
@@ -3672,7 +3686,7 @@ msgstr "Ifayili yokubhala imposiso '%1'"
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3701,7 +3715,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3754,12 +3768,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 #, fuzzy
 msgid "Error while modifying the repository:"
 msgstr "Kwenzeke imposiso xa bekufundwa isixhobo sokufumanisa imposiso"
@@ -4192,27 +4206,27 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Iyazihlaziya"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "Akukho sandi"
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 #, fuzzy
 msgid "See the above message for a hint."
 msgstr "Nceda lungisa imposiso kwaye uzame kwakhona."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4303,7 +4317,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Ifayili yokubhala imposiso '%1'"
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4323,21 +4337,25 @@ msgstr "&Shenxisa Isinxulumanisi"
 msgid "Service '%s' has been removed."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5229,15 +5247,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Inguqulelo"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "Ezokwakha."
 
@@ -5375,13 +5393,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -5419,7 +5437,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5686,98 +5704,98 @@ msgstr[1] "Ubulembelele"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, fuzzy, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Ifayili yokubhala imposiso '%1'"
 
 # power-off message
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Ingaba ufuna ukuzizilizisa isixokelelwano ngoku?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Ifayili yokubhala imposiso '%1'"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, fuzzy, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Ifunda uluhlu lwefayili ukusuka ku%s"
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 #, fuzzy
 msgid "Please see the above error message for a hint."
 msgstr "Nceda lungisa imposiso kwaye uzame kwakhona."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, fuzzy, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Kwenzeke imposiso xa bekufundwa isixhobo sokufumanisa imposiso"
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 #, fuzzy
 msgid "No alias defined for this repository."
 msgstr "Kwenzeke imposiso xa bekufundwa isixhobo sokufumanisa imposiso"
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, fuzzy, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Ifayili yokubhala imposiso '%1'"
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 #, fuzzy
 msgid "Forcing building of repository cache"
 msgstr "Isilumkiso: Uhlobo lwe-metadata olungaziwa"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, fuzzy, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Ifayili yokubhala imposiso '%1'"
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5785,42 +5803,42 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, fuzzy, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 #, fuzzy
 msgid "Error building the cache:"
 msgstr "Imposiso xa kwahlulwa isatifikethi."
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Ifayili yokubhala imposiso '%1'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, fuzzy, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Ifayili yokubhala imposiso '%1'"
@@ -5828,267 +5846,267 @@ msgstr "Ifayili yokubhala imposiso '%1'"
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Indulula Okujoliswe kuko"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 #, fuzzy
 msgid "Target initialization failed:"
 msgstr "Ukundulula kusilele"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, fuzzy, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Ifayili yokubhala imposiso '%1'"
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, fuzzy, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Ifayili yokubhala imposiso '%1'"
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, fuzzy, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Ifayili yokubhala imposiso '%1'"
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, fuzzy, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Ifunda imibekelo ukusuka ku%s"
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 #, fuzzy
 msgid "Cleaning installed packages cache."
 msgstr "Kuqwalaselwa imibekelelo ye-RPM ehlohliweyo..."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 #, fuzzy
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "ayikwazi kukhuphela oovimba (imposiso yesiseko senkcukacha)"
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 #, fuzzy
 msgid "Could not clean the repositories because of errors."
 msgstr "ayikwazi kukhuphela oovimba (imposiso yesiseko senkcukacha)"
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 #, fuzzy
 msgid "Specified repositories have been cleaned up."
 msgstr "Ifayili yokubhala imposiso '%1'"
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 #, fuzzy
 msgid "All repositories have been cleaned up."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, fuzzy, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Ifayili yokubhala imposiso '%1'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 #, fuzzy
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Isilumkiso: Uhlobo lwe-metadata olungaziwa"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 #, fuzzy
 msgid "Please check whether the specified URI is accessible."
 msgstr "ifayili yeskripti ayinakufikelelwa"
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 #, fuzzy
 msgid "Unknown problem when adding repository:"
 msgstr "Isilumkiso: Uhlobo lwe-metadata olungaziwa"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, fuzzy, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Ifunda imveliso ukusuka ku%s"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, fuzzy, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Ifunda imveliso ukusuka ku%s"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, fuzzy, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Ifunda imveliso ukusuka ku%s"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 #, fuzzy
 msgid "Problem accessing the file at the specified URI"
 msgstr "Isilumkiso: Uhlobo lwe-metadata olungaziwa"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 #, fuzzy
 msgid "Please check if the URI is valid and accessible."
 msgstr "ifayili yeskripti ayinakufikelelwa"
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 #, fuzzy
 msgid "Problem parsing the file at the specified URI"
 msgstr "Isilumkiso: Uhlobo lwe-metadata olungaziwa"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 #, fuzzy
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Isilumkiso: Uhlobo lwe-metadata olungaziwa"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 #, fuzzy
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Ifayili yokubhala imposiso '%1'"
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Ifayili yokubhala imposiso '%1'"
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Ifayili yokubhala imposiso '%1'"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Ifayili yokubhala imposiso '%1'"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, fuzzy, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, fuzzy, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Ifayili yokubhala imposiso '%1'"
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, fuzzy, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Isilumkiso: Uhlobo lwe-metadata olungaziwa"
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 #, fuzzy
 msgid "Loading repository data..."
 msgstr "Ifayili yokubhala imposiso '%1'"
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 #, fuzzy
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
@@ -6097,43 +6115,43 @@ msgstr ""
 "Isilumkiso: Akho mithombo. Isebenza kuphela ngezinto ezinokwahlulwa "
 "ezihlohliweyo. Akukho nto inokuhlohlwa."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Ifayili yokubhala imposiso '%1'"
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "Inkonzo iyaqhuba"
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6141,32 +6159,32 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "Kuqwalaselwa imibekelelo ye-RPM ehlohliweyo..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Kwenzeke imposiso xa bekufundwa kukavimba wokuhlohla."
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6175,28 +6193,28 @@ msgstr ""
 msgid "System Packages"
 msgstr "Amanqaku endawo yesixokelelwano"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 #, fuzzy
 msgid "No patterns found."
 msgstr "Akukho sandi"
 
-#: src/search.cc:450
+#: src/search.cc:453
 #, fuzzy
 msgid "No packages found."
 msgstr "Akukho sandi"
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "Imposiso yaNgaphakathi"
 
-#: src/search.cc:544
+#: src/search.cc:549
 #, fuzzy
 msgid "No products found."
 msgstr "Akukho sandi"
@@ -6587,7 +6605,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 #, fuzzy
 msgid "Patches"
 msgstr "lungisa"
@@ -6612,7 +6630,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "Le mibekelelo kufuneka ihlohliwe:"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 #, fuzzy
 msgid "No updates found."
 msgstr "Akukho sandi"
@@ -6623,56 +6641,56 @@ msgstr "Akukho sandi"
 msgid "The following updates are also available:"
 msgstr "Oovimba abalandelayo balungisiwe"
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 #, fuzzy
 msgid "Pattern updates"
 msgstr "Isimo Sebhetri"
 
-#: src/update.cc:706
+#: src/update.cc:713
 #, fuzzy
 msgid "Product updates"
 msgstr "Imveliso"
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "Uqhagamshelo Lwangoku"
 
-#: src/update.cc:795
+#: src/update.cc:801
 #, fuzzy
 msgid "Available Version"
 msgstr "Uvimba wolwazi Ofumanekayo"
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "Akukho sandi"
 
-#: src/update.cc:978
+#: src/update.cc:986
 #, fuzzy
 msgid "The following matches in issue numbers have been found:"
 msgstr "Le mibekelelo kufuneka ihlohliwe:"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-08-05 05:59+0000\n"
 "Last-Translator: Grace Yu <grace.yu@excel-gits.com>\n"
 "Language-Team: Chinese (China) <https://l10n.opensuse.org/projects/zypper/"
@@ -275,8 +275,9 @@ msgstr "使用一个附加软件源。"
 msgid ""
 "Additionally use disabled repositories providing a specific keyword. Try '--"
 "plus-content debug' to enable repos indicating to provide debug packages."
-msgstr "也使用提供指定关键字的已禁用软件源。可尝试使用 ‘--plus-content debug’ "
-"来临时启用表明其提供了侦错软件包的软件源。"
+msgstr ""
+"也使用提供指定关键字的已禁用软件源。可尝试使用 ‘--plus-content debug’ 来临时"
+"启用表明其提供了侦错软件包的软件源。"
 
 #: src/Config.cc:491
 msgid "Repositories disabled, using the database of installed packages only."
@@ -498,23 +499,26 @@ msgstr "没有 '%s' 的更新候选。"
 msgid ""
 "There is an update candidate '%s' for '%s', but it does not match the "
 "specified version, architecture, or repository."
-msgstr "有一个更新候选 '%s' 可供 '%s' 使用，但它不匹配指定的版本、架构或软件源。"
+msgstr ""
+"有一个更新候选 '%s' 可供 '%s' 使用，但它不匹配指定的版本、架构或软件源。"
 
 #: src/RequestFeedback.cc:124
 #, c-format, boost-format
 msgid ""
 "There is an update candidate for '%s' from vendor '%s', while the current "
 "vendor is '%s'. Use '%s' to install this candidate."
-msgstr "有一个 ‘%s’ 的更新候选，来自源 ‘%s’，但当前是来自 ‘%s’。可使用 ‘%s’ "
-"安装该候选。"
+msgstr ""
+"有一个 ‘%s’ 的更新候选，来自源 ‘%s’，但当前是来自 ‘%s’。可使用 ‘%s’ 安装该候"
+"选。"
 
 #: src/RequestFeedback.cc:133
 #, c-format, boost-format
 msgid ""
 "There is an update candidate for '%s', but it comes from a repository with a "
 "lower priority. Use '%s' to install this candidate."
-msgstr "有一个 '%s' 的更新候选，但它来自一个优先级较低的软件源。请使用 '%s' "
-"安装此候选。"
+msgstr ""
+"有一个 '%s' 的更新候选，但它来自一个优先级较低的软件源。请使用 '%s' 安装此候"
+"选。"
 
 #: src/RequestFeedback.cc:143
 #, c-format, boost-format
@@ -855,7 +859,8 @@ msgid ""
 msgid_plural ""
 "The following %d packages are recommended, but will not be installed because "
 "they are unwanted (were manually removed before):"
-msgstr[0] "推荐以下 %d 个软件包，但不会安装，因为它们是不需要的（曾经手动移除过）："
+msgstr[0] ""
+"推荐以下 %d 个软件包，但不会安装，因为它们是不需要的（曾经手动移除过）："
 
 #: src/Summary.cc:1169
 #, c-format, boost-format
@@ -1255,15 +1260,17 @@ msgstr "考虑取消："
 msgid ""
 "PackageKit is blocking zypper. This happens if you have an updater applet or "
 "other software management application using PackageKit running."
-msgstr "PackageKit 正屏蔽着 zypper。这发生在若您已运行了一个使用 PackageKit "
-"的升级挂件或其他软件管理程序时。"
+msgstr ""
+"PackageKit 正屏蔽着 zypper。这发生在若您已运行了一个使用 PackageKit 的升级挂"
+"件或其他软件管理程序时。"
 
 #: src/Zypper.cc:93
 msgid ""
 "We can ask PackageKit to interrupt the current action as soon as possible, "
 "but it depends on PackageKit how fast it will respond to this request."
-msgstr "我们已请求 PackageKit 尽快结束当前作业，但何时结束取决于 PackageKit "
-"对此请求的反应速度。"
+msgstr ""
+"我们已请求 PackageKit 尽快结束当前作业，但何时结束取决于 PackageKit 对此请求"
+"的反应速度。"
 
 #: src/Zypper.cc:96
 msgid "Ask PackageKit to quit?"
@@ -1277,7 +1284,7 @@ msgstr "PackageKit 仍在运行（或许正忙）。"
 msgid "Try again?"
 msgstr "重试吗？"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "意外异常。"
 
@@ -1307,12 +1314,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "%s 选项在此无效，正在忽略。"
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "无选项程序参数： "
 
@@ -1323,10 +1330,9 @@ msgid ""
 "the repository provider or check their web site. Many providers maintain a "
 "web page showing the fingerprints of the GPG keys they are using."
 msgstr ""
-"GPG "
-"公钥可通过它的指纹清楚地识别。不要依赖密钥名称。如果您不确定当前的密钥是否可"
-"信，清询问仓库提供者或者查看它的网站。"
-"很多提供者都会维护一个网页用来显示他们正在使用的 GPG 密钥的指纹。"
+"GPG 公钥可通过它的指纹清楚地识别。不要依赖密钥名称。如果您不确定当前的密钥是"
+"否可信，清询问仓库提供者或者查看它的网站。很多提供者都会维护一个网页用来显示"
+"他们正在使用的 GPG 密钥的指纹。"
 
 #: src/callbacks/keyring.h:38
 msgid ""
@@ -1334,7 +1340,8 @@ msgid ""
 "after the data were signed. Accepting data with no, wrong or unknown "
 "signature can lead to a corrupted system and in extreme cases even to a "
 "system compromise."
-msgstr "数据签名可让用户验证签名后的数据是否被篡改。使用无签名、签名校验有误或未知签"
+msgstr ""
+"数据签名可让用户验证签名后的数据是否被篡改。使用无签名、签名校验有误或未知签"
 "署方的数据可能造成系统毁损，极端情况下甚至导致系统被入侵。"
 
 #. translator: %1% is a file name
@@ -1349,7 +1356,8 @@ msgstr "文件 '%1%' 是软件源的主索引文件。它确保了整个软件�
 msgid ""
 "We can't verify that no one meddled with this file, so it might not be "
 "trustworthy anymore! You should not continue unless you know it's safe."
-msgstr "我们无法核实该文件是否为外界所干涉，因而该文件或许已不再可信！除非您知道它是"
+msgstr ""
+"我们无法核实该文件是否为外界所干涉，因而该文件或许已不再可信！除非您知道它是"
 "安全的，否则不应继续使用它。"
 
 #: src/callbacks/keyring.h:57
@@ -1357,7 +1365,8 @@ msgid ""
 "This file was modified after it has been signed. This may have been a "
 "malicious change, so it might not be trustworthy anymore! You should not "
 "continue unless you know it's safe."
-msgstr "该文件签名后被篡改过。那或许是一次恶意的篡改，因而该文件或许已不再可信！除非"
+msgstr ""
+"该文件签名后被篡改过。那或许是一次恶意的篡改，因而该文件或许已不再可信！除非"
 "您知道它是安全的，否则不应继续使用它。"
 
 #: src/callbacks/keyring.h:59
@@ -1551,8 +1560,9 @@ msgstr "文件 '%1%'（来自软件源 '%2%'）的签名校验失败。"
 msgid ""
 "The rpm database seems to contain old V3 version gpg keys which are "
 "meanwhile obsolete and considered insecure:"
-msgstr "该 RPM 数据库似乎含有旧的 V3 版本 GPG "
-"密钥。这种密钥已被淘汰因此被公认为不安全："
+msgstr ""
+"该 RPM 数据库似乎含有旧的 V3 版本 GPG 密钥。这种密钥已被淘汰因此被公认为不安"
+"全："
 
 #: src/callbacks/keyring.h:445
 #, boost-format
@@ -1564,7 +1574,8 @@ msgstr "查看密钥调用 '%1%' 详情。"
 msgid ""
 "Unless you believe the key in question is still in use, you can remove it "
 "from the rpm database calling '%1%'."
-msgstr "除非您确信该问题密钥仍在使用，否则您可调用 '%1%' 从 RPM 数据中移除该密钥。"
+msgstr ""
+"除非您确信该问题密钥仍在使用，否则您可调用 '%1%' 从 RPM 数据中移除该密钥。"
 
 #. translator: %1% is the number of keys, %2% the name of a repository
 #: src/callbacks/keyring.h:468
@@ -1578,7 +1589,8 @@ msgid ""
 "Those additional keys are usually used to sign packages shipped by the "
 "repository. In order to validate those packages upon download and "
 "installation the new keys will be imported into the rpm database."
-msgstr "这些额外密钥通常用于签名仓库分发的软件包。为了在下载和安装时验证这些软件包，"
+msgstr ""
+"这些额外密钥通常用于签名仓库分发的软件包。为了在下载和安装时验证这些软件包，"
 "这些新的密钥会被导入到 rpm 数据库。"
 
 #: src/callbacks/keyring.h:474
@@ -1620,7 +1632,8 @@ msgstr ""
 msgid ""
 "Accepting packages with wrong checksums can lead to a corrupted system and "
 "in extreme cases even to a system compromise."
-msgstr "使用校验码错误的软件包可能造成系统毁损，极端情况下甚至会导致系统被入侵。"
+msgstr ""
+"使用校验码错误的软件包可能造成系统毁损，极端情况下甚至会导致系统被入侵。"
 
 #: src/callbacks/keyring.h:548
 #, boost-format
@@ -1920,8 +1933,9 @@ msgid ""
 "Checking for file conflicts requires not installed packages to be downloaded "
 "in advance in order to access their file lists. See option '%1%' in the "
 "zypper manual page for details."
-msgstr "检查文件冲突需要先下载尚未安装的软件包以访问其文件列表。细节请参考 zypper "
-"手册页中的 '%1%' 选项。"
+msgstr ""
+"检查文件冲突需要先下载尚未安装的软件包以访问其文件列表。细节请参考 zypper 手"
+"册页中的 '%1%' 选项。"
 
 #. TranslatorExplanation %1%(number of conflicts); detailed list follows
 #: src/callbacks/rpm.h:523
@@ -1940,7 +1954,8 @@ msgid ""
 "File conflicts happen when two packages attempt to install files with the "
 "same name but different contents. If you continue, conflicting files will be "
 "replaced losing the previous content."
-msgstr "当两个软件包试图安装同名但内容不同的文件时就会产生文件冲突。若您继续，将替换"
+msgstr ""
+"当两个软件包试图安装同名但内容不同的文件时就会产生文件冲突。若您继续，将替换"
 "冲突的文件，并覆盖之前的内容。"
 
 #. TranslatorExplanation This text is a progress display label e.g. "Installing: foo-1.1.2 [42%]"
@@ -2014,25 +2029,31 @@ msgid "Commands:"
 msgstr "命令："
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "显示详细安装摘要。"
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "软件包类型 (%1%)。"
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr "'尽量'更新，更新到比最新版本低一些的版本也是可以接受的。"
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "只考虑影响软件包管理器自身的补丁。"
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2092,8 +2113,9 @@ msgid ""
 "You are about to do a distribution upgrade with all enabled repositories. "
 "Make sure these repositories are compatible before you continue. See '%s' "
 "for more information about this command."
-msgstr "您正要使用全部已启用软件源进行发行版升级。继续前请确保这些源之间相互兼容。"
-"参考 '%s' 获知更多关于此命令的信息。"
+msgstr ""
+"您正要使用全部已启用软件源进行发行版升级。继续前请确保这些源之间相互兼容。参"
+"考 '%s' 获知更多关于此命令的信息。"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/help.cc:22
@@ -2105,7 +2127,7 @@ msgstr "zypper [--全局选项] <命令> [--命令选项] [参数]"
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <子命令> [--命令选项] [参数]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "打印 zypper 帮助"
 
@@ -2149,16 +2171,17 @@ msgid ""
 "Called as '%1%', it restricts the command to just look for packages "
 "supporting available hardware, languages or filesystems. Useful after having "
 "added e.g. new hardware or driver repos."
-msgstr "调用 ‘%1%’ "
-"将限制该命令仅查找支持可用硬件、语言或文件系统的软件包。用于例如添加了新硬件"
-"或驱动软件源后。"
+msgstr ""
+"调用 ‘%1%’ 将限制该命令仅查找支持可用硬件、语言或文件系统的软件包。用于例如添"
+"加了新硬件或驱动软件源后。"
 
 #. translators: command description
 #: src/commands/inrverify.cc:101
 msgid ""
 "Check whether dependencies of installed packages are satisfied and suggest "
 "to install or remove packages in order to repair the dependency problems."
-msgstr "检查已安装软件包的依赖关系是否满足，并提供安装或移除软件包的建议以修复依赖问"
+msgstr ""
+"检查已安装软件包的依赖关系是否满足，并提供安装或移除软件包的建议以修复依赖问"
 "题。"
 
 #: src/commands/installremove.cc:62
@@ -2184,8 +2207,9 @@ msgstr "移除软件包。"
 msgid ""
 "Remove packages with specified capabilities. A capability is NAME[.ARCH]"
 "[OP<VERSION>], where OP is one of <, <=, =, >=, >."
-msgstr "移除具有指定功能的软件包。功能的定义为\"名称[.架构][操作符 <版本>]\"，"
-"操作符为 <, <=, =, >=, > 其中之一。"
+msgstr ""
+"移除具有指定功能的软件包。功能的定义为\"名称[.架构][操作符 <版本>]\"，操作符"
+"为 <, <=, =, >=, > 其中之一。"
 
 #: src/commands/installremove.cc:104 src/commands/installremove.cc:234
 #: src/utils/messages.cc:53
@@ -2231,8 +2255,8 @@ msgid ""
 "location. A capability is NAME[.ARCH][OP<VERSION>], where OP is one of <, "
 "<=, =, >=, >."
 msgstr ""
-"安装具有指定功能的软件包或者指定位置的 RPM 文件。功能的定义为\"名称[.架构]"
-"[操作符<版本>]\"，操作符为 <, <=, =, >=, > 其中之一。"
+"安装具有指定功能的软件包或者指定位置的 RPM 文件。功能的定义为\"名称[.架构][操"
+"作符<版本>]\"，操作符为 <, <=, =, >=, > 其中之一。"
 
 #. translators: --from <ALIAS|#|URI>
 #: src/commands/installremove.cc:195 src/commands/utils/download.cc:170
@@ -2244,7 +2268,8 @@ msgstr "从指定软件源选择软件包。"
 msgid ""
 "Allows one to replace a newer item with an older one. Handy if you are doing "
 "a rollback. Unlike --force it will not enforce a reinstall."
-msgstr "允许使用旧软件包替换新软件包。 若您正在做回滚那么该选项超有用。不像 --force "
+msgstr ""
+"允许使用旧软件包替换新软件包。 若您正在做回滚那么该选项超有用。不像 --force "
 "那样，它不强行重装。"
 
 #: src/commands/installremove.cc:203
@@ -2306,22 +2331,22 @@ msgstr ""
 "的目的就是将依赖软件包替换为其正式更新版本。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [选项]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "列出可获得的补丁。"
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "列出全部可应用的补丁。"
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "列出全部补丁而不仅是可应用补丁。"
 
@@ -2372,49 +2397,53 @@ msgid ""
 msgstr "通过语言代码指定应支持的区域。调用 ‘%s’ 获取全部可用区域列表。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [选项] [区域] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "列出所请求区域 (语言代码)。"
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "列出所请求区域和相关软件包。"
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "显示相关软件包。"
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "列出全部可用区域。"
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr "忽略位置相关参数因为 — 全部参数均已提供。"
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "要显示详情的区域。"
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr "获取语言代码 ‘en’ 下全部有自己国别代码的区域，排除后备语言代码 ‘en’："
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr "获取语言代码 ‘en’ 下的全部区域，不管有没有国别代码："
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "获取精确匹配参数的区域： "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "获取 ‘de’ 和 ‘en’ 语言可用的软件包列表："
 
@@ -2459,9 +2488,9 @@ msgid ""
 "have their KIND: string prepended (e.g. 'patch:foo') or use the commands --"
 "type option."
 msgstr ""
-"LOCKSPEC 的格式为“[KIND:]NAME[ OP EDITION]”，其中 NAME 也可以是使用 * 和 ? "
-"通配符的 glob 模式。非软件包类型可以在前面追加 KIND: "
-"字符串（例如“patch:foo”），或使用命令 --type 选项。"
+"LOCKSPEC 的格式为“[KIND:]NAME[ OP EDITION]”，其中 NAME 也可以是使用 * 和 ? 通"
+"配符的 glob 模式。非软件包类型可以在前面追加 KIND: 字符串（例"
+"如“patch:foo”），或使用命令 --type 选项。"
 
 #: src/commands/locks/add.cc:36
 msgid ""
@@ -2469,8 +2498,8 @@ msgid ""
 "optionally restrict the lock to match a specific edition or edition range "
 "using =, <, <=, >, >= or != followed an EDITION."
 msgstr ""
-"基本格式将锁定匹配项的所有版本。您可以选择性地使用 =、<、<=、>、>= 或 != "
-"后接 EDITION，将锁定限制为匹配特定的版本或版本范围。"
+"基本格式将锁定匹配项的所有版本。您可以选择性地使用 =、<、<=、>、>= 或 != 后"
+"接 EDITION，将锁定限制为匹配特定的版本或版本范围。"
 
 #: src/commands/locks/add.cc:46
 msgid "Restrict the lock to the specified repository."
@@ -2519,11 +2548,11 @@ msgstr[0] "已移除 %lu 锁定。"
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "名称"
 
@@ -2533,8 +2562,8 @@ msgstr "匹配"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "类型"
@@ -2542,7 +2571,7 @@ msgstr "类型"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "软件源"
@@ -2611,7 +2640,8 @@ msgstr "移除一个软件包锁定。"
 msgid ""
 "Remove a package lock. Specify the lock to remove by its number obtained "
 "with '%1%' or by package name."
-msgstr "移除一个软件包锁定。通过由 '%1%' 获取的编号或软件包名称指定要移除的锁定。"
+msgstr ""
+"移除一个软件包锁定。通过由 '%1%' 获取的编号或软件包名称指定要移除的锁定。"
 
 #: src/commands/locks/remove.cc:45
 msgid "Remove only locks with specified repository."
@@ -2802,8 +2832,9 @@ msgid ""
 "Install the packages even if they replace files from other, already "
 "installed, packages. Default is to treat file conflicts as an error. --"
 "download-as-needed disables the fileconflict check."
-msgstr "即使新软件包会替换其它已安装软件包的文件 也安装它们。默认是将文件冲突视为错误"
-"。--download-as-needed 会禁用文件冲突检查。"
+msgstr ""
+"即使新软件包会替换其它已安装软件包的文件 也安装它们。默认是将文件冲突视为错"
+"误。--download-as-needed 会禁用文件冲突检查。"
 
 #. translators: -y, --no-confirm
 #: src/commands/optionsets.cc:291
@@ -2866,7 +2897,8 @@ msgstr "安装全部可用且需要的补丁。"
 msgid ""
 "When updating the affected/vulnerable packages described by a patch, zypper "
 "always aims for the latest available version."
-msgstr "当更新补丁所描述的受影响/带漏洞软件包时，zypper 始终采用最新的可用版本。"
+msgstr ""
+"当更新补丁所描述的受影响/带漏洞软件包时，zypper 始终采用最新的可用版本。"
 
 #: src/commands/patch.cc:50
 msgid "Skip needed patches which do not apply without conflict."
@@ -2896,8 +2928,9 @@ msgstr "检查补丁。"
 msgid ""
 "Display stats about applicable patches. The command returns 100 if needed "
 "patches were found, 101 if there is at least one needed security patch."
-msgstr "显示可应用补丁统计。该命令若找到了所需补丁则会返回 100，"
-"若有至少一个所需的安全补丁则会返回 101。"
+msgstr ""
+"显示可应用补丁统计。该命令若找到了所需补丁则会返回 100，若有至少一个所需的安"
+"全补丁则会返回 101。"
 
 #. translators: command synopsis; do not translate the command 'name (abbreviations)' or '-option' names
 #: src/commands/ps.cc:27
@@ -2917,7 +2950,8 @@ msgid ""
 "Create a short table not showing the deleted files. Given twice, show only "
 "processes which are associated with a system service. Given three times, "
 "list the associated system service names only."
-msgstr "创建一个不显示已删除文件的简短表格。给出两次仅显示关联着系统服务的进程。给出"
+msgstr ""
+"创建一个不显示已删除文件的简短表格。给出两次仅显示关联着系统服务的进程。给出"
 "三次则仅列出关联的系统服务名称。"
 
 #. translators: --print <format>
@@ -2927,7 +2961,8 @@ msgid ""
 "For each associated system service print <format> on the standard output, "
 "followed by a newline. Any '%s' directive in <format> is replaced by the "
 "system service name."
-msgstr "每个相关系统服务均会输出 <format> 至标准输出，并另起一行。<format> 中的所有 "
+msgstr ""
+"每个相关系统服务均会输出 <format> 至标准输出，并另起一行。<format> 中的所有 "
 "‘%s’ 参数均会被替换为系统服务名称。"
 
 #. translators: -d, --debugFile <path>
@@ -2970,7 +3005,7 @@ msgid "Command"
 msgstr "命令"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "服务"
 
@@ -3003,8 +3038,9 @@ msgid ""
 "Note: Not running as root you are limited to searching for files you have "
 "permission to examine with the system stat(2) function. The result might be "
 "incomplete."
-msgstr "注意：不使用根用户运行您只能搜索现有用户有权限使用系统 stat(2) "
-"函数检测的文件。结果可能不完整。"
+msgstr ""
+"注意：不使用根用户运行您只能搜索现有用户有权限使用系统 stat(2) 函数检测的文"
+"件。结果可能不完整。"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/query/info.cc:19
@@ -3024,9 +3060,8 @@ msgid ""
 "partially matching use option '--match-substrings' or use wildcards (*?) in "
 "name."
 msgstr ""
-"显示指定软件包的详细信息。 默认显示精确匹配给定名称的软件包。 "
-"要也获取部分匹配的软件包请使用选项 '--match-substrings' 或在名称中使用通配符 "
-"(*?)。"
+"显示指定软件包的详细信息。 默认显示精确匹配给定名称的软件包。 要也获取部分匹"
+"配的软件包请使用选项 '--match-substrings' 或在名称中使用通配符 (*?)。"
 
 #: src/commands/query/info.cc:25
 msgid ""
@@ -3137,120 +3172,120 @@ msgid "Show detailed information for products."
 msgstr "显示产品的详细信息。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [选项] [软件源] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "列出全部可用软件包。"
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "列出指定软件源中可用的全部软件包。"
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr "显示解析器自动选择且已安装的软件包。"
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr "显示用户明确选择且已安装的软件包。"
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr "显示并非由任何储存库提供的已安装软件包。"
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr "显示孤立的系统软件包（没有储存库和候选更新软件包）。"
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "显示建议的软件包。"
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "显示推荐的软件包。"
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "显示不再需要的软件包。"
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "按软件包名称排序列表。"
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "按软件源排序列表。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [软件源] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "列出全部可用补丁。"
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "列出指定软件源中全部可用的补丁。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [选项] [软件源] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "列出全部可用软件集。"
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "列出指定软件源中全部可用的软件集。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [选项] [软件源] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "列出全部可用产品。"
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "列出指定软件源中全部可用的产品。"
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr "仅 XML 输出：直接显示产品文件中找到的 XML 标签。"
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "当未指定全局选项 %2% 时，%1% 选项无法单独生效。"
@@ -3271,8 +3306,9 @@ msgstr "添加一个新软件源。"
 msgid ""
 "Add a repository to the system. The repository can be specified by its URI "
 "or can be read from specified .repo file (even remote)."
-msgstr "向系统中添加一个软件源。软件源可通过其 URI 指定也可从指定的 .repo "
-"文件（甚至是远程）中读取。"
+msgstr ""
+"向系统中添加一个软件源。软件源可通过其 URI 指定也可从指定的 .repo 文件（甚至"
+"是远程）中读取。"
 
 #: src/commands/repos/add.cc:40
 msgid "Just another means to specify a .repo file to read."
@@ -3290,12 +3326,12 @@ msgstr "不探测 URI，稍后刷新时再探测。"
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr "源类型始终都是自动检测的。该选项已被忽略。"
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "无法同时使用 %s 和 %s。正在使用 %s 设置。"
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr "如果只用一个参数，那么它必须是一个指向 .repo 文件的 URI。"
@@ -3337,111 +3373,115 @@ msgstr "清理原始元数据缓存。"
 msgid "Clean both metadata and package caches."
 msgstr "清理元数据和软件包缓存。"
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "别名"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "URI"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "已启用"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "GPG 检查"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "优先级"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "自动刷新"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "开"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "关"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "保留软件包"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "GPG 密钥 URI"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "路径前缀"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "父服务"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "关键字"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "软件源信息路径"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "MD 缓存路径"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [选项] [软件源] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "列出全部已定义的软件源。"
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "将全部已定义的软件源导出为一个本地 .repo 文件。"
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "读取软件源出错："
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "无法打开 %s 进行写操作。"
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "或许您没有写入权限？"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "已成功导出软件源到 %s。"
@@ -3449,20 +3489,20 @@ msgstr "已成功导出软件源到 %s。"
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "刷新"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "保留"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "未定义软件源。"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr "请使用 'zypper addrepo' 命令添加一个或更多软件源。"
 
@@ -3509,7 +3549,8 @@ msgstr "刷新全部软件源。"
 msgid ""
 "Refresh repositories specified by their alias, number or URI. If none are "
 "specified, all enabled repositories will be refreshed."
-msgstr "刷新通过别名、编号或 URI 指定的软件源。若未指定则刷新全部启用的软件源。"
+msgstr ""
+"刷新通过别名、编号或 URI 指定的软件源。若未指定则刷新全部启用的软件源。"
 
 #. translators: -f, --force
 #: src/commands/repos/refresh.cc:80 src/commands/services/refresh.cc:113
@@ -3565,7 +3606,7 @@ msgstr "全局选项 '%s' 在此无效。"
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "若使用 '%s' 则不允许使用参数。"
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "指定的软件源： "
 
@@ -3574,7 +3615,7 @@ msgstr "指定的软件源： "
 msgid "Refreshing repository '%s'."
 msgstr "正在刷新软件源 '%s'。"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "正在扫描已禁用软件源 '%s' 的内容。"
@@ -3584,7 +3625,7 @@ msgstr "正在扫描已禁用软件源 '%s' 的内容。"
 msgid "Skipping disabled repository '%s'"
 msgstr "正在跳过已禁用的软件源 '%s'"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "由于以上错误，正在跳过软件源 '%s' 。"
@@ -3611,7 +3652,7 @@ msgstr "请使用 '%s' 或者 '%s' 命令添加或启用软件源。"
 msgid "Could not refresh the repositories because of errors."
 msgstr "由于若干错误无法刷新软件源。"
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "由于某处出错未刷新部分软件源。"
 
@@ -3657,19 +3698,20 @@ msgstr "通过别名、编号或 URI 都未找到软件源 '%s'。"
 msgid ""
 "Cannot change alias of '%s' repository. The repository belongs to service "
 "'%s' which is responsible for setting its alias."
-msgstr "无法修改软件源 '%s' 的别名。该软件源属于服务 '%s' ，该服务负责设置其别名。"
+msgstr ""
+"无法修改软件源 '%s' 的别名。该软件源属于服务 '%s' ，该服务负责设置其别名。"
 
 #: src/commands/repos/rename.cc:43
 #, c-format, boost-format
 msgid "Repository '%s' renamed to '%s'."
 msgstr "软件源 '%s' 已重命名为 '%s' 。"
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "已存在名为 '%s' 的软件源。请使用其它别名。"
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "修改软件源时出错："
 
@@ -3943,8 +3985,9 @@ msgstr "搜索匹配任意给定搜索字符串的软件包。"
 msgid ""
 "* and ? wildcards can also be used within search strings. If a search string "
 "is enclosed in '/', it's interpreted as a regular expression."
-msgstr "* 和 ? 通配符也可以用于搜索字符串中。 若搜索字符串以 '/' "
-"结尾，它将被解释为一个正则表达式。"
+msgstr ""
+"* 和 ? 通配符也可以用于搜索字符串中。 若搜索字符串以 '/' 结尾，它将被解释为一"
+"个正则表达式。"
 
 #. translators: --match-substrings
 #: src/commands/search/search.cc:105
@@ -4094,28 +4137,29 @@ msgstr "分行显示每个软件源中的每个可用版本。"
 msgid ""
 "Like --details, with additional information where the search has matched "
 "(useful for search in dependencies)."
-msgstr "像 --details 一样，带有搜索匹配到的位置的额外信息 "
-"（在依赖关系中搜索时很有用）。"
+msgstr ""
+"像 --details 一样，带有搜索匹配到的位置的额外信息 （在依赖关系中搜索时很有"
+"用）。"
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "已禁用指定软件源 '%s'。"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "未找到匹配项。"
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "初始化或执行搜索查询出现问题"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "请参考以上消息汲取灵感。"
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "以 root 身份运行 'zypper refresh' 或许会解决该问题。"
 
@@ -4205,7 +4249,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "检索服务 '%s' 的软件源索引文件出现问题："
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "由于以上错误，正在跳过服务 '%s' 。"
@@ -4224,22 +4268,26 @@ msgstr "正在移除服务 '%s'："
 msgid "Service '%s' has been removed."
 msgstr "已移除服务 '%s'。"
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [选项]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "列出全部已定义服务。"
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "列出已定义的服务。"
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr "未定义服务。请用 '%s' 命令添加一个或多个服务。"
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4576,8 +4624,9 @@ msgid ""
 "The default location where rpm installs source packages to is '%1%', but the "
 "value can be changed in your local rpm configuration. In case of doubt try "
 "executing '%2%'."
-msgstr "rpm 安装源代码软件包的默认位置是 '%1%'，但该值可在您的本地 rpm 配置中修改。"
-"存疑请尝试执行 '%2%'。"
+msgstr ""
+"rpm 安装源代码软件包的默认位置是 '%1%'，但该值可在您的本地 rpm 配置中修改。存"
+"疑请尝试执行 '%2%'。"
 
 #. translators: -d, --build-deps-only
 #: src/commands/sourceinstall.cc:48
@@ -4775,7 +4824,8 @@ msgstr "要更新已安装的产品请使用 '%s'。"
 msgid ""
 "Zypper does not keep track of installed source packages. To install the "
 "latest source package and its build dependencies, use '%s'."
-msgstr "Zypper 不会追踪已安装的源软件包。要安装最新的源软件包和它的编译依赖，请使用 "
+msgstr ""
+"Zypper 不会追踪已安装的源软件包。要安装最新的源软件包和它的编译依赖，请使用 "
 "'%s'。"
 
 #: src/commands/update.cc:83
@@ -4806,9 +4856,9 @@ msgid ""
 "packages; for non-root users $XDG_CACHE_HOME/zypp/packages), but this can be "
 "changed by using the global --pkg-cache-dir option."
 msgstr ""
-"下载命令行指定的 RPM 到本地文件夹。 默认将软件包下载到 libzypp "
-"软件包缓存文件夹 (/var/cache/zypp/packages; 非 root 用户则是 $XDG_CACHE_HOME/"
-"zypp/packages)，但可使用全局的 --pkg-cache-dir 选项修改。"
+"下载命令行指定的 RPM 到本地文件夹。 默认将软件包下载到 libzypp 软件包缓存文件"
+"夹 (/var/cache/zypp/packages; 非 root 用户则是 $XDG_CACHE_HOME/zypp/"
+"packages)，但可使用全局的 --pkg-cache-dir 选项修改。"
 
 #. translators: command description
 #: src/commands/utils/download.cc:151
@@ -4826,7 +4876,8 @@ msgstr ""
 msgid ""
 "Download all versions matching the commandline arguments. Otherwise only the "
 "best version of each matching package is downloaded."
-msgstr "下载匹配命令行参数的全部版本。否则将仅下载每个匹配到的软件包的最佳版本。"
+msgstr ""
+"下载匹配命令行参数的全部版本。否则将仅下载每个匹配到的软件包的最佳版本。"
 
 #. translators: Label text; is followed by ': cmdline argument'
 #: src/commands/utils/download.cc:236
@@ -4891,8 +4942,8 @@ msgid ""
 "zypp/zypp.conf:multiversion.kernels which can be given as <version>, latest(-"
 "N), running, oldest(+N)."
 msgstr ""
-"根据 /etc/zypp/zypp.conf:multiversion.kernels 中要保留的内核列表（可能会以 "
-"<版本>、latest(-N)、running、oldest(+N) 指定）自动移除安装的内核。"
+"根据 /etc/zypp/zypp.conf:multiversion.kernels 中要保留的内核列表（可能会以 <"
+"版本>、latest(-N)、running、oldest(+N) 指定）自动移除安装的内核。"
 
 #: src/commands/utils/purge-kernels.cc:51
 msgid "Preparing to purge obsolete kernels..."
@@ -5133,15 +5184,15 @@ msgstr "%s 较 %s 旧"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "版本"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "架构"
 
@@ -5274,13 +5325,13 @@ msgstr "（空）"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "依赖关系"
 
@@ -5317,7 +5368,7 @@ msgid "Flavor"
 msgstr "风格"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "是基础"
 
@@ -5570,94 +5621,95 @@ msgstr[0] "%1% 个软件源"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "正在检查是否需要刷新 %s 的元数据"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "软件源 '%s' 是最新的。"
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "已推延了对 '%s' 的更新检查。"
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "正在强制执行原始元数据刷新"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "正在检索软件源 '%s' 的元数据"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "您想要永久禁用软件源 %s 吗？"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "禁用软件源 '%s' 时出错。"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "从 '%s'检索文件时出现问题。"
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "请参考以上错误消息汲取灵感。"
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "没有为 '%s' 定义 URI。"
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
-msgstr "请添加一个或者更多的基础 URI 项 (baseurl=URI) 至 %s（针对软件源 '%s'）。"
+msgstr ""
+"请添加一个或者更多的基础 URI 项 (baseurl=URI) 至 %s（针对软件源 '%s'）。"
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "该软件源没有定义别名。"
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "软件源 '%s' 无效。"
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr "请检查此软件源定义的 URI 是否指向了一个有效的软件源。"
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "检索 '%s' 元数据时出错："
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "正在强制构建软件源缓存"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "解析 '%s' 元数据出错："
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5665,44 +5717,44 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 "这可能是由源中无效的元数据或者元数据解析器的故障导致的。若是后一种情况，或者"
-"存疑，请参考 http://zh.opensuse.org/SDB:Zypper_疑难解答 "
-"的指南填写一份故障报告"
+"存疑，请参考 http://zh.opensuse.org/SDB:Zypper_疑难解答 的指南填写一份故障报"
+"告"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "在本地缓存中未找到 '%s' 的软件源元数据。"
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "构建缓存出错："
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "未能通过别名、编号或 URI 找到软件源 '%s'。"
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "使用 '%s' 获取已定义软件源的列表。"
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "正在忽略已禁用的软件源 '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr "全局选项 '%s' 可用来临时启用软件源。"
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "正在忽略软件源 '%s'，因为启用了 '%s' 选项。"
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "正在暂时性启用软件源 '%s'。"
@@ -5710,330 +5762,330 @@ msgstr "正在暂时性启用软件源 '%s'。"
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr "软件源 '%s' 已经过时。您可以 root 身份运行 'zypper refresh' 更新它。"
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
-msgstr "需要构建软件源 '%s' 的元数据缓存。您可以 root 身份运行 'zypper refresh' "
-"执行此操作。"
+msgstr ""
+"需要构建软件源 '%s' 的元数据缓存。您可以 root 身份运行 'zypper refresh' 执行"
+"此操作。"
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "软件源 '%s' 保持禁用。"
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "正在初始化目标"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "目标初始化失败："
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "正在清理 '%s' 的元数据缓存。"
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "正在清理 '%s' 的原始元数据缓存。"
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "正在保留 %s 的原始元数据缓存 '%s'。"
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "正在为 '%s' 清理软件包。"
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "由于某处出错无法清理软件源 '%s' 。"
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "正在清理已安装软件包缓存。"
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "由于某处出错无法清理已安装软件包缓存。"
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "由于若干错误无法清理软件源。"
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "由于某处出错未清理部分软件源。"
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "指定软件源清理完毕。"
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "全部软件源清理完毕。"
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr "这是一个可变只读介质 (CD/DVD)，正在禁用自动刷新。"
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "无效的软件源别名：'%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr "无法确定软件源类型。请检查定义的 URI (见下) 是否指向了有效的软件源："
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "未能在给定位置找到有效的软件源："
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "从指定 URI 传输软件源数据出现问题："
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "请检查是否可访问指定的 URI。"
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "添加软件源时出现未知问题："
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr "软件源 '%1%' 的配置中禁用了 GPG 检查。无法校验完整性和软件包的出处。"
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "成功添加了软件源 '%s'"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "正在从介质 '%s' 读取数据"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "从介质 '%s' 读取数据时出现问题"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "请检查您的安装介质是否有效和可读。"
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "推迟从 '%s' 介质读取数据直至下次刷新。"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "正在从介质 '%s' 读取数据"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "从介质 '%s' 读取数据时出现问题"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "请检查您的安装介质是否有效和可读。"
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "访问指定 URI 处文件时出现问题"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "请检查该 URI 是否有效且可访问。"
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "解析指定 URI 处文件时出现问题"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "它是一个 .repo 文件吗？"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "尝试读取指定 URI 处文件时遇到问题"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "在文件中发现了未定义别名的软件源，正在跳过。"
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "软件源 '%s' 未定义 URI，正在跳过。"
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "已移除软件源 '%s'。"
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "未变动软件源 '%s' 的优先级 (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "已成功启用软件源 '%s'。"
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "已成功禁用软件源 '%s'。"
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "已启用自动刷新软件源 '%s'。"
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "已禁用自动刷新软件源 '%s'。"
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "已为软件源 '%s' 启用 RPM 文件缓存。"
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "已为软件源 '%s' 禁用 RPM 文件缓存。"
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "已对软件源 '%s' 启用 GPG 检查。"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "已对软件源 '%s' 禁用 GPG 检查。"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "软件源 '%s' 的优先级已设为 %d。"
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "软件源 '%s' 名称已设为 '%s'。"
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "软件源 '%s' 无需修改。"
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "软件源 %s 未变动。"
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "正在加载软件源数据..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
 msgstr "未定义软件源。只能操作已安装的可解析项。不能安装新东西。"
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "正在检索软件源 '%s' 的数据..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "未缓存软件源 '%s'。正在缓存中..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "从 '%s' 加载数据出现问题"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "无法刷新软件源 '%s'。正在使用旧缓存。"
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "由于某处错误未加载来自 '%s' 的可解析项。"
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "自 %2% 起，软件源 \"%1%\" 元数据已失效。"
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "这么做前请先尝试 '%s'，甚至在那之前先尝试一下 '%s'。"
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
 "not solve the issue, it could be that you are using a broken mirror or the "
 "server has actually discontinued to support the repository."
 msgstr ""
-"软件源元数据已失效：请确认已启用 \"autorefresh\" (zypper lr)，"
-"否则需手动更新软件源 (zypper "
-"ref)。如果这样无法解决问题，则可能是因为您使用的镜像已损坏或服务器实际上已停"
-"止支持该软件源。"
+"软件源元数据已失效：请确认已启用 \"autorefresh\" (zypper lr)，否则需手动更新"
+"软件源 (zypper ref)。如果这样无法解决问题，则可能是因为您使用的镜像已损坏或服"
+"务器实际上已停止支持该软件源。"
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "正在读取已安装的软件包..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "读取已安装软件包时发生问题："
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' 貌似是一个 RPM 文件，将尝试下载之。"
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "指定为 '%s' 的 RPM 文件有问题，正在跳过。"
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "读取 %s 的 RPM 头部出现问题。它是一个 RPM 文件吗？"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "纯 RPM 文件缓存"
 
@@ -6041,25 +6093,25 @@ msgstr "纯 RPM 文件缓存"
 msgid "System Packages"
 msgstr "系统软件包"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "未找到所需补丁。"
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "未找到软件集。"
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "未找到软件包。"
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "内部名称"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "未找到产品。"
 
@@ -6201,8 +6253,9 @@ msgstr "明确选择 DownloadAsNeeded 还会选择 classic_rpmtrans 后端。"
 msgid ""
 "Check for running processes using deleted libraries is disabled in "
 "zypper.conf. Run '%s' to check manually."
-msgstr "检查使用了已删除函数库的运行中进程的功能在 zypper.conf 中禁用了。运行 '%s' "
-"手动检查。"
+msgstr ""
+"检查使用了已删除函数库的运行中进程的功能在 zypper.conf 中禁用了。运行 '%s' 手"
+"动检查。"
 
 #: src/solve-commit.cc:636
 msgid "Skip check:"
@@ -6214,7 +6267,8 @@ msgid ""
 "There are running programs which still use files and libraries deleted or "
 "updated by recent upgrades. They should be restarted to benefit from the "
 "latest updates. Run '%1%' to list these programs."
-msgstr "某些运行中的程序仍在使用被最近升级所删除或更新的文件和函数库。应重启它们使其"
+msgstr ""
+"某些运行中的程序仍在使用被最近升级所删除或更新的文件和函数库。应重启它们使其"
 "也能从最新更新中获益。运行 ‘%1%’ 列出这些程序。"
 
 #: src/solve-commit.cc:657
@@ -6246,7 +6300,8 @@ msgstr "正在解决软件包依赖关系..."
 msgid ""
 "Some of the dependencies of installed packages are broken. In order to fix "
 "these dependencies, the following actions need to be taken:"
-msgstr "已安装软件包的某些依赖关系已损坏。要修复这些依赖关系，需要执行以下动作："
+msgstr ""
+"已安装软件包的某些依赖关系已损坏。要修复这些依赖关系，需要执行以下动作："
 
 #: src/solve-commit.cc:795
 msgid "Root privileges are required to fix broken package dependencies."
@@ -6368,7 +6423,8 @@ msgstr "已安装的某个补丁需要重启计算机。请尽快重启。"
 msgid ""
 "One of the installed patches affects the package manager itself. Run this "
 "command once more to install any other needed patches."
-msgstr "已安装的某个补丁影响到了软件包管理器自身。请再次运行此命令来安装全部其它所需"
+msgstr ""
+"已安装的某个补丁影响到了软件包管理器自身。请再次运行此命令来安装全部其它所需"
 "补丁。"
 
 #: src/solve-commit.cc:1119
@@ -6430,7 +6486,7 @@ msgid "Updatestack"
 msgstr "更新堆栈"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "补丁"
 
@@ -6453,7 +6509,7 @@ msgstr "包含的分类"
 msgid "Needed software management updates will be installed first:"
 msgstr "将首先安装所需软件管理更新："
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "未找到更新。"
 
@@ -6462,50 +6518,50 @@ msgstr "未找到更新。"
 msgid "The following updates are also available:"
 msgstr "以下更新也可用："
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "软件包更新"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "软件集更新"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "产品更新"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "当前版本"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "可用版本"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "未找到匹配的问题。"
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "已找到以下匹配问题编号的补丁："
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "已找到以下补丁描述匹配的补丁："
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr "未找到或不需要故障专区问题编号 %s 的修复。"
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "未找到或不需要 CVE 问题编号 %s 的修复。"
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "%s 的修复，问题编号为 %s 未找到或不需要。"
@@ -6719,7 +6775,8 @@ msgid ""
 "You have chosen to ignore a problem with download or installation of a "
 "package which might lead to broken dependencies of other packages. It is "
 "recommended to run '%s' after the operation has finished."
-msgstr "您选择忽略了某个软件包下载或安装时的一个问题，其可能导致损坏其它软件包的依赖"
+msgstr ""
+"您选择忽略了某个软件包下载或安装时的一个问题，其可能导致损坏其它软件包的依赖"
 "关系。推荐在操作完成后运行 '%s'。"
 
 #: src/utils/messages.cc:111
@@ -6760,8 +6817,9 @@ msgstr "输入 '%s' 获取全局选项和命令的列表。"
 msgid ""
 "In case '%1%' is not a typo it's probably not a built-in command, but "
 "provided as a subcommand or plug-in (see '%2%')."
-msgstr "若 '%1%' 不是输入错误那么它很可能不是一个内置命令，而是一个 subcommand "
-"或插件 (参考 '%2%')。"
+msgstr ""
+"若 '%1%' 不是输入错误那么它很可能不是一个内置命令，而是一个 subcommand 或插"
+"件 (参考 '%2%')。"
 
 #. translators: %1% and %2% are plug-in packages which might provide it.
 #. translators: The word 'subcommand' also refers to a zypper command and should not be translated.
@@ -6770,7 +6828,8 @@ msgstr "若 '%1%' 不是输入错误那么它很可能不是一个内置命令�
 msgid ""
 "In this case a specific package providing the subcommand needs to be "
 "installed first. Those packages are often named '%1%' or '%2%'."
-msgstr "在此情况下需要先安装提供这一 subcommand 的特定软件包。这样的软件包通常名为 "
+msgstr ""
+"在此情况下需要先安装提供这一 subcommand 的特定软件包。这样的软件包通常名为 "
 "'%1%' 或 '%2%'。"
 
 #: src/utils/misc.cc:93
@@ -6997,7 +7056,8 @@ msgstr "若其它方法均不起作用，输入 '%s' 为 '%s'，输入 '%s' 为 
 msgid ""
 "If nothing else works enter '#1' to select the 1st option, '#2' for the 2nd "
 "one, ..."
-msgstr "若没有能用的选项，输入 ‘#1’ 选择第一个选项，’#2’ 选择第二个，以此类推..."
+msgstr ""
+"若没有能用的选项，输入 ‘#1’ 选择第一个选项，’#2’ 选择第二个，以此类推..."
 
 #. TranslatorExplanation These are reasons for various failures.
 #: src/utils/prompt.h:95

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-08-05 05:59+0000\n"
 "Last-Translator: Grace Yu <grace.yu@excel-gits.com>\n"
 "Language-Team: Chinese (Taiwan) <https://l10n.opensuse.org/projects/zypper/"
@@ -276,8 +276,9 @@ msgstr "使用額外的套件庫。"
 msgid ""
 "Additionally use disabled repositories providing a specific keyword. Try '--"
 "plus-content debug' to enable repos indicating to provide debug packages."
-msgstr "另外使用提供特定關鍵字的被停用套件庫。 嘗試 '--plus-content debug' "
-"來啟用有提供除錯套件的套件庫。"
+msgstr ""
+"另外使用提供特定關鍵字的被停用套件庫。 嘗試 '--plus-content debug' 來啟用有提"
+"供除錯套件的套件庫。"
 
 #: src/Config.cc:491
 msgid "Repositories disabled, using the database of installed packages only."
@@ -506,16 +507,18 @@ msgstr "有更新候選 '%s' (適用於 '%s')，但它不符合特定版本、�
 msgid ""
 "There is an update candidate for '%s' from vendor '%s', while the current "
 "vendor is '%s'. Use '%s' to install this candidate."
-msgstr "有一個「%s」的更新候選 "
-"(來自廠商「%s」)，但當前廠商是「%s」。請使用「%s」安裝此候選。"
+msgstr ""
+"有一個「%s」的更新候選 (來自廠商「%s」)，但當前廠商是「%s」。請使用「%s」安裝"
+"此候選。"
 
 #: src/RequestFeedback.cc:133
 #, c-format, boost-format
 msgid ""
 "There is an update candidate for '%s', but it comes from a repository with a "
 "lower priority. Use '%s' to install this candidate."
-msgstr "有針對 '%s' 的更新候選，但是從優先等級較低的套件庫而來。 使用 '%s' "
-"來安裝此更新。"
+msgstr ""
+"有針對 '%s' 的更新候選，但是從優先等級較低的套件庫而來。 使用 '%s' 來安裝此更"
+"新。"
 
 #: src/RequestFeedback.cc:143
 #, c-format, boost-format
@@ -559,8 +562,9 @@ msgstr "不需要修補程式 '%s'。"
 msgid ""
 "Patch '%1%' is optional. Use '%2%' to install it, or '%3%' to include all "
 "optional patches."
-msgstr "'%s' 為選擇性修補程式。請用 '%s' 來安裝它，或使用 '%s' "
-"包括所有選擇性修補程式。"
+msgstr ""
+"'%s' 為選擇性修補程式。請用 '%s' 來安裝它，或使用 '%s' 包括所有選擇性修補程"
+"式。"
 
 #: src/RequestFeedback.cc:193
 #, c-format, boost-format
@@ -857,8 +861,9 @@ msgid ""
 msgid_plural ""
 "The following %d packages are recommended, but will not be installed because "
 "they are unwanted (were manually removed before):"
-msgstr[0] "下列 %d 個套件是推薦的，但將不會被安裝，因為它們是您不想要的 "
-"(之前已被手動移除)："
+msgstr[0] ""
+"下列 %d 個套件是推薦的，但將不會被安裝，因為它們是您不想要的 (之前已被手動移"
+"除)："
 
 #: src/Summary.cc:1169
 #, c-format, boost-format
@@ -1266,8 +1271,9 @@ msgstr ""
 msgid ""
 "We can ask PackageKit to interrupt the current action as soon as possible, "
 "but it depends on PackageKit how fast it will respond to this request."
-msgstr "我們可以要求 PackageKit 儘快中止目前的動作，但取決於 PackageKit "
-"對此要求的回應速度。"
+msgstr ""
+"我們可以要求 PackageKit 儘快中止目前的動作，但取決於 PackageKit 對此要求的回"
+"應速度。"
 
 #: src/Zypper.cc:96
 msgid "Ask PackageKit to quit?"
@@ -1281,7 +1287,7 @@ msgstr "PackageKit 仍在執行中 (可能正忙)。"
 msgid "Try again?"
 msgstr "再次嘗試嗎？"
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "非預期的例外。"
 
@@ -1311,12 +1317,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr "%s 選項在此無效，將忽略。"
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr "非選項程式引數︰ "
 
@@ -1327,9 +1333,9 @@ msgid ""
 "the repository provider or check their web site. Many providers maintain a "
 "web page showing the fingerprints of the GPG keys they are using."
 msgstr ""
-"透過指紋已清楚地識別一個 GPG "
-"公開金鑰。請不要信任金鑰名稱。若您不確定該金鑰是否可信，請詢問套件庫提供者或"
-"是查看其網站。許多提供者會維護一個網頁以顯示他們所使用的 GPG 金鑰指紋。"
+"透過指紋已清楚地識別一個 GPG 公開金鑰。請不要信任金鑰名稱。若您不確定該金鑰是"
+"否可信，請詢問套件庫提供者或是查看其網站。許多提供者會維護一個網頁以顯示他們"
+"所使用的 GPG 金鑰指紋。"
 
 #: src/callbacks/keyring.h:38
 msgid ""
@@ -1337,7 +1343,8 @@ msgid ""
 "after the data were signed. Accepting data with no, wrong or unknown "
 "signature can lead to a corrupted system and in extreme cases even to a "
 "system compromise."
-msgstr "資料簽名可讓接收者能夠驗證資料被簽名後並無變動。接受無簽名或者簽名錯誤或未知"
+msgstr ""
+"資料簽名可讓接收者能夠驗證資料被簽名後並無變動。接受無簽名或者簽名錯誤或未知"
 "的資料可能導致系統毀損，在極端情況下甚至會導致系統被入侵。"
 
 #. translator: %1% is a file name
@@ -1352,7 +1359,8 @@ msgstr "檔案「%1%」是套件庫主索引檔案。它可確保整個套件庫
 msgid ""
 "We can't verify that no one meddled with this file, so it might not be "
 "trustworthy anymore! You should not continue unless you know it's safe."
-msgstr "我們無法確認此檔案是否曾受到他人的干預，因此它可能不再可信！除非您確定該檔案"
+msgstr ""
+"我們無法確認此檔案是否曾受到他人的干預，因此它可能不再可信！除非您確定該檔案"
 "安全，否則不應繼續。"
 
 #: src/callbacks/keyring.h:57
@@ -1360,7 +1368,8 @@ msgid ""
 "This file was modified after it has been signed. This may have been a "
 "malicious change, so it might not be trustworthy anymore! You should not "
 "continue unless you know it's safe."
-msgstr "此檔案簽章後已被修改。這可能是惡意變更，因此該檔案可能不再可信！除非您確定該"
+msgstr ""
+"此檔案簽章後已被修改。這可能是惡意變更，因此該檔案可能不再可信！除非您確定該"
 "檔案安全，否則不應繼續。"
 
 #: src/callbacks/keyring.h:59
@@ -1554,8 +1563,9 @@ msgstr "檔案 '%1%' (來自套件庫 '%2%') 的簽章驗證失敗。"
 msgid ""
 "The rpm database seems to contain old V3 version gpg keys which are "
 "meanwhile obsolete and considered insecure:"
-msgstr "該 RPM 資料庫看似包含了舊的 V3 版本 GPG "
-"金鑰，這些金鑰已經廢棄，因此被認為是不安全的："
+msgstr ""
+"該 RPM 資料庫看似包含了舊的 V3 版本 GPG 金鑰，這些金鑰已經廢棄，因此被認為是"
+"不安全的："
 
 #: src/callbacks/keyring.h:445
 #, boost-format
@@ -1567,8 +1577,9 @@ msgstr "檢視呼叫「%1%」的金鑰詳細資訊。"
 msgid ""
 "Unless you believe the key in question is still in use, you can remove it "
 "from the rpm database calling '%1%'."
-msgstr "除非您相信這些有問題的金鑰仍在使用當中，否則您可以從 RPM "
-"資料庫中呼叫「%1%」移除它們。"
+msgstr ""
+"除非您相信這些有問題的金鑰仍在使用當中，否則您可以從 RPM 資料庫中呼叫「%1%」"
+"移除它們。"
 
 #. translator: %1% is the number of keys, %2% the name of a repository
 #: src/callbacks/keyring.h:468
@@ -1582,7 +1593,8 @@ msgid ""
 "Those additional keys are usually used to sign packages shipped by the "
 "repository. In order to validate those packages upon download and "
 "installation the new keys will be imported into the rpm database."
-msgstr "這些額外的金鑰通常被使用於簽署由套件庫分發的套件。為了在下載及安裝時驗證這些"
+msgstr ""
+"這些額外的金鑰通常被使用於簽署由套件庫分發的套件。為了在下載及安裝時驗證這些"
 "套件，這些新的金鑰將會被匯入到 rpm 資料庫。"
 
 #: src/callbacks/keyring.h:474
@@ -1636,10 +1648,10 @@ msgid ""
 "to unblock using this file on your own risk. Empty input will discard the "
 "file.\n"
 msgstr ""
-"然而，若您確定該檔案 (檢核碼 '%1%..') "
-"是安全且正確的，在此操作中應該要使用它，\n"
-"請輸入檢核碼的前 4 "
-"個字元來取消阻擋該檔案，並請您自負風險。空白輸入將直接放棄該檔案。\n"
+"然而，若您確定該檔案 (檢核碼 '%1%..') 是安全且正確的，在此操作中應該要使用"
+"它，\n"
+"請輸入檢核碼的前 4 個字元來取消阻擋該檔案，並請您自負風險。空白輸入將直接放棄"
+"該檔案。\n"
 
 #. translators: A prompt option
 #: src/callbacks/keyring.h:555
@@ -1921,7 +1933,8 @@ msgid ""
 "Checking for file conflicts requires not installed packages to be downloaded "
 "in advance in order to access their file lists. See option '%1%' in the "
 "zypper manual page for details."
-msgstr "檢查檔案衝突需要事先下載尚未安裝的套件，才能存取其檔案清單。詳情請見 zypper "
+msgstr ""
+"檢查檔案衝突需要事先下載尚未安裝的套件，才能存取其檔案清單。詳情請見 zypper "
 "說明文件中關於選項 '%1%' 的說明。"
 
 #. TranslatorExplanation %1%(number of conflicts); detailed list follows
@@ -1941,7 +1954,8 @@ msgid ""
 "File conflicts happen when two packages attempt to install files with the "
 "same name but different contents. If you continue, conflicting files will be "
 "replaced losing the previous content."
-msgstr "當二個套件嘗試安裝檔名相同、內容卻不同的檔案時，檔案衝突就會發生。若您選擇繼"
+msgstr ""
+"當二個套件嘗試安裝檔名相同、內容卻不同的檔案時，檔案衝突就會發生。若您選擇繼"
 "續，衝突檔案將會被取代，先前的內容也會消失。"
 
 #. TranslatorExplanation This text is a progress display label e.g. "Installing: foo-1.1.2 [42%]"
@@ -2015,25 +2029,31 @@ msgid "Commands:"
 msgstr "指令："
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr "顯示詳細的安裝摘要。"
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr "套件 (%1%) 的類型。"
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr "盡最大努力來趨近最新狀態， 更新到比最新版本還低些的也 可以接受。"
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
 msgstr "僅考慮影響套件管理本身的修補程式。"
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
+msgstr ""
 
 #: src/commands/conditions.cc:19
 msgid "Root privileges are required to run this command."
@@ -2093,9 +2113,9 @@ msgid ""
 "You are about to do a distribution upgrade with all enabled repositories. "
 "Make sure these repositories are compatible before you continue. See '%s' "
 "for more information about this command."
-msgstr "您將要使用所有可用的套件庫進行發行版本升級。 "
-"在您繼續之前，請先確定這些套件庫的相容性。參閱 '%s' "
-"得到更多關於此命令的資訊。"
+msgstr ""
+"您將要使用所有可用的套件庫進行發行版本升級。 在您繼續之前，請先確定這些套件庫"
+"的相容性。參閱 '%s' 得到更多關於此命令的資訊。"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/help.cc:22
@@ -2107,7 +2127,7 @@ msgstr "zypper [--全域選項] <指令> [--指令選項] [參數]"
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr "zypper <個別指令> [--指令選項] [參數]"
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr "列印 zypper 說明"
 
@@ -2151,7 +2171,8 @@ msgid ""
 "Called as '%1%', it restricts the command to just look for packages "
 "supporting available hardware, languages or filesystems. Useful after having "
 "added e.g. new hardware or driver repos."
-msgstr "呼叫「%1%」將限制該指令，僅允許其尋找支援可用硬體、語言或檔案系統的套件。新增"
+msgstr ""
+"呼叫「%1%」將限制該指令，僅允許其尋找支援可用硬體、語言或檔案系統的套件。新增"
 "硬體或驅動程式儲存庫後此指令會十分有用。"
 
 #. translators: command description
@@ -2184,8 +2205,9 @@ msgstr "移除套件。"
 msgid ""
 "Remove packages with specified capabilities. A capability is NAME[.ARCH]"
 "[OP<VERSION>], where OP is one of <, <=, =, >=, >."
-msgstr "移除具有指定功能的套件。 功能是名稱[.ARCH][OP<版本>]，其中 OP "
-"為以下運算子之一： <、<=、=、>=、>。"
+msgstr ""
+"移除具有指定功能的套件。 功能是名稱[.ARCH][OP<版本>]，其中 OP 為以下運算子之"
+"一： <、<=、=、>=、>。"
 
 #: src/commands/installremove.cc:104 src/commands/installremove.cc:234
 #: src/utils/messages.cc:53
@@ -2244,7 +2266,8 @@ msgstr "從指定的套件庫選取套件。"
 msgid ""
 "Allows one to replace a newer item with an older one. Handy if you are doing "
 "a rollback. Unlike --force it will not enforce a reinstall."
-msgstr "允許使用舊版本取代新版本。 如果您要回復到舊版本，該選項是個方便的功能。不像 "
+msgstr ""
+"允許使用舊版本取代新版本。 如果您要回復到舊版本，該選項是個方便的功能。不像 "
 "--force， 它不會強迫重新安裝。"
 
 #: src/commands/installremove.cc:203
@@ -2306,22 +2329,22 @@ msgstr ""
 "的就是以相依套件的正式更新版本取代相依套件。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr "list-patches (lp) [選項]"
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr "列出已就緒的修補程式。"
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr "列出所有適用修補程式。"
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr "列出所有修補程式，不僅僅是適用的那些。"
 
@@ -2369,53 +2392,59 @@ msgstr "不安裝針對指定地區設定的對應套件。"
 msgid ""
 "Specify locale which shall be supported by the language code. Get a list of "
 "all available locales by calling '%s'."
-msgstr "依據語言代碼指定應支援的地區設定。透過呼叫「%s」獲取所有可用地區設定的清單。"
+msgstr ""
+"依據語言代碼指定應支援的地區設定。透過呼叫「%s」獲取所有可用地區設定的清單。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr "locales (lloc) [選項] [地區設定] ..."
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr "列出請求的地區設定 (語言代碼)。"
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr "列出請求的地區設定和對應套件。"
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr "顯示對應套件。"
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr "列出所有可用地區設定。"
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr "由於提供了 --all 引數，將忽略位置引數。"
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr "要列印資訊的相應地區設定。"
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
-msgstr "獲取語言代碼為「en」且具有自己國家/地區代碼的所有地區設定，不包括錯誤回復「en"
-"」："
+msgstr ""
+"獲取語言代碼為「en」且具有自己國家/地區代碼的所有地區設定，不包括錯誤回復"
+"「en」："
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr "獲取語言代碼為「en」且含有或不含國家/地區代碼的所有地區設定："
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr "獲取與引數完全相符的地區設定： "
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr "獲取「de」和「en」可用的套件清單："
 
@@ -2437,7 +2466,8 @@ msgstr "從支援的語言清單移除指定地區設定。"
 msgid ""
 "Specify locales which shall be removed by the language code. Get the list of "
 "requested locales by calling '%s'."
-msgstr "指定要依據語言代碼移除的地區設定。透過呼叫「%s」獲取所請求地區設定的清單。"
+msgstr ""
+"指定要依據語言代碼移除的地區設定。透過呼叫「%s」獲取所請求地區設定的清單。"
 
 #: src/commands/locale/removelocalecmd.cc:46
 msgid "Do not remove corresponding packages for given locale(s)."
@@ -2461,8 +2491,8 @@ msgid ""
 "type option."
 msgstr ""
 "LOCKSPEC 的格式為「[KIND:]NAME[ OP EDITION]」，其中 NAME 也可以是使用 * 和 ? "
-"萬用字元的 glob 模式。非套件類型可以在前面預增 KIND: 字串 "
-"(例如「patch:foo」)，或使用指令 --type 選項。"
+"萬用字元的 glob 模式。非套件類型可以在前面預增 KIND: 字串 (例如"
+"「patch:foo」)，或使用指令 --type 選項。"
 
 #: src/commands/locks/add.cc:36
 msgid ""
@@ -2470,8 +2500,8 @@ msgid ""
 "optionally restrict the lock to match a specific edition or edition range "
 "using =, <, <=, >, >= or != followed an EDITION."
 msgstr ""
-"基本格式將鎖定匹配項目的所有版本。您可以選擇性地使用 =、<、<=、>、>= 或 != "
-"後接 EDITION，將鎖定限制為比對特定的版本或版本範圍。"
+"基本格式將鎖定匹配項目的所有版本。您可以選擇性地使用 =、<、<=、>、>= 或 != 後"
+"接 EDITION，將鎖定限制為比對特定的版本或版本範圍。"
 
 #: src/commands/locks/add.cc:46
 msgid "Restrict the lock to the specified repository."
@@ -2520,11 +2550,11 @@ msgstr[0] "移除 %lu 鎖定。"
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "名稱"
 
@@ -2534,8 +2564,8 @@ msgstr "符合"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "類型"
@@ -2543,7 +2573,7 @@ msgstr "類型"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr "套件庫"
@@ -2612,7 +2642,8 @@ msgstr "解除一個套件鎖定。"
 msgid ""
 "Remove a package lock. Specify the lock to remove by its number obtained "
 "with '%1%' or by package name."
-msgstr "移除一個套件鎖定。透過由 '%1% 1' 獲得的編號或透過套件名稱指定要移除的鎖定。"
+msgstr ""
+"移除一個套件鎖定。透過由 '%1% 1' 獲得的編號或透過套件名稱指定要移除的鎖定。"
 
 #: src/commands/locks/remove.cc:45
 msgid "Remove only locks with specified repository."
@@ -2719,9 +2750,9 @@ msgstr "列出所有提供指定功能的套件。"
 msgid ""
 "The command is an alias for '%1%' and performs a case-insensitive search. "
 "For a case-sensitive search call the search command and add the '%2%' option."
-msgstr "這個指令是 '%1%' "
-"的縮寫，並且執行不區分大小寫的搜尋。若要執行區分大小寫的搜尋，"
-"請呼叫該搜尋指令並加上 '%2%' 選項。"
+msgstr ""
+"這個指令是 '%1%' 的縮寫，並且執行不區分大小寫的搜尋。若要執行區分大小寫的搜"
+"尋，請呼叫該搜尋指令並加上 '%2%' 選項。"
 
 #. "what-provides" is obsolete
 #. The "what-provides" now is included in "search" command, e.g.
@@ -2789,7 +2820,8 @@ msgstr "僅顯示未安裝的套件。"
 msgid ""
 "Automatically say 'yes' to third party license confirmation prompt. See 'man "
 "zypper' for more details."
-msgstr "對協力廠商授權資訊提示自動選取「是」。請參閱「man zypper」瞭解詳細資料。"
+msgstr ""
+"對協力廠商授權資訊提示自動選取「是」。請參閱「man zypper」瞭解詳細資料。"
 
 #: src/commands/optionsets.cc:244
 msgid ""
@@ -2804,9 +2836,8 @@ msgid ""
 "installed, packages. Default is to treat file conflicts as an error. --"
 "download-as-needed disables the fileconflict check."
 msgstr ""
-"安裝套件，即使它會取代來自其他已安裝套件的檔案。 "
-"預設將檔案衝突視為錯誤來處理。 使用 --download-as-needed "
-"選項來停用檔案衝突檢查。"
+"安裝套件，即使它會取代來自其他已安裝套件的檔案。 預設將檔案衝突視為錯誤來處"
+"理。 使用 --download-as-needed 選項來停用檔案衝突檢查。"
 
 #. translators: -y, --no-confirm
 #: src/commands/optionsets.cc:291
@@ -2900,8 +2931,9 @@ msgstr "檢查有無修補程式。"
 msgid ""
 "Display stats about applicable patches. The command returns 100 if needed "
 "patches were found, 101 if there is at least one needed security patch."
-msgstr "顯示適用修補程式的統計資料。如果找到需要的修補程式，該指令會傳回 "
-"100；如果至少存在一個需要的安全性修補程式，則傳回 101。"
+msgstr ""
+"顯示適用修補程式的統計資料。如果找到需要的修補程式，該指令會傳回 100；如果至"
+"少存在一個需要的安全性修補程式，則傳回 101。"
 
 #. translators: command synopsis; do not translate the command 'name (abbreviations)' or '-option' names
 #: src/commands/ps.cc:27
@@ -2921,7 +2953,8 @@ msgid ""
 "Create a short table not showing the deleted files. Given twice, show only "
 "processes which are associated with a system service. Given three times, "
 "list the associated system service names only."
-msgstr "產生一個不顯示刪除檔案的簡短列表。給定二次相同參數，則只顯示和系統服務相關的"
+msgstr ""
+"產生一個不顯示刪除檔案的簡短列表。給定二次相同參數，則只顯示和系統服務相關的"
 "程序。給定三次，則只列出相關的系統服務名稱。"
 
 #. translators: --print <format>
@@ -2931,8 +2964,9 @@ msgid ""
 "For each associated system service print <format> on the standard output, "
 "followed by a newline. Any '%s' directive in <format> is replaced by the "
 "system service name."
-msgstr "每個關聯系統服務均會在標準輸出上列印 <format>，並後跟一個换行符。<format> "
-"中的所有「%s」指令都將由系統服務名稱取代。"
+msgstr ""
+"每個關聯系統服務均會在標準輸出上列印 <format>，並後跟一個换行符。<format> 中"
+"的所有「%s」指令都將由系統服務名稱取代。"
 
 #. translators: -d, --debugFile <path>
 #: src/commands/ps.cc:52
@@ -2974,7 +3008,7 @@ msgid "Command"
 msgstr "命令"
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr "服務"
 
@@ -3006,8 +3040,9 @@ msgid ""
 "Note: Not running as root you are limited to searching for files you have "
 "permission to examine with the system stat(2) function. The result might be "
 "incomplete."
-msgstr "注意：您沒有使用 root 身分執行，您的搜尋範圍將限制為透過 system stat(2) "
-"功能有權檢視的檔案。結果可能並不完整。"
+msgstr ""
+"注意：您沒有使用 root 身分執行，您的搜尋範圍將限制為透過 system stat(2) 功能"
+"有權檢視的檔案。結果可能並不完整。"
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/query/info.cc:19
@@ -3027,9 +3062,8 @@ msgid ""
 "partially matching use option '--match-substrings' or use wildcards (*?) in "
 "name."
 msgstr ""
-"顯示指定套件的詳細資訊。 預設僅有完全符合指定名稱的才會顯示。 "
-"若也要顯示部份符合的套件，使用 '--match-substrings' 選項 "
-"或在名稱中使用萬用字元 (*?)。"
+"顯示指定套件的詳細資訊。 預設僅有完全符合指定名稱的才會顯示。 若也要顯示部份"
+"符合的套件，使用 '--match-substrings' 選項 或在名稱中使用萬用字元 (*?)。"
 
 #: src/commands/query/info.cc:25
 msgid ""
@@ -3140,120 +3174,120 @@ msgid "Show detailed information for products."
 msgstr "顯示產品的詳細資料。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr "packages (pa) [選項] [套件庫] ..."
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr "列出所有可用的套件。"
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr "列出指定套件庫中所有可用的套件。"
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr "顯示解析器自動選取且已安裝的套件。"
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr "顯示使用者明確選取且已安裝的套件。"
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr "顯示並非由任何儲存庫提供的已安裝套件。"
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr "顯示孤立的系統套件 (沒有儲存庫和候選更新套件)。"
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr "顯示建議的套件。"
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr "顯示推薦的套件。"
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr "顯示不需要的套件。"
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr "以套件名稱排列清單。"
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr "以套件庫排列清單。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr "patches (pch) [套件庫] ..."
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr "列出所有可用的修補程式。"
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr "列出指定套件庫中所有可用的修補程式。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr "patterns (pt) [選項] [套件庫] ..."
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr "列出所有可用的樣式。"
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr "列出指定套件庫中所有可用的樣式。"
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr "products (pd) [選項] [套件庫] ..."
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr "列出所有可用的產品。"
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr "列出指定套件庫中所有可用的產品。"
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr "僅限 XML 輸出：直接轉發在產品文件中找到的 XML 標記。"
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr "當未指定 %2% 全域選項時，%1% 選項沒有作用。"
@@ -3274,8 +3308,9 @@ msgstr "加入一個新的套件庫。"
 msgid ""
 "Add a repository to the system. The repository can be specified by its URI "
 "or can be read from specified .repo file (even remote)."
-msgstr "增加一個套件庫到此系統。套件庫可藉由指定位址或從指定的 .repo "
-"檔讀取(甚至是遠端的)。"
+msgstr ""
+"增加一個套件庫到此系統。套件庫可藉由指定位址或從指定的 .repo 檔讀取(甚至是遠"
+"端的)。"
 
 #: src/commands/repos/add.cc:40
 msgid "Just another means to specify a .repo file to read."
@@ -3293,12 +3328,12 @@ msgstr "不要偵測位址，稍候重新整理時再偵測。"
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr "已自動偵測到該儲存庫類型。將忽略此選項。"
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr "無法搭配使用 %s 和 %s。 將使用 %s 設定。"
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr "如果只使用一個引數，它必須是一個指向 .repo 檔案的位址。"
@@ -3340,111 +3375,115 @@ msgstr "清除原始中繼資料快取。"
 msgid "Clean both metadata and package caches."
 msgstr "清除中繼資料和套件快取。"
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr "別名"
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr "位址"
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "已啟用"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr "GPG 檢查"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr "優先權"
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr "自動重新整理"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr "開啟"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr "關閉"
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr "保留套件"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr "GPG 金鑰 URI"
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr "路徑前置"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr "上層服務"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr "關鍵字"
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr "套件庫資訊路徑"
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr "MD 快取路徑"
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr "repos (lr) [選項] [套件庫] ..."
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr "列出所有已定義的套件庫。"
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr "將所有已定義的套件庫匯出為單一的本機 .repo 檔。"
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr "讀取套件庫發生錯誤："
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "無法開啟 %s 來寫入。"
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr "可能您沒有寫入的權限？"
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr "套件庫已成功匯出到 %s。"
@@ -3452,20 +3491,20 @@ msgstr "套件庫已成功匯出到 %s。"
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "重新整理"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr "保留"
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr "尚未定義套件庫。"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr "請用 'zypper addrepo' 指令來加入一或多個套件庫。"
 
@@ -3512,7 +3551,8 @@ msgstr "重新整理所有套件庫。"
 msgid ""
 "Refresh repositories specified by their alias, number or URI. If none are "
 "specified, all enabled repositories will be refreshed."
-msgstr "重新整理由別名、編號或位址指定的套件庫。若未指定任何套件庫，將會重新整理所有"
+msgstr ""
+"重新整理由別名、編號或位址指定的套件庫。若未指定任何套件庫，將會重新整理所有"
 "啟用的套件庫。"
 
 #. translators: -f, --force
@@ -3568,7 +3608,7 @@ msgstr "全域選項 '%s' 在此無效。"
 msgid "Arguments are not allowed if '%s' is used."
 msgstr "如果使用了 '%s'，則不允許使用參數。"
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr "指定的套件庫： "
 
@@ -3577,7 +3617,7 @@ msgstr "指定的套件庫： "
 msgid "Refreshing repository '%s'."
 msgstr "正在重新整理套件庫 '%s'。"
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "正在掃描已停用的套件庫 '%s' 的內容。"
@@ -3587,7 +3627,7 @@ msgstr "正在掃描已停用的套件庫 '%s' 的內容。"
 msgid "Skipping disabled repository '%s'"
 msgstr "正在跳過已停用的套件庫 '%s'"
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr "由於上述錯誤，正在跳過套件庫 '%s'。"
@@ -3614,7 +3654,7 @@ msgstr "請用 '%s' 或 '%s' 指令來加入或啟用套件庫。"
 msgid "Could not refresh the repositories because of errors."
 msgstr "因發生錯誤無法重新整理套件庫。"
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr "因發生錯誤，某些套件庫尚未被重新整理。"
 
@@ -3660,19 +3700,20 @@ msgstr "無法由它的別名、編號或位址找到套件庫 '%s'。"
 msgid ""
 "Cannot change alias of '%s' repository. The repository belongs to service "
 "'%s' which is responsible for setting its alias."
-msgstr "無法變更 '%s' 套件庫的別名。此套件庫屬於 '%s' 服務，此服務才能設定它的別名。"
+msgstr ""
+"無法變更 '%s' 套件庫的別名。此套件庫屬於 '%s' 服務，此服務才能設定它的別名。"
 
 #: src/commands/repos/rename.cc:43
 #, c-format, boost-format
 msgid "Repository '%s' renamed to '%s'."
 msgstr "套件庫 '%s' 已改名為 '%s'。"
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr "套件庫名稱 '%s' 已存在。請使用其他的別名。"
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr "修改套件庫時發生錯誤："
 
@@ -3946,8 +3987,9 @@ msgstr "搜尋符合指定搜尋字串的套件。"
 msgid ""
 "* and ? wildcards can also be used within search strings. If a search string "
 "is enclosed in '/', it's interpreted as a regular expression."
-msgstr "* 和 ? 萬用字元也可以用在搜尋字串中。 如果搜尋字串被 '/' "
-"包圍，它會被解讀為正規表示式。"
+msgstr ""
+"* 和 ? 萬用字元也可以用在搜尋字串中。 如果搜尋字串被 '/' 包圍，它會被解讀為正"
+"規表示式。"
 
 #. translators: --match-substrings
 #: src/commands/search/search.cc:105
@@ -4097,27 +4139,28 @@ msgstr "每個套件庫中每個可用的版本 單獨顯示在一行。"
 msgid ""
 "Like --details, with additional information where the search has matched "
 "(useful for search in dependencies)."
-msgstr "與 --details 相似，不過會額外顯示相符項的 位置資訊 (對搜尋相依套件很有用)。"
+msgstr ""
+"與 --details 相似，不過會額外顯示相符項的 位置資訊 (對搜尋相依套件很有用)。"
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "指定套件庫 '%s' 已停用。"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr "找不到符合項目。"
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr "初始化或執行搜尋查詢時出現問題"
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr "請檢視上面的訊息以獲得提示。"
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr "以 root 執行 'zypper refresh' 也許可以解決這個問題。"
 
@@ -4207,7 +4250,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "為服務 '%s' 取得套件庫索引檔案時發生問題："
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr "由於上述錯誤，正在跳過服務 '%s'。"
@@ -4226,22 +4269,26 @@ msgstr "正在移除服務 '%s'："
 msgid "Service '%s' has been removed."
 msgstr "服務 '%s' 已經被移除。"
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr "services (ls) [選項]"
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr "列出所有已定義的服務。"
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr "列出已定義的服務。"
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
 msgstr "尚未定義服務。請用 '%s' 指令來加入一或多項服務。"
+
+#: src/commands/services/list.cc:237
+msgid "service"
+msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
 #: src/commands/services/modify.cc:18
@@ -4578,8 +4625,9 @@ msgid ""
 "The default location where rpm installs source packages to is '%1%', but the "
 "value can be changed in your local rpm configuration. In case of doubt try "
 "executing '%2%'."
-msgstr "預設 rpm 源碼套件的安裝位置是在 '%1%'，但您可在本地端的 rpm "
-"設定修改此值。若有疑問，請嘗試執行 '%2%'。"
+msgstr ""
+"預設 rpm 源碼套件的安裝位置是在 '%1%'，但您可在本地端的 rpm 設定修改此值。若"
+"有疑問，請嘗試執行 '%2%'。"
 
 #. translators: -d, --build-deps-only
 #: src/commands/sourceinstall.cc:48
@@ -4777,8 +4825,9 @@ msgstr "要更新已安裝的產品請用 '%s'。"
 msgid ""
 "Zypper does not keep track of installed source packages. To install the "
 "latest source package and its build dependencies, use '%s'."
-msgstr "Zypper 不會追蹤安裝的原始碼套件。若要安裝最新的原始碼套件及其建構相依項，"
-"請使用 '%s 1'。"
+msgstr ""
+"Zypper 不會追蹤安裝的原始碼套件。若要安裝最新的原始碼套件及其建構相依項，請使"
+"用 '%s 1'。"
 
 #: src/commands/update.cc:83
 msgid ""
@@ -4820,8 +4869,8 @@ msgid ""
 "result/localpath@path'."
 msgstr ""
 "在 XML 輸出模式下，對每個 zypper 嘗試下載的套件， 將會寫入一個 <download-"
-"result> 節點。下載成功後， 本地端路徑可在「download-result/"
-"localpath@path」中找到。"
+"result> 節點。下載成功後， 本地端路徑可在「download-result/localpath@path」中"
+"找到。"
 
 #. translators: --all-matches
 #: src/commands/utils/download.cc:166
@@ -5135,15 +5184,15 @@ msgstr "%s 比 %s 還舊"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "版本"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "結構"
 
@@ -5276,13 +5325,13 @@ msgstr "(空)"
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr "相依性"
 
@@ -5319,7 +5368,7 @@ msgid "Flavor"
 msgstr "類別"
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr "是基礎"
 
@@ -5455,7 +5504,8 @@ msgstr "正在中止安裝，因為必須確認授權條款。"
 msgid ""
 "Please restart the operation in interactive mode and confirm your agreement "
 "with required licenses, or use the %s option."
-msgstr "請在互動模式中重新啟動作業，並確認您同意所需的授權合約，或使用 %s 的選項。"
+msgstr ""
+"請在互動模式中重新啟動作業，並確認您同意所需的授權合約，或使用 %s 的選項。"
 
 #. translators: e.g. "... with flash package license."
 #: src/misc.cc:209
@@ -5531,7 +5581,8 @@ msgstr "暫時"
 msgid ""
 "Repo '%1%' is managed by service '%2%'. Volatile changes are reset by the "
 "next service refresh!"
-msgstr "套件庫「%1%」由服務「%2%」管理。暫時性的變動將會在下次服務重新整理時重設！"
+msgstr ""
+"套件庫「%1%」由服務「%2%」管理。暫時性的變動將會在下次服務重新整理時重設！"
 
 #: src/repos.cc:75
 msgid "default priority"
@@ -5572,139 +5623,140 @@ msgstr[0] "%1% 個套件庫"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr "檢查是否需要重新整理 %s 的中繼資料"
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "套件庫 '%s' 已是最新狀態。"
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "'%s' 的最新狀態檢查已被延遲。"
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr "正在強迫原始中繼資料重新整理"
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "正在取回套件庫 '%s' 中繼資料"
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "您要永久停用套件庫 %s 嗎？"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "停用套件庫 '%s' 發生錯誤。"
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "從 '%s' 取出檔案出現問題。"
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr "請檢視上面的錯誤訊息以獲得提示。"
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "'%s' 沒有定義位址。"
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
-msgstr "請加入一個或數個基礎位址 (baseurl=位址) 項目到 %s，以供套件庫 '%s' 使用。"
+msgstr ""
+"請加入一個或數個基礎位址 (baseurl=位址) 項目到 %s，以供套件庫 '%s' 使用。"
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr "這個套件庫未定義別名。"
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "套件庫 '%s' 無效。"
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr "請檢查為此套件庫定義的位址是否指向有效的套件庫。"
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "取回 '%s' 的中繼資料發生錯誤："
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr "正在強迫建立套件庫快取"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "分析 '%s' 的中繼資料發生錯誤："
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
 "report by following instructions at http://en.opensuse.org/Zypper/"
 "Troubleshooting"
 msgstr ""
-"這可能是因為套件庫的中繼資訊不適用，或中繼資訊分析器存在錯誤。若是後者的情形("
-"或您懷疑是)請參考 http://en.opensuse.org/Zypper/Troubleshooting "
-"的指引發出錯誤回報"
+"這可能是因為套件庫的中繼資訊不適用，或中繼資訊分析器存在錯誤。若是後者的情形"
+"(或您懷疑是)請參考 http://en.opensuse.org/Zypper/Troubleshooting 的指引發出錯"
+"誤回報"
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "在本機快取中找不到 '%s' 的套件庫中繼資料。"
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr "建立快取時發生錯誤："
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "無法由它的別名、編號或位址找到套件庫 '%s'。"
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr "請用 '%s' 取得已定義的套件庫清單。"
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "正在忽略已停用的套件庫 '%s'"
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr "全域選項 '%s' 可用來暫時啟用套件庫。"
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "正在忽略套件庫 '%s'，因為使用了 '%s' 選項。"
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "正在暫時啟用套件庫 '%s'。"
@@ -5712,331 +5764,333 @@ msgstr "正在暫時啟用套件庫 '%s'。"
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr "套件庫 '%s' 已過期。您可以用 root 執行 'zypper refresh' 來更新它。"
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
-msgstr "需要建立套件庫 '%s' 的中繼資料快取。您可以用 root 執行 'zypper refresh' "
-"來完成。"
+msgstr ""
+"需要建立套件庫 '%s' 的中繼資料快取。您可以用 root 執行 'zypper refresh' 來完"
+"成。"
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "套件庫 '%s' 維持停用狀態。"
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "啟始化目標"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr "目標初始化失敗："
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "正在清除 '%s' 的中繼資料快取。"
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "正在清除 '%s' 的原始中繼資料快取。"
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "正在保留 %s 的原始中繼資料快取 '%s'。"
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "正在清除 '%s' 的套件。"
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr "因錯誤無法清除套件庫 '%s'。"
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr "正在清除已安裝套件的快取。"
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr "因錯誤無法清除已安裝套件的快取。"
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr "因發生錯誤，無法清除套件庫。"
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr "因發生錯誤，某些套件庫尚未被清理。"
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr "指定的套件庫已清理完成。"
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr "所有套件庫已清理完成。"
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr "這是一個可抽換的唯讀媒體 (CD/DVD)，正在停用自動重新整理。"
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "無效的套件庫別名：'%s'"
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
-msgstr "無法決定套件庫的類型。請檢查是否定義的位址 (參看下方) "
-"真的指向一個有效的軟體庫："
+msgstr ""
+"無法決定套件庫的類型。請檢查是否定義的位址 (參看下方) 真的指向一個有效的軟體"
+"庫："
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr "在指定的位置找不到有效的套件庫："
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr "由指定的位址傳輸套件庫資料時發生錯誤："
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr "請檢查指定的位址是否可存取。"
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr "新增套件庫時發生未知的問題："
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr "'%1%' 套件庫設定中已停用 GPG 檢查。將無法驗證套件完整性及來源。"
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr "已成功新增套件庫 '%s'"
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "正在從媒體 '%s' 讀取資料"
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "從媒體 '%s' 讀取資料時發生問題"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr "請檢查您的安裝媒體是否有效與可讀取。"
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "延遲從媒體 '%s' 讀取資料到下一次的重新整理。"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "正在從媒體 '%s' 讀取資料"
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "從媒體 '%s' 讀取資料時發生問題"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr "請檢查您的安裝媒體是否有效與可讀取。"
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr "在指定的位址存取檔案時發生問題"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr "請檢查位址是否有效且可存取。"
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr "在指定的位址解析檔案時發生問題"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr "這確定是一個 .repo 檔案嗎？"
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "在指定的 URI 嘗試讀取檔案時發生問題"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "檔案中有未定義別名的套件庫，正在跳過。"
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "套件庫 '%s' 未定義位址，正在跳過。"
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "套件庫 '%s' 已經被移除。"
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "套件庫 '%s' 的優先權維持不變 (%d)"
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "套件庫 '%s' 已成功啟用。"
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "套件庫 '%s' 已成功停用。"
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr "套件庫 '%s' 已啟用自動重新整理。"
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr "套件庫 '%s' 已停用自動重新整理。"
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "套件庫 '%s' 已啟用 RPM 檔案快取。"
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "套件庫 '%s' 已停用 RPM 檔案快取。"
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "套件庫 '%s' 已啟用 GPG 檢查。"
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "套件庫 '%s' 已停用 GPG 檢查。"
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "套件庫 '%s' 的優先權已被設為 %d。"
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "套件庫 '%s' 的名稱已被設為 '%s'。"
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "套件庫 '%s' 將不變更。"
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "套件庫 %s 維持不變。"
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr "正在載入套件庫資料..."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
 "Nothing can be installed."
-msgstr "警告：沒有已定義的套件庫。您只能使用已安裝的解決方案操作。無法安裝任何項目。"
+msgstr ""
+"警告：沒有已定義的套件庫。您只能使用已安裝的解決方案操作。無法安裝任何項目。"
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "正在取回套件庫 '%s' 資料..."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr "套件庫 '%s' 沒有快取。快取中..."
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "從 '%s' 載入資料有問題"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "無法重新整理套件庫 '%s'。正在使用舊快取。"
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr "因為錯誤，由 '%s' 提供的解決方案無法載入。"
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr "自 %2% 起，儲存庫 \"%1%\" 中繼資料已過期。"
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr "在您這樣做之前，嘗試 '%s'，或甚至 '%s' 。"
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
 "not solve the issue, it could be that you are using a broken mirror or the "
 "server has actually discontinued to support the repository."
 msgstr ""
-"儲存庫中繼資料已過期：請確認已啟用 \"autorefresh\" (zypper lr)，"
-"否則需以手動方式更新儲存庫 (zypper "
-"ref)。如果這樣無法解決問題，則可能是因為您使用的鏡像已損毀或伺服器實際上已停"
-"止支援該儲存庫。"
+"儲存庫中繼資料已過期：請確認已啟用 \"autorefresh\" (zypper lr)，否則需以手動"
+"方式更新儲存庫 (zypper ref)。如果這樣無法解決問題，則可能是因為您使用的鏡像已"
+"損毀或伺服器實際上已停止支援該儲存庫。"
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr "正在讀取已安裝的套件..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr "讀取已安裝套件時發生錯誤："
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr "'%s' 看起來像是一個 RPM 檔。將嘗試去下載它。"
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr "指定的 RPM 檔 '%s' 有問題，正在跳過。"
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr "讀取 %s 的 RPM 檔頭出現問題。確認是一個 RPM 檔嗎？"
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr "純 RPM 檔快取"
 
@@ -6044,25 +6098,25 @@ msgstr "純 RPM 檔快取"
 msgid "System Packages"
 msgstr "系統套件"
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr "沒有需要的修補程式。"
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr "沒有發現樣式。"
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr "沒有發現套件。"
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr "內部名稱"
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr "沒有發現產品。"
 
@@ -6091,7 +6145,8 @@ msgstr "詳細資訊： "
 #: src/solve-commit.cc:138
 msgid "Choose the above solution using '1' or skip, retry or cancel"
 msgid_plural "Choose from above solutions by number or skip, retry or cancel"
-msgstr[0] "使用'數字'選擇上列的解決方法，或 skip(跳過)、retry(重試)或 cancel(取消)"
+msgstr[0] ""
+"使用'數字'選擇上列的解決方法，或 skip(跳過)、retry(重試)或 cancel(取消)"
 
 #. translators: translate 'c' to whatever you translated the 'c' in
 #. "c" and "s/r/c" strings
@@ -6204,7 +6259,8 @@ msgstr "明確選取 DownloadAsNeeded 還會選取 classic_rpmtrans 後端。"
 msgid ""
 "Check for running processes using deleted libraries is disabled in "
 "zypper.conf. Run '%s' to check manually."
-msgstr "檢查使用已刪除函式庫之執行中程序的功能在 zypper.conf 中已被關閉。請手動執行 "
+msgstr ""
+"檢查使用已刪除函式庫之執行中程序的功能在 zypper.conf 中已被關閉。請手動執行 "
 "'%s' 來做檢查。"
 
 #: src/solve-commit.cc:636
@@ -6217,7 +6273,8 @@ msgid ""
 "There are running programs which still use files and libraries deleted or "
 "updated by recent upgrades. They should be restarted to benefit from the "
 "latest updates. Run '%1%' to list these programs."
-msgstr "有些執行中的程式仍在使用已被近期升級刪除或更新的檔案和文件庫。應重新啟動它們"
+msgstr ""
+"有些執行中的程式仍在使用已被近期升級刪除或更新的檔案和文件庫。應重新啟動它們"
 "以使其獲得最新更新。執行「%1%」列出這些程式。"
 
 #: src/solve-commit.cc:657
@@ -6371,7 +6428,8 @@ msgstr "其中一個安裝的修補程式需要重新啟動您的機器。 請�
 msgid ""
 "One of the installed patches affects the package manager itself. Run this "
 "command once more to install any other needed patches."
-msgstr "其中一個安裝的修補程式會影響套件管理員本身，請再次執行此命令以安裝其他所需的"
+msgstr ""
+"其中一個安裝的修補程式會影響套件管理員本身，請再次執行此命令以安裝其他所需的"
 "修補程式。"
 
 #: src/solve-commit.cc:1119
@@ -6433,7 +6491,7 @@ msgid "Updatestack"
 msgstr "Updatestack"
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr "修補程式"
 
@@ -6456,7 +6514,7 @@ msgstr "包括的類別"
 msgid "Needed software management updates will be installed first:"
 msgstr "將先安裝需要的軟體管理更新："
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr "沒有發現更新。"
 
@@ -6465,50 +6523,50 @@ msgstr "沒有發現更新。"
 msgid "The following updates are also available:"
 msgstr "還有下列更新可用："
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr "套件更新"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr "樣式更新"
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr "產品更新"
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr "目前版本"
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr "可用版本"
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr "找不到相符問題。"
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr "已找到下列符合問題編號的項目："
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr "已找到以下修補程式之修補程式描述中的相符項："
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr "Bugzilla 問題編號 %s 的修正未發現或不需要。"
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr "CVS 問題編號 %s 的修正未發現或不需要。"
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr "%s 問題編號 %s 的修正未發現或不需要。"
@@ -6720,8 +6778,9 @@ msgid ""
 "You have chosen to ignore a problem with download or installation of a "
 "package which might lead to broken dependencies of other packages. It is "
 "recommended to run '%s' after the operation has finished."
-msgstr "您已經選擇去忽略套件下載或安裝的問題，這可能導致其他套件的相依性被破壞。"
-"建議您在此操作完成後執行 '%s' 命令。"
+msgstr ""
+"您已經選擇去忽略套件下載或安裝的問題，這可能導致其他套件的相依性被破壞。建議"
+"您在此操作完成後執行 '%s' 命令。"
 
 #: src/utils/messages.cc:111
 #, boost-format
@@ -6761,8 +6820,9 @@ msgstr "輸入 '%s' 以獲取全域選項與指令的清單。"
 msgid ""
 "In case '%1%' is not a typo it's probably not a built-in command, but "
 "provided as a subcommand or plug-in (see '%2%')."
-msgstr "如果「%1%」不是拼字錯誤，則可能不是內建指令，而是子指令或外掛程式 "
-"(請參閱「%2%」)。"
+msgstr ""
+"如果「%1%」不是拼字錯誤，則可能不是內建指令，而是子指令或外掛程式 (請參閱"
+"「%2%」)。"
 
 #. translators: %1% and %2% are plug-in packages which might provide it.
 #. translators: The word 'subcommand' also refers to a zypper command and should not be translated.
@@ -6771,8 +6831,9 @@ msgstr "如果「%1%」不是拼字錯誤，則可能不是內建指令，而是
 msgid ""
 "In this case a specific package providing the subcommand needs to be "
 "installed first. Those packages are often named '%1%' or '%2%'."
-msgstr "在此情況下，需要先安裝提供該子指令的特定套件。這些套件通常名為「%1%」或「%2%"
-"」。"
+msgstr ""
+"在此情況下，需要先安裝提供該子指令的特定套件。這些套件通常名為「%1%」或"
+"「%2%」。"
 
 #: src/utils/misc.cc:93
 msgid "package"
@@ -6998,7 +7059,8 @@ msgstr "如果沒有可用的答案，輸入 '%s' 表示 '%s' 或 '%s' 表示 '%
 msgid ""
 "If nothing else works enter '#1' to select the 1st option, '#2' for the 2nd "
 "one, ..."
-msgstr "如果沒有可用回答，輸入「#1」選取第一個選項，輸入「#2」選取第二個選項..."
+msgstr ""
+"如果沒有可用回答，輸入「#1」選取第一個選項，輸入「#2」選取第二個選項..."
 
 #. TranslatorExplanation These are reasons for various failures.
 #: src/utils/prompt.h:95

--- a/po/zu.po
+++ b/po/zu.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: 2025-07-22 12:48+0000\n"
 "Last-Translator: Julia Faltenbacher <julia.faltenbacher@suse.com>\n"
 "Language-Team: Zulu <https://l10n.opensuse.org/projects/zypper/master/zu/>\n"
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Try again?"
 msgstr "Ilungiselela ukufaka uhlelo..."
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr "Into engavamile engalindelekile."
 
@@ -1398,12 +1398,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 #, fuzzy
 msgid "Non-option program arguments: "
 msgstr "Ama-agumenti Ohlelo Ayimpoqo:"
@@ -2133,24 +2133,30 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid ""
 "Do a 'best effort' approach to update. Updates to a lower than the latest "
 "version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2220,7 +2226,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2406,22 +2412,22 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2472,49 +2478,53 @@ msgid ""
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid ""
 "Get all locales with lang code 'en' that have their own country code, "
 "excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2618,11 +2628,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr "Igama"
 
@@ -2633,8 +2643,8 @@ msgstr "isichibiyelo"
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr "Uhlobo"
@@ -2642,7 +2652,7 @@ msgstr "Uhlobo"
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 #, fuzzy
 msgid "Repository"
@@ -3074,7 +3084,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 #, fuzzy
 msgid "Service"
 msgstr "Isiphakelalwazi"
@@ -3239,120 +3249,120 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid ""
 "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid ""
 "Show system packages which are orphaned (without repository and without "
 "update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid ""
 "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3391,12 +3401,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid ""
 "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
@@ -3438,119 +3448,123 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr "Ivuliwe ukuze isebenze"
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 #, fuzzy
 msgid "GPG Check"
 msgstr "Ukuhlola I-DNS"
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 #, fuzzy
 msgid "Autorefresh"
 msgstr "Ukuzivuselela"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 #, fuzzy
 msgid "On"
 msgstr "cha"
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 #, fuzzy
 msgid "Keep Packages"
 msgstr "Izinto zendawo yesistimu"
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 #, fuzzy
 msgid "Path Prefix"
 msgstr "Isanduleli Sokudayela"
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 #, fuzzy
 msgid "Parent Service"
 msgstr "Isiphakelalwazi"
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 #, fuzzy
 msgid "Error reading repositories:"
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, fuzzy, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr "Ayikwazi ukuvula ifayela ukuze ibhale."
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 #, fuzzy
 msgid "Maybe you do not have write permissions?"
 msgstr "Awunalo igunya lokufakazela."
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3558,21 +3572,21 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr "Vuselela kabusha"
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 #, fuzzy
 msgid "No repositories defined."
 msgstr "Ukuzivuselela"
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3673,7 +3687,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 #, fuzzy
 msgid "Specified repositories: "
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
@@ -3683,7 +3697,7 @@ msgstr "Kwenzeke iphutha ifunda i-sector %u."
 msgid "Refreshing repository '%s'."
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, fuzzy, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
@@ -3693,7 +3707,7 @@ msgstr "Kwenzeke iphutha ifunda i-sector %u."
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3723,7 +3737,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3776,12 +3790,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 #, fuzzy
 msgid "Error while modifying the repository:"
 msgstr "Kwenzeke iphutha ngesikhathi inqunta isicelo."
@@ -4214,27 +4228,27 @@ msgid ""
 "(useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, fuzzy, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr "Ukuzivuselela"
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 #, fuzzy
 msgid "No matching items found."
 msgstr "Awekho amaphutha atholakele."
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 #, fuzzy
 msgid "See the above message for a hint."
 msgstr "Sicela ulungise iphutha bese uphinda uzama."
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -4325,7 +4339,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -4345,21 +4359,25 @@ msgstr "&Susa Ilinki"
 msgid "Service '%s' has been removed."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -5253,15 +5271,15 @@ msgstr "%s idingwa yi- %s"
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr "Uhlelo"
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr "I-Arch"
 
@@ -5399,13 +5417,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr "S"
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -5443,7 +5461,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5710,98 +5728,98 @@ msgstr[1] "Ukulanda imidanti"
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, fuzzy, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
 # power-off message
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, fuzzy, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr "Ingabe ufuna ukulumisa manje uhlelo?"
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, fuzzy, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, fuzzy, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr "Ifunda umkhiqizo ovela kwi-%s"
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 #, fuzzy
 msgid "Please see the above error message for a hint."
 msgstr "Sicela ulungise iphutha bese uphinda uzama."
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, fuzzy, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr "Kwenzeke iphutha ngesikhathi inqunta isicelo."
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid ""
 "Please add one or more base URI (baseurl=URI) entries to %s for repository "
 "'%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 #, fuzzy
 msgid "No alias defined for this repository."
 msgstr "Kwenzeke iphutha ngesikhathi inqunta isicelo."
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid ""
 "Please check if the URIs defined for this repository are pointing to a valid "
 "repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, fuzzy, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 #, fuzzy
 msgid "Forcing building of repository cache"
 msgstr "Isexwayiso: Uhlobo lwe-metadata olungaziwa"
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, fuzzy, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid ""
 "This may be caused by invalid metadata in the repository, or by a bug in the "
 "metadata parser. In the latter case, or if in doubt, please, file a bug "
@@ -5809,42 +5827,42 @@ msgid ""
 "Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, fuzzy, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 #, fuzzy
 msgid "Error building the cache:"
 msgstr "Kwenzeke iphutha ngesikhathi inqunta isitifiketi."
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, fuzzy, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, fuzzy, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, fuzzy, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
@@ -5852,269 +5870,269 @@ msgstr "Kwenzeke iphutha ifunda i-sector %u."
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid ""
 "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to "
 "update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid ""
 "The metadata cache needs to be built for the '%s' repository. You can run "
 "'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr "Ilungiselela Ukuqalisa Ithagethi"
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 #, fuzzy
 msgid "Target initialization failed:"
 msgstr "Ukulungiselela ukuqala kuhlulekile"
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, fuzzy, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, fuzzy, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, fuzzy, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, fuzzy, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr "Ifunda amaphakheji avela kwi-%s"
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 #, fuzzy
 msgid "Cleaning installed packages cache."
 msgstr "Ihlola amaphakheji eRPM afakiwe..."
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 #, fuzzy
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 "ayikwazanga ukukopisha imithombo yokwaziswa (iphutha lesizinda sokwaziswa)"
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 #, fuzzy
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 "ayikwazanga ukukopisha imithombo yokwaziswa (iphutha lesizinda sokwaziswa)"
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 #, fuzzy
 msgid "Specified repositories have been cleaned up."
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 #, fuzzy
 msgid "All repositories have been cleaned up."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, fuzzy, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid ""
 "Could not determine the type of the repository. Please check if the defined "
 "URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 #, fuzzy
 msgid "Problem transferring repository data from specified URI:"
 msgstr "Isexwayiso: Uhlobo lwe-metadata olungaziwa"
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 #, fuzzy
 msgid "Please check whether the specified URI is accessible."
 msgstr "ifayela ye-script ayifinyeleleki"
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 #, fuzzy
 msgid "Unknown problem when adding repository:"
 msgstr "Isexwayiso: Uhlobo lwe-metadata olungaziwa"
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid ""
 "GPG checking is disabled in configuration of repository '%1%'. Integrity and "
 "origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, fuzzy, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr "Ifunda umkhiqizo ovela kwi-%s"
-
-#: src/repos.cc:1275
-#, fuzzy, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr "Ifunda umkhiqizo ovela kwi-%s"
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, fuzzy, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr "Ifunda umkhiqizo ovela kwi-%s"
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, fuzzy, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr "Ifunda umkhiqizo ovela kwi-%s"
+
+#: src/repos.cc:1273
+#, fuzzy, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr "Ifunda umkhiqizo ovela kwi-%s"
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 #, fuzzy
 msgid "Problem accessing the file at the specified URI"
 msgstr "Isexwayiso: Uhlobo lwe-metadata olungaziwa"
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 #, fuzzy
 msgid "Please check if the URI is valid and accessible."
 msgstr "ifayela ye-script ayifinyeleleki"
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 #, fuzzy
 msgid "Problem parsing the file at the specified URI"
 msgstr "Isexwayiso: Uhlobo lwe-metadata olungaziwa"
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 #, fuzzy
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr "Isexwayiso: Uhlobo lwe-metadata olungaziwa"
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 #, fuzzy
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, fuzzy, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, fuzzy, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, fuzzy, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, fuzzy, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, fuzzy, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr "Isexwayiso: Uhlobo lwe-metadata olungaziwa"
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 #, fuzzy
 msgid "Loading repository data..."
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 #, fuzzy
 msgid ""
 "No repositories defined. Operating only with the installed resolvables. "
@@ -6123,43 +6141,43 @@ msgstr ""
 "Isexwayiso: Ayikho imithombo. Isebenza kuphala ngezixazululi ezifakiwe. "
 "Akukho okungafakwa."
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, fuzzy, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr "Kwenzeke iphutha ifunda i-sector %u."
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, fuzzy, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr "Ifunda umkhiqizo ovela kwi-%s"
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, fuzzy, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr "Isiphakeli %s asizange sitholakale."
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid ""
 "Repository metadata expired: Check if 'autorefresh' is turned on (zypper "
 "lr), otherwise manually refresh the repository (zypper ref). If this does "
@@ -6167,32 +6185,32 @@ msgid ""
 "server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 #, fuzzy
 msgid "Reading installed packages..."
 msgstr "Ihlola amaphakheji eRPM afakiwe..."
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 #, fuzzy
 msgid "Problem occurred while reading the installed packages:"
 msgstr "Kwenzeke iphutha ngesikhathi ifunda umthombo wokufakwa kohlelo."
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -6201,29 +6219,29 @@ msgstr ""
 msgid "System Packages"
 msgstr "Izinto zendawo yesistimu"
 
-#: src/search.cc:261
+#: src/search.cc:262
 #, fuzzy
 msgid "No needed patches found."
 msgstr "Akukho Ukuvuselelwa Kwama-Driver Amasha okutholakele"
 
-#: src/search.cc:342
+#: src/search.cc:344
 #, fuzzy
 msgid "No patterns found."
 msgstr "Awekho amaphutha atholakele."
 
-#: src/search.cc:450
+#: src/search.cc:453
 #, fuzzy
 msgid "No packages found."
 msgstr "Awekho amaphutha atholakele."
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 #, fuzzy
 msgid "Internal Name"
 msgstr "Iphutha Langaphakathi"
 
-#: src/search.cc:544
+#: src/search.cc:549
 #, fuzzy
 msgid "No products found."
 msgstr "Awekho amaphutha atholakele."
@@ -6613,7 +6631,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 #, fuzzy
 msgid "Patches"
 msgstr "isichibiyelo"
@@ -6638,7 +6656,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr "La maphakheji kudingeka afakwe (installed):"
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 #, fuzzy
 msgid "No updates found."
 msgstr "Awekho amaphutha atholakele."
@@ -6649,56 +6667,56 @@ msgstr "Awekho amaphutha atholakele."
 msgid "The following updates are also available:"
 msgstr "Imithombo yokwaziswa elandelayo iyalungiswa"
 
-#: src/update.cc:700
+#: src/update.cc:707
 #, fuzzy
 msgid "Package updates"
 msgstr "Igama lephakheja: %1"
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr ""
 
-#: src/update.cc:706
+#: src/update.cc:713
 #, fuzzy
 msgid "Product updates"
 msgstr "Umkhiqizo"
 
-#: src/update.cc:794
+#: src/update.cc:800
 #, fuzzy
 msgid "Current Version"
 msgstr "Ukuxhumana Kwamanje"
 
-#: src/update.cc:795
+#: src/update.cc:801
 #, fuzzy
 msgid "Available Version"
 msgstr "Imemori Etholakalayo"
 
-#: src/update.cc:972
+#: src/update.cc:980
 #, fuzzy
 msgid "No matching issues found."
 msgstr "Awekho amaphutha atholakele."
 
-#: src/update.cc:978
+#: src/update.cc:986
 #, fuzzy
 msgid "The following matches in issue numbers have been found:"
 msgstr "La maphakheji kudingeka afakwe (installed):"
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/po/zypper.pot
+++ b/po/zypper.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zypper\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 13:50+0200\n"
+"POT-Creation-Date: 2025-08-21 05:59+1000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1279,7 +1279,7 @@ msgstr ""
 msgid "Try again?"
 msgstr ""
 
-#: src/Zypper.cc:244 src/Zypper.cc:721 src/commands/basecommand.cc:293
+#: src/Zypper.cc:244 src/Zypper.cc:730 src/commands/basecommand.cc:293
 msgid "Unexpected exception."
 msgstr ""
 
@@ -1307,12 +1307,12 @@ msgstr ""
 
 #. TranslatorExplanation The %s is "--plus-repo"
 #. TranslatorExplanation The %s is "--option-name"
-#: src/Zypper.cc:536 src/Zypper.cc:588
+#: src/Zypper.cc:545 src/Zypper.cc:597
 #, c-format, boost-format
 msgid "The %s option has no effect here, ignoring."
 msgstr ""
 
-#: src/Zypper.cc:630
+#: src/Zypper.cc:639
 msgid "Non-option program arguments: "
 msgstr ""
 
@@ -1939,22 +1939,28 @@ msgid "Commands:"
 msgstr ""
 
 #. translators: --details
-#: src/commands/commonflags.h:23 src/commands/inrverify.cc:35
+#: src/commands/commonflags.h:25 src/commands/inrverify.cc:35
 msgid "Show the detailed installation summary."
 msgstr ""
 
-#: src/commands/commonflags.h:30
+#: src/commands/commonflags.h:32
 #, boost-format
 msgid "Type of package (%1%)."
 msgstr ""
 
 #. translators: --best-effort
-#: src/commands/commonflags.h:38
+#: src/commands/commonflags.h:40
 msgid "Do a 'best effort' approach to update. Updates to a lower than the latest version are also acceptable."
 msgstr ""
 
-#: src/commands/commonflags.h:45
+#: src/commands/commonflags.h:47
 msgid "Consider only patches which affect the package management itself."
+msgstr ""
+
+#. translators: --name-only
+#: src/commands/commonflags.h:61
+#, c-format, boost-format
+msgid "Just print %s ids."
 msgstr ""
 
 #: src/commands/conditions.cc:19
@@ -2013,7 +2019,7 @@ msgstr ""
 msgid "zypper <SUBCOMMAND> [--COMMAND-OPTIONS] [ARGUMENTS]"
 msgstr ""
 
-#: src/commands/help.cc:80 src/commands/help.cc:81
+#: src/commands/help.cc:89 src/commands/help.cc:90
 msgid "Print zypper help"
 msgstr ""
 
@@ -2164,22 +2170,22 @@ msgid "A PTF is typically removed as soon as the fix it provides is applied to t
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/listpatches.cc:16
+#: src/commands/listpatches.cc:17
 msgid "list-patches (lp) [OPTIONS]"
 msgstr ""
 
 #. translators: command summary: list-patches, lp
-#: src/commands/listpatches.cc:18
+#: src/commands/listpatches.cc:19
 msgid "List available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/listpatches.cc:20
+#: src/commands/listpatches.cc:21
 msgid "List all applicable patches."
 msgstr ""
 
 #. translators: -a, --all
-#: src/commands/listpatches.cc:31
+#: src/commands/listpatches.cc:32
 msgid "List all patches, not only applicable ones."
 msgstr ""
 
@@ -2226,47 +2232,51 @@ msgid "Specify locale which shall be supported by the language code. Get a list 
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/locale/localescmd.cc:17
+#: src/commands/locale/localescmd.cc:18
 msgid "locales (lloc) [OPTIONS] [LOCALE] ..."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:18
+#: src/commands/locale/localescmd.cc:19
 msgid "List requested locales (languages codes)."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:20
+#: src/commands/locale/localescmd.cc:21
 msgid "List requested locales and corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:34
+#: src/commands/locale/localescmd.cc:35
 msgid "Show corresponding packages."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:35
+#: src/commands/locale/localescmd.cc:36
 msgid "List all available locales."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:48
+#: src/commands/locale/localescmd.cc:37
+msgid "locale (or package)"
+msgstr ""
+
+#: src/commands/locale/localescmd.cc:51
 msgid "Ignoring positional arguments because --all argument was provided."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:75
+#: src/commands/locale/localescmd.cc:78
 msgid "The locale(s) for which the information shall be printed."
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:79
+#: src/commands/locale/localescmd.cc:82
 msgid "Get all locales with lang code 'en' that have their own country code, excluding the fallback 'en':"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:86
+#: src/commands/locale/localescmd.cc:89
 msgid "Get all locales with lang code 'en' with or without country code:"
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:93
+#: src/commands/locale/localescmd.cc:96
 msgid "Get the locale matching the argument exactly: "
 msgstr ""
 
-#: src/commands/locale/localescmd.cc:100
+#: src/commands/locale/localescmd.cc:103
 msgid "Get the list of packages which are available for 'de' and 'en':"
 msgstr ""
 
@@ -2358,11 +2368,11 @@ msgstr[1] ""
 #. translators: Table column header
 #. translators: header of table column - the name of the package
 #. translators: name (general header)
-#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:49
-#: src/commands/repos/list.cc:236 src/commands/services/list.cc:107
+#: src/commands/locks/list.cc:133 src/commands/repos/list.cc:50
+#: src/commands/repos/list.cc:239 src/commands/services/list.cc:109
 #: src/info.cc:92 src/info.cc:563 src/info.cc:798 src/locales.cc:201
-#: src/search.cc:48 src/search.cc:199 src/search.cc:304 src/search.cc:458
-#: src/search.cc:508 src/update.cc:789 src/utils/misc.cc:324
+#: src/search.cc:48 src/search.cc:199 src/search.cc:305 src/search.cc:461
+#: src/search.cc:512 src/update.cc:795 src/utils/misc.cc:324
 msgid "Name"
 msgstr ""
 
@@ -2372,8 +2382,8 @@ msgstr ""
 
 #. translators: Table column header
 #. translators: type (general header)
-#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:63
-#: src/commands/repos/list.cc:285 src/commands/services/list.cc:116
+#: src/commands/locks/list.cc:136 src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:288 src/commands/services/list.cc:118
 #: src/info.cc:564 src/search.cc:50 src/search.cc:202
 msgid "Type"
 msgstr ""
@@ -2381,7 +2391,7 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: package's repository (header)
 #: src/commands/locks/list.cc:136 src/info.cc:90 src/search.cc:56
-#: src/search.cc:306 src/search.cc:457 src/search.cc:504 src/update.cc:786
+#: src/search.cc:307 src/search.cc:460 src/search.cc:508 src/update.cc:792
 #: src/utils/misc.cc:323
 msgid "Repository"
 msgstr ""
@@ -2756,7 +2766,7 @@ msgid "Command"
 msgstr ""
 
 #. "/etc/init.d/ script that might be used to restart the command (guessed)
-#: src/commands/ps.cc:152 src/commands/repos/list.cc:301
+#: src/commands/ps.cc:152 src/commands/repos/list.cc:304
 msgid "Service"
 msgstr ""
 
@@ -2905,116 +2915,116 @@ msgid "Show detailed information for products."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/packages.cc:18
+#: src/commands/query/packages.cc:19
 msgid "packages (pa) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: packages, pa
-#: src/commands/query/packages.cc:20
+#: src/commands/query/packages.cc:21
 msgid "List all available packages."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/packages.cc:22
+#: src/commands/query/packages.cc:23
 msgid "List all packages available in specified repositories."
 msgstr ""
 
 #. translators: --autoinstalled
-#: src/commands/query/packages.cc:35
+#: src/commands/query/packages.cc:36
 msgid "Show installed packages which were automatically selected by the resolver."
 msgstr ""
 
 #. translators: --userinstalled
-#: src/commands/query/packages.cc:39
+#: src/commands/query/packages.cc:40
 msgid "Show installed packages which were explicitly selected by the user."
 msgstr ""
 
 #. translators: --system
-#: src/commands/query/packages.cc:43
+#: src/commands/query/packages.cc:44
 msgid "Show installed packages which are not provided by any repository."
 msgstr ""
 
 #. translators: --orphaned
-#: src/commands/query/packages.cc:47
+#: src/commands/query/packages.cc:48
 msgid "Show system packages which are orphaned (without repository and without update candidate)."
 msgstr ""
 
 #. translators: --suggested
-#: src/commands/query/packages.cc:51
+#: src/commands/query/packages.cc:52
 msgid "Show packages which are suggested."
 msgstr ""
 
 #. translators: --recommended
-#: src/commands/query/packages.cc:55
+#: src/commands/query/packages.cc:56
 msgid "Show packages which are recommended."
 msgstr ""
 
 #. translators: --unneeded
-#: src/commands/query/packages.cc:59
+#: src/commands/query/packages.cc:60
 msgid "Show packages which are unneeded."
 msgstr ""
 
 #. translators: -N, --sort-by-name
-#: src/commands/query/packages.cc:63
+#: src/commands/query/packages.cc:64
 msgid "Sort the list by package name."
 msgstr ""
 
 #. translators: -R, --sort-by-repo
-#: src/commands/query/packages.cc:67
+#: src/commands/query/packages.cc:68
 msgid "Sort the list by repository."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patches.cc:18
+#: src/commands/query/patches.cc:19
 msgid "patches (pch) [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patches, pch
-#: src/commands/query/patches.cc:20
+#: src/commands/query/patches.cc:21
 msgid "List all available patches."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patches.cc:22
+#: src/commands/query/patches.cc:23
 msgid "List all patches available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/patterns.cc:18
+#: src/commands/query/patterns.cc:19
 msgid "patterns (pt) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: patterns, pt
-#: src/commands/query/patterns.cc:20
+#: src/commands/query/patterns.cc:21
 msgid "List all available patterns."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/patterns.cc:22
+#: src/commands/query/patterns.cc:23
 msgid "List all patterns available in specified repositories."
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
-#: src/commands/query/products.cc:18
+#: src/commands/query/products.cc:19
 msgid "products (pd) [OPTIONS] [REPOSITORY] ..."
 msgstr ""
 
 #. translators: command summary: products, pd
-#: src/commands/query/products.cc:20
+#: src/commands/query/products.cc:21
 msgid "List all available products."
 msgstr ""
 
 #. translators: command description
-#: src/commands/query/products.cc:22
+#: src/commands/query/products.cc:23
 msgid "List all products available in specified repositories."
 msgstr ""
 
 #. translators: --xmlfwd <TAG>
-#: src/commands/query/products.cc:36
+#: src/commands/query/products.cc:37
 msgid "XML output only: Literally forward the XML tags found in a product file."
 msgstr ""
 
-#: src/commands/query/products.cc:50
+#: src/commands/query/products.cc:53
 #, boost-format
 msgid "Option %1% has no effect without the %2% global option."
 msgstr ""
@@ -3051,12 +3061,12 @@ msgstr ""
 msgid "The repository type is always autodetected. This option is ignored."
 msgstr ""
 
-#: src/commands/repos/add.cc:70
+#: src/commands/repos/add.cc:71
 #, c-format, boost-format
 msgid "Cannot use %s together with %s. Using the %s setting."
 msgstr ""
 
-#: src/commands/repos/add.cc:93
+#: src/commands/repos/add.cc:98
 msgid "If only one argument is used, it must be a URI pointing to a .repo file."
 msgstr ""
 
@@ -3097,111 +3107,115 @@ msgstr ""
 msgid "Clean both metadata and package caches."
 msgstr ""
 
-#: src/commands/repos/list.cc:48 src/commands/repos/list.cc:225
-#: src/commands/services/list.cc:106
+#: src/commands/repos/list.cc:49 src/commands/repos/list.cc:228
+#: src/commands/services/list.cc:108
 msgid "Alias"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translator: Option argument like '--export <FILE.repo>'. Do do not translate lowercase wordparts
-#: src/commands/repos/list.cc:51 src/commands/repos/list.cc:54
-#: src/commands/repos/list.cc:292 src/commands/services/add.cc:83
-#: src/commands/services/list.cc:118 src/repos.cc:1249
+#: src/commands/repos/list.cc:52 src/commands/repos/list.cc:55
+#: src/commands/repos/list.cc:295 src/commands/services/add.cc:83
+#: src/commands/services/list.cc:120 src/repos.cc:1242
 #: src/utils/flags/zyppflags.h:49
 msgid "URI"
 msgstr ""
 
 #. 'enabled' flag
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:58 src/commands/repos/list.cc:244
-#: src/commands/services/add.cc:85 src/commands/services/list.cc:108
-#: src/repos.cc:1251
+#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:247
+#: src/commands/services/add.cc:85 src/commands/services/list.cc:110
+#: src/repos.cc:1244
 msgid "Enabled"
 msgstr ""
 
 #. GPG Check
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:59 src/commands/repos/list.cc:248
-#: src/commands/services/list.cc:109 src/repos.cc:1253
+#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:251
+#: src/commands/services/list.cc:111 src/repos.cc:1246
 msgid "GPG Check"
 msgstr ""
 
 #. translators: repository priority (in zypper repos -p or -d)
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:60 src/commands/repos/list.cc:276
-#: src/commands/services/list.cc:115 src/repos.cc:1257
+#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:279
+#: src/commands/services/list.cc:117 src/repos.cc:1250
 msgid "Priority"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/commands/repos/list.cc:61 src/commands/services/add.cc:87
-#: src/repos.cc:1255
+#: src/commands/repos/list.cc:62 src/commands/services/add.cc:87
+#: src/repos.cc:1248
 msgid "Autorefresh"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "On"
 msgstr ""
 
-#: src/commands/repos/list.cc:61 src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:62 src/commands/repos/list.cc:63
 msgid "Off"
 msgstr ""
 
-#: src/commands/repos/list.cc:62
+#: src/commands/repos/list.cc:63
 msgid "Keep Packages"
 msgstr ""
 
-#: src/commands/repos/list.cc:64
+#: src/commands/repos/list.cc:65
 msgid "GPG Key URI"
 msgstr ""
 
-#: src/commands/repos/list.cc:65
+#: src/commands/repos/list.cc:66
 msgid "Path Prefix"
 msgstr ""
 
-#: src/commands/repos/list.cc:66
+#: src/commands/repos/list.cc:67
 msgid "Parent Service"
 msgstr ""
 
-#: src/commands/repos/list.cc:67
+#: src/commands/repos/list.cc:68
 msgid "Keywords"
 msgstr ""
 
-#: src/commands/repos/list.cc:68
+#: src/commands/repos/list.cc:69
 msgid "Repo Info Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:69
+#: src/commands/repos/list.cc:70
 msgid "MD Cache Path"
 msgstr ""
 
-#: src/commands/repos/list.cc:85
+#: src/commands/repos/list.cc:86
 msgid "repos (lr) [OPTIONS] [REPO] ..."
 msgstr ""
 
-#: src/commands/repos/list.cc:86 src/commands/repos/list.cc:87
+#: src/commands/repos/list.cc:87 src/commands/repos/list.cc:88
 msgid "List all defined repositories."
 msgstr ""
 
 #. translators: -e, --export <FILE.repo>
-#: src/commands/repos/list.cc:98
+#: src/commands/repos/list.cc:99
 msgid "Export all defined repositories as a single local .repo file."
 msgstr ""
 
-#: src/commands/repos/list.cc:129 src/repos.cc:1006
+#: src/commands/repos/list.cc:100
+msgid "repository"
+msgstr ""
+
+#: src/commands/repos/list.cc:132 src/repos.cc:999
 msgid "Error reading repositories:"
 msgstr ""
 
-#: src/commands/repos/list.cc:155
+#: src/commands/repos/list.cc:158
 #, c-format, boost-format
 msgid "Can't open %s for writing."
 msgstr ""
 
-#: src/commands/repos/list.cc:156
+#: src/commands/repos/list.cc:159
 msgid "Maybe you do not have write permissions?"
 msgstr ""
 
-#: src/commands/repos/list.cc:162
+#: src/commands/repos/list.cc:165
 #, c-format, boost-format
 msgid "Repositories have been successfully exported to %s."
 msgstr ""
@@ -3209,20 +3223,20 @@ msgstr ""
 #. translators: 'zypper repos' column - whether autorefresh is enabled
 #. for the repository
 #. translators: 'zypper repos' column - whether autorefresh is enabled for the repository
-#: src/commands/repos/list.cc:256 src/commands/services/list.cc:111
+#: src/commands/repos/list.cc:259 src/commands/services/list.cc:113
 msgid "Refresh"
 msgstr ""
 
 #. translators: 'zypper repos' column - whether keep-packages is enabled for the repository
-#: src/commands/repos/list.cc:266
+#: src/commands/repos/list.cc:269
 msgid "Keep"
 msgstr ""
 
-#: src/commands/repos/list.cc:357
+#: src/commands/repos/list.cc:360
 msgid "No repositories defined."
 msgstr ""
 
-#: src/commands/repos/list.cc:358
+#: src/commands/repos/list.cc:361
 msgid "Use the 'zypper addrepo' command to add one or more repositories."
 msgstr ""
 
@@ -3317,7 +3331,7 @@ msgstr ""
 msgid "Arguments are not allowed if '%s' is used."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:239 src/repos.cc:1018
+#: src/commands/repos/refresh.cc:239 src/repos.cc:1011
 msgid "Specified repositories: "
 msgstr ""
 
@@ -3326,7 +3340,7 @@ msgstr ""
 msgid "Refreshing repository '%s'."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:280 src/repos.cc:843
+#: src/commands/repos/refresh.cc:280 src/repos.cc:836
 #, c-format, boost-format
 msgid "Scanning content of disabled repository '%s'."
 msgstr ""
@@ -3336,7 +3350,7 @@ msgstr ""
 msgid "Skipping disabled repository '%s'"
 msgstr ""
 
-#: src/commands/repos/refresh.cc:306 src/repos.cc:861 src/repos.cc:908
+#: src/commands/repos/refresh.cc:306 src/repos.cc:854 src/repos.cc:901
 #, c-format, boost-format
 msgid "Skipping repository '%s' because of the above error."
 msgstr ""
@@ -3362,7 +3376,7 @@ msgstr ""
 msgid "Could not refresh the repositories because of errors."
 msgstr ""
 
-#: src/commands/repos/refresh.cc:342 src/repos.cc:937
+#: src/commands/repos/refresh.cc:342 src/repos.cc:930
 msgid "Some of the repositories have not been refreshed because of an error."
 msgstr ""
 
@@ -3413,12 +3427,12 @@ msgstr ""
 msgid "Repository '%s' renamed to '%s'."
 msgstr ""
 
-#: src/commands/repos/rename.cc:47 src/repos.cc:1197
+#: src/commands/repos/rename.cc:47 src/repos.cc:1190
 #, c-format, boost-format
 msgid "Repository named '%s' already exists. Please use another alias."
 msgstr ""
 
-#: src/commands/repos/rename.cc:52 src/repos.cc:1675
+#: src/commands/repos/rename.cc:52 src/repos.cc:1668
 msgid "Error while modifying the repository:"
 msgstr ""
 
@@ -3811,25 +3825,25 @@ msgstr ""
 msgid "Like --details, with additional information where the search has matched (useful for search in dependencies)."
 msgstr ""
 
-#: src/commands/search/search.cc:298 src/repos.cc:780
+#: src/commands/search/search.cc:300 src/repos.cc:773
 #, c-format, boost-format
 msgid "Specified repository '%s' is disabled."
 msgstr ""
 
 #. translators: empty search result message
-#: src/commands/search/search.cc:471 src/info.cc:366
+#: src/commands/search/search.cc:473 src/info.cc:366
 msgid "No matching items found."
 msgstr ""
 
-#: src/commands/search/search.cc:503
+#: src/commands/search/search.cc:508
 msgid "Problem occurred initializing or executing the search query"
 msgstr ""
 
-#: src/commands/search/search.cc:504
+#: src/commands/search/search.cc:509
 msgid "See the above message for a hint."
 msgstr ""
 
-#: src/commands/search/search.cc:505 src/repos.cc:985
+#: src/commands/search/search.cc:510 src/repos.cc:978
 msgid "Running 'zypper refresh' as root might resolve the problem."
 msgstr ""
 
@@ -3916,7 +3930,7 @@ msgid "Problem retrieving the repository index file for service '%s':"
 msgstr ""
 
 #: src/commands/services/common.cc:138 src/commands/services/refresh.cc:226
-#: src/repos.cc:1727
+#: src/repos.cc:1720
 #, c-format, boost-format
 msgid "Skipping service '%s' because of the above error."
 msgstr ""
@@ -3935,21 +3949,25 @@ msgstr ""
 msgid "Service '%s' has been removed."
 msgstr ""
 
-#: src/commands/services/list.cc:83
+#: src/commands/services/list.cc:85
 msgid "services (ls) [OPTIONS]"
 msgstr ""
 
-#: src/commands/services/list.cc:84
+#: src/commands/services/list.cc:86
 msgid "List all defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:85
+#: src/commands/services/list.cc:87
 msgid "List defined services."
 msgstr ""
 
-#: src/commands/services/list.cc:172
+#: src/commands/services/list.cc:174
 #, c-format, boost-format
 msgid "No services defined. Use the '%s' command to add one or more services."
+msgstr ""
+
+#: src/commands/services/list.cc:237
+msgid "service"
 msgstr ""
 
 #. translators: command synopsis; do not translate lowercase words
@@ -4775,15 +4793,15 @@ msgstr ""
 #. translators: property name; short; used like "Name: value"
 #. translators: Table column header
 #. translators: package version (header)
-#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:305
-#: src/search.cc:459 src/search.cc:509
+#: src/info.cc:94 src/info.cc:799 src/search.cc:52 src/search.cc:306
+#: src/search.cc:462 src/search.cc:513
 msgid "Version"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
 #. translators: package architecture (header)
-#: src/info.cc:96 src/search.cc:54 src/search.cc:460 src/search.cc:510
-#: src/update.cc:795
+#: src/info.cc:96 src/search.cc:54 src/search.cc:463 src/search.cc:514
+#: src/update.cc:801
 msgid "Arch"
 msgstr ""
 
@@ -4915,13 +4933,13 @@ msgstr ""
 #. translators: S for installed Status
 #. TranslatorExplanation S stands for Status
 #: src/info.cc:562 src/info.cc:797 src/locales.cc:199 src/search.cc:46
-#: src/search.cc:198 src/search.cc:303 src/search.cc:456 src/search.cc:503
-#: src/update.cc:784
+#: src/search.cc:198 src/search.cc:304 src/search.cc:459 src/search.cc:507
+#: src/update.cc:790
 msgid "S"
 msgstr ""
 
 #. translators: Table column header
-#: src/info.cc:565 src/search.cc:307
+#: src/info.cc:565 src/search.cc:308
 msgid "Dependency"
 msgstr ""
 
@@ -4958,7 +4976,7 @@ msgid "Flavor"
 msgstr ""
 
 #. translators: property name; short; used like "Name: value"
-#: src/info.cc:658 src/search.cc:511
+#: src/info.cc:658 src/search.cc:515
 msgid "Is Base"
 msgstr ""
 
@@ -5204,128 +5222,128 @@ msgstr[1] ""
 
 #. check whether libzypp indicates a refresh is needed, and if so,
 #. print a message
-#: src/repos.cc:227
+#: src/repos.cc:226
 #, c-format, boost-format
 msgid "Checking whether to refresh metadata for %s"
 msgstr ""
 
-#: src/repos.cc:257
+#: src/repos.cc:250
 #, c-format, boost-format
 msgid "Repository '%s' is up to date."
 msgstr ""
 
-#: src/repos.cc:263
+#: src/repos.cc:256
 #, c-format, boost-format
 msgid "The up-to-date check of '%s' has been delayed."
 msgstr ""
 
-#: src/repos.cc:285
+#: src/repos.cc:278
 msgid "Forcing raw metadata refresh"
 msgstr ""
 
-#: src/repos.cc:291
+#: src/repos.cc:284
 #, c-format, boost-format
 msgid "Retrieving repository '%s' metadata"
 msgstr ""
 
-#: src/repos.cc:315
+#: src/repos.cc:308
 #, c-format, boost-format
 msgid "Do you want to disable the repository %s permanently?"
 msgstr ""
 
-#: src/repos.cc:331
+#: src/repos.cc:324
 #, c-format, boost-format
 msgid "Error while disabling repository '%s'."
 msgstr ""
 
-#: src/repos.cc:347
+#: src/repos.cc:340
 #, c-format, boost-format
 msgid "Problem retrieving files from '%s'."
 msgstr ""
 
-#: src/repos.cc:348 src/repos.cc:1866 src/solve-commit.cc:990
+#: src/repos.cc:341 src/repos.cc:1859 src/solve-commit.cc:990
 #: src/solve-commit.cc:1022 src/solve-commit.cc:1046
 msgid "Please see the above error message for a hint."
 msgstr ""
 
-#: src/repos.cc:360
+#: src/repos.cc:353
 #, c-format, boost-format
 msgid "No URIs defined for '%s'."
 msgstr ""
 
 #. TranslatorExplanation the first %s is a .repo file path
-#: src/repos.cc:365
+#: src/repos.cc:358
 #, c-format, boost-format
 msgid "Please add one or more base URI (baseurl=URI) entries to %s for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:379
+#: src/repos.cc:372
 msgid "No alias defined for this repository."
 msgstr ""
 
-#: src/repos.cc:391
+#: src/repos.cc:384
 #, c-format, boost-format
 msgid "Repository '%s' is invalid."
 msgstr ""
 
-#: src/repos.cc:392
+#: src/repos.cc:385
 msgid "Please check if the URIs defined for this repository are pointing to a valid repository."
 msgstr ""
 
-#: src/repos.cc:404
+#: src/repos.cc:397
 #, c-format, boost-format
 msgid "Error retrieving metadata for '%s':"
 msgstr ""
 
-#: src/repos.cc:417
+#: src/repos.cc:410
 msgid "Forcing building of repository cache"
 msgstr ""
 
-#: src/repos.cc:442
+#: src/repos.cc:435
 #, c-format, boost-format
 msgid "Error parsing metadata for '%s':"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the URL unless it is translated, too
-#: src/repos.cc:444
+#: src/repos.cc:437
 msgid "This may be caused by invalid metadata in the repository, or by a bug in the metadata parser. In the latter case, or if in doubt, please, file a bug report by following instructions at http://en.opensuse.org/Zypper/Troubleshooting"
 msgstr ""
 
-#: src/repos.cc:453
+#: src/repos.cc:446
 #, c-format, boost-format
 msgid "Repository metadata for '%s' not found in local cache."
 msgstr ""
 
-#: src/repos.cc:461
+#: src/repos.cc:454
 msgid "Error building the cache:"
 msgstr ""
 
-#: src/repos.cc:680
+#: src/repos.cc:673
 #, c-format, boost-format
 msgid "Repository '%s' not found by its alias, number, or URI."
 msgstr ""
 
-#: src/repos.cc:682
+#: src/repos.cc:675
 #, c-format, boost-format
 msgid "Use '%s' to get the list of defined repositories."
 msgstr ""
 
-#: src/repos.cc:702
+#: src/repos.cc:695
 #, c-format, boost-format
 msgid "Ignoring disabled repository '%s'"
 msgstr ""
 
-#: src/repos.cc:786
+#: src/repos.cc:779
 #, c-format, boost-format
 msgid "Global option '%s' can be used to temporarily enable repositories."
 msgstr ""
 
-#: src/repos.cc:802 src/repos.cc:808
+#: src/repos.cc:795 src/repos.cc:801
 #, c-format, boost-format
 msgid "Ignoring repository '%s' because of '%s' option."
 msgstr ""
 
-#: src/repos.cc:829 src/repos.cc:922
+#: src/repos.cc:822 src/repos.cc:915
 #, c-format, boost-format
 msgid "Temporarily enabling repository '%s'."
 msgstr ""
@@ -5333,311 +5351,311 @@ msgstr ""
 #. bsc#1235636: Asks to suppress reporting the Exception (usually: No permission to
 #. write repository cache), because it scares. This was was indeed the legacy behavior:
 #. SUPPRESS: zypper.out().error( ex, "Problem" );
-#: src/repos.cc:886
+#: src/repos.cc:879
 #, c-format, boost-format
 msgid "Repository '%s' is out-of-date. You can run 'zypper refresh' as root to update it."
 msgstr ""
 
-#: src/repos.cc:903
+#: src/repos.cc:896
 #, c-format, boost-format
 msgid "The metadata cache needs to be built for the '%s' repository. You can run 'zypper refresh' as root to do this."
 msgstr ""
 
-#: src/repos.cc:929
+#: src/repos.cc:922
 #, c-format, boost-format
 msgid "Repository '%s' stays disabled."
 msgstr ""
 
-#: src/repos.cc:976
+#: src/repos.cc:969
 msgid "Initializing Target"
 msgstr ""
 
-#: src/repos.cc:984
+#: src/repos.cc:977
 msgid "Target initialization failed:"
 msgstr ""
 
-#: src/repos.cc:1066
+#: src/repos.cc:1059
 #, c-format, boost-format
 msgid "Cleaning metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1074
+#: src/repos.cc:1067
 #, c-format, boost-format
 msgid "Cleaning raw metadata cache for '%s'."
 msgstr ""
 
-#: src/repos.cc:1080
+#: src/repos.cc:1073
 #, c-format, boost-format
 msgid "Keeping raw metadata cache for %s '%s'."
 msgstr ""
 
 #. translators: meaning the cached rpm files
-#: src/repos.cc:1087
+#: src/repos.cc:1080
 #, c-format, boost-format
 msgid "Cleaning packages for '%s'."
 msgstr ""
 
-#: src/repos.cc:1095
+#: src/repos.cc:1088
 #, c-format, boost-format
 msgid "Cannot clean repository '%s' because of an error."
 msgstr ""
 
-#: src/repos.cc:1106
+#: src/repos.cc:1099
 msgid "Cleaning installed packages cache."
 msgstr ""
 
-#: src/repos.cc:1115
+#: src/repos.cc:1108
 msgid "Cannot clean installed packages cache because of an error."
 msgstr ""
 
-#: src/repos.cc:1133
+#: src/repos.cc:1126
 msgid "Could not clean the repositories because of errors."
 msgstr ""
 
-#: src/repos.cc:1139
+#: src/repos.cc:1132
 msgid "Some of the repositories have not been cleaned up because of an error."
 msgstr ""
 
-#: src/repos.cc:1144
+#: src/repos.cc:1137
 msgid "Specified repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1146
+#: src/repos.cc:1139
 msgid "All repositories have been cleaned up."
 msgstr ""
 
-#: src/repos.cc:1168
+#: src/repos.cc:1161
 msgid "This is a changeable read-only media (CD/DVD), disabling autorefresh."
 msgstr ""
 
-#: src/repos.cc:1189
+#: src/repos.cc:1182
 #, c-format, boost-format
 msgid "Invalid repository alias: '%s'"
 msgstr ""
 
-#: src/repos.cc:1206
+#: src/repos.cc:1199
 msgid "Could not determine the type of the repository. Please check if the defined URIs (see below) point to a valid repository:"
 msgstr ""
 
-#: src/repos.cc:1212
+#: src/repos.cc:1205
 msgid "Can't find a valid repository at given location:"
 msgstr ""
 
-#: src/repos.cc:1220
+#: src/repos.cc:1213
 msgid "Problem transferring repository data from specified URI:"
 msgstr ""
 
-#: src/repos.cc:1221
+#: src/repos.cc:1214
 msgid "Please check whether the specified URI is accessible."
 msgstr ""
 
-#: src/repos.cc:1228
+#: src/repos.cc:1221
 msgid "Unknown problem when adding repository:"
 msgstr ""
 
 #. translators: BOOST STYLE POSITIONAL DIRECTIVES ( %N% )
 #. translators: %1% - a repository name
-#: src/repos.cc:1238
+#: src/repos.cc:1231
 #, boost-format
 msgid "GPG checking is disabled in configuration of repository '%1%'. Integrity and origin of packages cannot be verified."
 msgstr ""
 
-#: src/repos.cc:1243
+#: src/repos.cc:1236
 #, c-format, boost-format
 msgid "Repository '%s' successfully added"
 msgstr ""
 
-#: src/repos.cc:1269
-#, c-format, boost-format
-msgid "Reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1275
-#, c-format, boost-format
-msgid "Problem reading data from '%s' media"
-msgstr ""
-
-#: src/repos.cc:1276
-msgid "Please check if your installation media is valid and readable."
-msgstr ""
-
-#: src/repos.cc:1283
+#: src/repos.cc:1262
 #, c-format, boost-format
 msgid "Reading data from '%s' media is delayed until next refresh."
 msgstr ""
 
-#: src/repos.cc:1352
+#: src/repos.cc:1267
+#, c-format, boost-format
+msgid "Reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1273
+#, c-format, boost-format
+msgid "Problem reading data from '%s' media"
+msgstr ""
+
+#: src/repos.cc:1274
+msgid "Please check if your installation media is valid and readable."
+msgstr ""
+
+#: src/repos.cc:1345
 msgid "Problem accessing the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1353
+#: src/repos.cc:1346
 msgid "Please check if the URI is valid and accessible."
 msgstr ""
 
-#: src/repos.cc:1360
+#: src/repos.cc:1353
 msgid "Problem parsing the file at the specified URI"
 msgstr ""
 
 #. TranslatorExplanation Don't translate the '.repo' string.
-#: src/repos.cc:1362
+#: src/repos.cc:1355
 msgid "Is it a .repo file?"
 msgstr ""
 
-#: src/repos.cc:1369
+#: src/repos.cc:1362
 msgid "Problem encountered while trying to read the file at the specified URI"
 msgstr ""
 
-#: src/repos.cc:1382
+#: src/repos.cc:1375
 msgid "Repository with no alias defined found in the file, skipping."
 msgstr ""
 
-#: src/repos.cc:1388
+#: src/repos.cc:1381
 #, c-format, boost-format
 msgid "Repository '%s' has no URI defined, skipping."
 msgstr ""
 
-#: src/repos.cc:1436
+#: src/repos.cc:1429
 #, c-format, boost-format
 msgid "Repository '%s' has been removed."
 msgstr ""
 
-#: src/repos.cc:1584
+#: src/repos.cc:1577
 #, c-format, boost-format
 msgid "Repository '%s' priority has been left unchanged (%d)"
 msgstr ""
 
-#: src/repos.cc:1617
+#: src/repos.cc:1610
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully enabled."
 msgstr ""
 
-#: src/repos.cc:1619
+#: src/repos.cc:1612
 #, c-format, boost-format
 msgid "Repository '%s' has been successfully disabled."
 msgstr ""
 
-#: src/repos.cc:1626
+#: src/repos.cc:1619
 #, c-format, boost-format
 msgid "Autorefresh has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1628
+#: src/repos.cc:1621
 #, c-format, boost-format
 msgid "Autorefresh has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1635
+#: src/repos.cc:1628
 #, c-format, boost-format
 msgid "RPM files caching has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1637
+#: src/repos.cc:1630
 #, c-format, boost-format
 msgid "RPM files caching has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1644
+#: src/repos.cc:1637
 #, c-format, boost-format
 msgid "GPG check has been enabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1646
+#: src/repos.cc:1639
 #, c-format, boost-format
 msgid "GPG check has been disabled for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1652
+#: src/repos.cc:1645
 #, c-format, boost-format
 msgid "Repository '%s' priority has been set to %d."
 msgstr ""
 
-#: src/repos.cc:1658
+#: src/repos.cc:1651
 #, c-format, boost-format
 msgid "Name of repository '%s' has been set to '%s'."
 msgstr ""
 
-#: src/repos.cc:1669
+#: src/repos.cc:1662
 #, c-format, boost-format
 msgid "Nothing to change for repository '%s'."
 msgstr ""
 
-#: src/repos.cc:1676
+#: src/repos.cc:1669
 #, c-format, boost-format
 msgid "Leaving repository %s unchanged."
 msgstr ""
 
-#: src/repos.cc:1763
+#: src/repos.cc:1756
 msgid "Loading repository data..."
 msgstr ""
 
-#: src/repos.cc:1765
+#: src/repos.cc:1758
 msgid "No repositories defined. Operating only with the installed resolvables. Nothing can be installed."
 msgstr ""
 
-#: src/repos.cc:1788
+#: src/repos.cc:1781
 #, c-format, boost-format
 msgid "Retrieving repository '%s' data..."
 msgstr ""
 
-#: src/repos.cc:1796
+#: src/repos.cc:1789
 #, c-format, boost-format
 msgid "Repository '%s' not cached. Caching..."
 msgstr ""
 
-#: src/repos.cc:1802 src/repos.cc:1836
+#: src/repos.cc:1795 src/repos.cc:1829
 #, c-format, boost-format
 msgid "Problem loading data from '%s'"
 msgstr ""
 
-#: src/repos.cc:1806
+#: src/repos.cc:1799
 #, c-format, boost-format
 msgid "Repository '%s' could not be refreshed. Using old cache."
 msgstr ""
 
-#: src/repos.cc:1810 src/repos.cc:1839
+#: src/repos.cc:1803 src/repos.cc:1832
 #, c-format, boost-format
 msgid "Resolvables from '%s' not loaded because of error."
 msgstr ""
 
-#: src/repos.cc:1826
+#: src/repos.cc:1819
 #, boost-format
 msgid "Repository '%1%' metadata expired since %2%."
 msgstr ""
 
 #. translators: the first %s is 'zypper refresh' and the second 'zypper clean -m'
-#: src/repos.cc:1838
+#: src/repos.cc:1831
 #, c-format, boost-format
 msgid "Try '%s', or even '%s' before doing so."
 msgstr ""
 
-#: src/repos.cc:1843
+#: src/repos.cc:1836
 msgid "Repository metadata expired: Check if 'autorefresh' is turned on (zypper lr), otherwise manually refresh the repository (zypper ref). If this does not solve the issue, it could be that you are using a broken mirror or the server has actually discontinued to support the repository."
 msgstr ""
 
-#: src/repos.cc:1856
+#: src/repos.cc:1849
 msgid "Reading installed packages..."
 msgstr ""
 
-#: src/repos.cc:1865
+#: src/repos.cc:1858
 msgid "Problem occurred while reading the installed packages:"
 msgstr ""
 
-#: src/repos.cc:1882
+#: src/repos.cc:1875
 #, c-format, boost-format
 msgid "'%s' looks like an RPM file. Will try to download it."
 msgstr ""
 
-#: src/repos.cc:1891
+#: src/repos.cc:1884
 #, c-format, boost-format
 msgid "Problem with the RPM file specified as '%s', skipping."
 msgstr ""
 
-#: src/repos.cc:1913
+#: src/repos.cc:1906
 #, c-format, boost-format
 msgid "Problem reading the RPM header of %s. Is it an RPM file?"
 msgstr ""
 
-#: src/repos.cc:1933
+#: src/repos.cc:1926
 msgid "Plain RPM files cache"
 msgstr ""
 
@@ -5645,25 +5663,25 @@ msgstr ""
 msgid "System Packages"
 msgstr ""
 
-#: src/search.cc:261
+#: src/search.cc:262
 msgid "No needed patches found."
 msgstr ""
 
-#: src/search.cc:342
+#: src/search.cc:344
 msgid "No patterns found."
 msgstr ""
 
-#: src/search.cc:450
+#: src/search.cc:453
 msgid "No packages found."
 msgstr ""
 
 #. translators: used in products. Internal Name is the unix name of the
 #. product whereas simply Name is the official full name of the product.
-#: src/search.cc:507
+#: src/search.cc:511
 msgid "Internal Name"
 msgstr ""
 
-#: src/search.cc:544
+#: src/search.cc:549
 msgid "No products found."
 msgstr ""
 
@@ -6016,7 +6034,7 @@ msgid "Updatestack"
 msgstr ""
 
 #. translator: Table column header.
-#: src/update.cc:410 src/update.cc:702
+#: src/update.cc:410 src/update.cc:709
 msgid "Patches"
 msgstr ""
 
@@ -6039,7 +6057,7 @@ msgstr ""
 msgid "Needed software management updates will be installed first:"
 msgstr ""
 
-#: src/update.cc:600 src/update.cc:842
+#: src/update.cc:600 src/update.cc:848
 msgid "No updates found."
 msgstr ""
 
@@ -6048,50 +6066,50 @@ msgstr ""
 msgid "The following updates are also available:"
 msgstr ""
 
-#: src/update.cc:700
+#: src/update.cc:707
 msgid "Package updates"
 msgstr ""
 
-#: src/update.cc:704
+#: src/update.cc:711
 msgid "Pattern updates"
 msgstr ""
 
-#: src/update.cc:706
+#: src/update.cc:713
 msgid "Product updates"
 msgstr ""
 
-#: src/update.cc:794
+#: src/update.cc:800
 msgid "Current Version"
 msgstr ""
 
-#: src/update.cc:795
+#: src/update.cc:801
 msgid "Available Version"
 msgstr ""
 
-#: src/update.cc:972
+#: src/update.cc:980
 msgid "No matching issues found."
 msgstr ""
 
-#: src/update.cc:978
+#: src/update.cc:986
 msgid "The following matches in issue numbers have been found:"
 msgstr ""
 
-#: src/update.cc:988
+#: src/update.cc:996
 msgid "Matches in patch descriptions of the following patches have been found:"
 msgstr ""
 
-#: src/update.cc:1050
+#: src/update.cc:1058
 #, c-format, boost-format
 msgid "Fix for bugzilla issue number %s was not found or is not needed."
 msgstr ""
 
-#: src/update.cc:1052
+#: src/update.cc:1060
 #, c-format, boost-format
 msgid "Fix for CVE issue number %s was not found or is not needed."
 msgstr ""
 
 #. translators: keep '%s issue' together, it's something like 'CVE issue' or 'Bugzilla issue'
-#: src/update.cc:1055
+#: src/update.cc:1063
 #, c-format, boost-format
 msgid "Fix for %s issue number %s was not found or is not needed."
 msgstr ""

--- a/src/callbacks/keyring.h
+++ b/src/callbacks/keyring.h
@@ -519,7 +519,7 @@ namespace zypp
         Zypper & zypper = Zypper::instance();
         std::string unblock( found.substr( 0, 4 ) );
 
-        zypper.out().gap();
+        zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
         // translators: !!! BOOST STYLE PLACEHOLDERS ( %N% - reorder and multiple occurrence is OK )
         // translators: %1%      - a file name
         // translators: %2%      - full path name
@@ -540,7 +540,7 @@ namespace zypp
                 "Accepting packages with wrong checksums can lead to a corrupted system "
                 "and in extreme cases even to a system compromise." ) ).str()
         );
-        zypper.out().gap();
+        zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
 
         // translators: !!! BOOST STYLE PLACEHOLDERS ( %N% - reorder and multiple occurrence is OK )
         // translators: %1%      - abbreviated checksum (4 chars)

--- a/src/commands/commonflags.h
+++ b/src/commands/commonflags.h
@@ -8,6 +8,8 @@
 #define ZYPPER_COMMANDS_COMMONFLAGS_INCLUDED
 
 #include "utils/flags/flagtypes.h"
+#include "utils/misc.h"
+#include "Zypper.h"
 
 /**
  * \file Contains all flags that are commonly used in multiple commands but which are too simple for a OptionSet
@@ -44,6 +46,27 @@ namespace CommonFlags
       "updatestack-only", '\0', zypp::ZyppFlags::NoArgument, zypp::ZyppFlags::BoolType( &targetFlag, zypp::ZyppFlags::StoreTrue, targetFlag ),
       _("Consider only patches which affect the package management itself.")
     };
+  }
+
+  static inline ZyppFlags::CommandOption idsOnlyFlag( bool &target, std::string &&kind ) {
+    return {"ids-only", '\0', ZyppFlags::NoArgument,
+      std::move( ZyppFlags::BoolType(&target, ZyppFlags::StoreTrue).after(
+        [&target]() {
+          auto &out = Zypper::instance().out();
+          if (out.type() == Out::TYPE_XML)
+            target = false;
+          out.setVerbosity( Out::QUIET );
+        }) ),
+      // translators: --name-only
+      str::Format(_("Just print %s ids.")) % kind
+    };
+  }
+
+  static inline ZyppFlags::CommandOption idsOnlyFlag( bool &target, const ResKind & kind ) {
+    // Print 'package' in the help, instead of "resolvables" as that's more consistent with other help messages
+    // (We still pass ResKind::nokind so we can easilly change this later)
+    auto &display_kind = kind == ResKind::nokind ? ResKind::package : kind;
+    return idsOnlyFlag( target,  kind_to_string_localized( display_kind, 1 ));
   }
 }
 

--- a/src/commands/listpatches.cc
+++ b/src/commands/listpatches.cc
@@ -8,6 +8,7 @@
 #include "commonflags.h"
 #include "src/update.h"
 #include "utils/messages.h"
+#include "commands/commonflags.h"
 
 ListPatchesCmd::ListPatchesCmd(std::vector<std::string> &&commandAliases_r)
   : ZypperBaseCommand (
@@ -29,13 +30,15 @@ zypp::ZyppFlags::CommandGroup ListPatchesCmd::cmdOptions() const
       {"all", 'a', ZyppFlags::NoArgument, ZyppFlags::BoolType( &that._all, ZyppFlags::StoreTrue, _all ),
             // translators: -a, --all
             _("List all patches, not only applicable ones.")
-      }
+      },
+      CommonFlags::idsOnlyFlag( that._idsOnly, ResKind::patch )
   }};
 }
 
 void ListPatchesCmd::doReset()
 {
   _all = false;
+  _idsOnly = false;
 }
 
 int ListPatchesCmd::execute( Zypper &zypper, const std::vector<std::string> &positionalArgs_r )
@@ -55,9 +58,9 @@ int ListPatchesCmd::execute( Zypper &zypper, const std::vector<std::string> &pos
     };
 
     if ( _selectPatchOpts._select._requestedIssues.size() )
-      list_patches_by_issue( zypper, _all, _selectPatchOpts._select );
+      list_patches_by_issue( zypper, _all, _idsOnly, _selectPatchOpts._select );
     else
-      list_updates( zypper, kinds, false, _all, _selectPatchOpts._select );
+      list_updates( zypper, kinds, false, _all, _idsOnly, _selectPatchOpts._select );
 
     return zypper.exitCode();
 }

--- a/src/commands/listpatches.h
+++ b/src/commands/listpatches.h
@@ -19,6 +19,7 @@ public:
 
 private:
   bool _all = false;
+  bool _idsOnly = false;
   InitReposOptionSet _initReposOpts { *this };
   SelectPatchOptionSet _selectPatchOpts { *this, SelectPatchOptionSet::EnableAnyType };
   OptionalPatchesOptionSet _optionalPatchesOpts { *this };

--- a/src/commands/listupdates.cc
+++ b/src/commands/listupdates.cc
@@ -33,7 +33,8 @@ zypp::ZyppFlags::CommandGroup ListUpdatesCmd::cmdOptions() const
     { "all", 'a', ZyppFlags::NoArgument, ZyppFlags::BoolType( &that._all, ZyppFlags::StoreTrue, _all ),
           // translators: -a, --all
           _("List all packages for which newer versions are available, regardless whether they are installable or not.")
-    }
+    },
+    CommonFlags::idsOnlyFlag( that._idsOnly, ResKind::nokind )
   }};
 }
 
@@ -42,6 +43,7 @@ void ListUpdatesCmd::doReset()
   _kinds.clear();
   _all = false;
   _bestEffort = false;
+  _idsOnly = false;
 }
 
 int ListUpdatesCmd::execute( Zypper &zypper, const std::vector<std::string> &positionalArgs_r )
@@ -59,6 +61,6 @@ int ListUpdatesCmd::execute( Zypper &zypper, const std::vector<std::string> &pos
   if ( code != ZYPPER_EXIT_OK )
     return code;
 
-  list_updates( zypper, _kinds, _bestEffort, _all );
+  list_updates( zypper, _kinds, _bestEffort, _all, _idsOnly );
   return zypper.exitCode();
 }

--- a/src/commands/listupdates.h
+++ b/src/commands/listupdates.h
@@ -23,6 +23,7 @@ private:
   std::set<ResKind> _kinds;
   bool _all = false;
   bool _bestEffort = false;
+  bool _idsOnly = false;
   InitReposOptionSet _initReposOpts { *this };
   SolverInstallsOptionSet _solverOpts { *this };
 

--- a/src/commands/locale/localescmd.cc
+++ b/src/commands/locale/localescmd.cc
@@ -8,6 +8,7 @@
 #include "localescmd.h"
 #include "utils/flags/flagtypes.h"
 #include "commands/commandhelpformatter.h"
+#include "commands/commonflags.h"
 #include "locales.h"
 
 LocalesCmd::LocalesCmd( std::vector<std::string> &&commandAliases_r )
@@ -32,7 +33,8 @@ zypp::ZyppFlags::CommandGroup LocalesCmd::cmdOptions() const
   auto &that = *const_cast<LocalesCmd *>(this);
   return {{
     { "packages", 'p', ZyppFlags::NoArgument, ZyppFlags::BoolCompatibleType( that._packages, ZyppFlags::StoreTrue ), _("Show corresponding packages.") },
-    { "all", 'a', ZyppFlags::NoArgument, ZyppFlags::BoolCompatibleType( that._all, ZyppFlags::StoreTrue ), _("List all available locales.") }
+    { "all", 'a', ZyppFlags::NoArgument, ZyppFlags::BoolCompatibleType( that._all, ZyppFlags::StoreTrue ), _("List all available locales.") },
+    CommonFlags::idsOnlyFlag( that._idsOnly, _("locale (or package)") ),
   }};
 }
 
@@ -40,6 +42,7 @@ void LocalesCmd::doReset()
 {
   _packages = false;
   _all = false;
+  _idsOnly = false;
 }
 
 int LocalesCmd::execute(Zypper &zypper, const std::vector<std::string> &positionalArgs)
@@ -60,9 +63,9 @@ int LocalesCmd::execute(Zypper &zypper, const std::vector<std::string> &position
     return code;
 
   if ( _packages )
-    localePackages( zypper, positionalArgs, _all );
+    localePackages( zypper, positionalArgs, _all, _idsOnly );
   else
-    listLocales( zypper, positionalArgs, _all );
+    listLocales( zypper, positionalArgs, _all, _idsOnly );
   return zypper.exitCode();
 }
 

--- a/src/commands/locale/localescmd.h
+++ b/src/commands/locale/localescmd.h
@@ -18,6 +18,7 @@ public:
 private:
   bool _packages;
   bool _all;
+  bool _idsOnly;
 
   // ZypperBaseCommand interface
 public:

--- a/src/commands/query/packages.cc
+++ b/src/commands/query/packages.cc
@@ -7,6 +7,7 @@
 #include "packages.h"
 #include "Zypper.h"
 #include "utils/flags/flagtypes.h"
+#include "commands/commonflags.h"
 #include "global-settings.h"
 
 using namespace zypp;
@@ -66,6 +67,7 @@ zypp::ZyppFlags::CommandGroup PackagesCmdBase::cmdOptions() const
             // translators: -R, --sort-by-repo
             _("Sort the list by repository.")
       },
+      CommonFlags::idsOnlyFlag( that->_idsOnly, ResKind::package ),
       {"sort-by-catalog", '\0', ZyppFlags::NoArgument | ZyppFlags::Hidden, ZyppFlags::BitFieldType( that->_flags, ListPackagesBits::SortByRepo ), ""}
   }};
 }
@@ -73,6 +75,7 @@ zypp::ZyppFlags::CommandGroup PackagesCmdBase::cmdOptions() const
 void PackagesCmdBase::doReset()
 {
   _flags = ListPackagesBits::Default;
+  _idsOnly = false;
 }
 
 int PackagesCmdBase::execute( Zypper &zypper, const std::vector<std::string> & )
@@ -80,6 +83,7 @@ int PackagesCmdBase::execute( Zypper &zypper, const std::vector<std::string> & )
   ListPackagesFlags  flags = _flags;
   flags.setFlag( ListPackagesBits::HideInstalled, _notInstalledOnly._mode == SolvableFilterMode::ShowOnlyNotInstalled );
   flags.setFlag( ListPackagesBits::HideNotInstalled, _notInstalledOnly._mode == SolvableFilterMode::ShowOnlyInstalled );
+  flags.setFlag( ListPackagesBits::IdsOnly, _idsOnly );
 
   list_packages( zypper, flags );
 

--- a/src/commands/query/packages.h
+++ b/src/commands/query/packages.h
@@ -21,6 +21,7 @@ public:
 
 private:
   ListPackagesFlags _flags = ListPackagesBits::Default;
+  bool _idsOnly = false;
   InitReposOptionSet _initRepoFlags { *this };
   NotInstalledOnlyOptionSet _notInstalledOnly { *this };
 

--- a/src/commands/query/patches.cc
+++ b/src/commands/query/patches.cc
@@ -7,6 +7,7 @@
 #include "patches.h"
 #include "Zypper.h"
 #include "utils/flags/flagtypes.h"
+#include "commands/commonflags.h"
 #include "global-settings.h"
 
 using namespace zypp;
@@ -29,14 +30,19 @@ PatchesCmdBase::PatchesCmdBase(std::vector<std::string> &&commandAliases_r) :
 
 zypp::ZyppFlags::CommandGroup PatchesCmdBase::cmdOptions() const
 {
-  return {};
+  auto that = const_cast<PatchesCmdBase *>(this);
+  return {{
+    CommonFlags::idsOnlyFlag( that->_idsOnly, ResKind::patch )
+  }};
 }
 
 void PatchesCmdBase::doReset()
-{ }
+{
+  _idsOnly = false;
+}
 
 int PatchesCmdBase::execute( Zypper &zypper, const std::vector<std::string> & )
 {
-  list_patches( zypper );
+  list_patches( zypper, _idsOnly );
   return ZYPPER_EXIT_OK;
 }

--- a/src/commands/query/patches.h
+++ b/src/commands/query/patches.h
@@ -21,6 +21,7 @@ public:
 
 private:
   InitReposOptionSet _initRepoFlags { *this };
+  bool _idsOnly = false;
 
   // ZypperBaseCommand interface
 protected:

--- a/src/commands/query/patterns.cc
+++ b/src/commands/query/patterns.cc
@@ -7,6 +7,7 @@
 #include "patterns.h"
 #include "Zypper.h"
 #include "utils/flags/flagtypes.h"
+#include "commands/commonflags.h"
 #include "global-settings.h"
 
 using namespace zypp;
@@ -29,14 +30,19 @@ PatternsCmdBase::PatternsCmdBase(std::vector<std::string> &&commandAliases_r) :
 
 zypp::ZyppFlags::CommandGroup PatternsCmdBase::cmdOptions() const
 {
-  return {};
+  auto that = const_cast<PatternsCmdBase *>(this);
+  return {{
+    CommonFlags::idsOnlyFlag( that->_idsOnly, ResKind::pattern )
+  }};
 }
 
 void PatternsCmdBase::doReset()
-{ }
+{
+  _idsOnly = false;
+}
 
 int PatternsCmdBase::execute( Zypper &zypper, const std::vector<std::string> & )
 {
-  list_patterns( zypper, _instOnlyFlags._mode );
+  list_patterns( zypper, _instOnlyFlags._mode, _idsOnly );
   return ZYPPER_EXIT_OK;
 }

--- a/src/commands/query/patterns.h
+++ b/src/commands/query/patterns.h
@@ -22,6 +22,7 @@ public:
 private:
   InitReposOptionSet _initRepoFlags { *this };
   NotInstalledOnlyOptionSet _instOnlyFlags { *this };
+  bool _idsOnly = false;
 
   // ZypperBaseCommand interface
 protected:

--- a/src/commands/query/products.cc
+++ b/src/commands/query/products.cc
@@ -7,6 +7,7 @@
 #include "products.h"
 #include "Zypper.h"
 #include "utils/flags/flagtypes.h"
+#include "commands/commonflags.h"
 #include "global-settings.h"
 
 using namespace zypp;
@@ -34,13 +35,15 @@ zypp::ZyppFlags::CommandGroup ProductsCmdBase::cmdOptions() const
     { "xmlfwd", '\0', ZyppFlags::RequiredArgument | ZyppFlags::Repeatable, ZyppFlags::StringVectorType( &that->_xmlFwdTags, ARG_TAG ),
       // translators: --xmlfwd <TAG>
       _("XML output only: Literally forward the XML tags found in a product file.")
-    }
+    },
+    CommonFlags::idsOnlyFlag( that->_idsOnly, ResKind::product )
   }};
 }
 
 void ProductsCmdBase::doReset()
 {
   _xmlFwdTags.clear();
+  _idsOnly = false;
 }
 
 int ProductsCmdBase::execute( Zypper &zypper, const std::vector<std::string> & )
@@ -53,6 +56,6 @@ int ProductsCmdBase::execute( Zypper &zypper, const std::vector<std::string> & )
   if ( zypper.out().type() == Out::TYPE_XML )
     list_products_xml( zypper, _instFilterFlags._mode, _xmlFwdTags );
   else
-    list_product_table( zypper, _instFilterFlags._mode );
+    list_product_table( zypper, _instFilterFlags._mode, _idsOnly  );
   return ZYPPER_EXIT_OK;
 }

--- a/src/commands/query/products.h
+++ b/src/commands/query/products.h
@@ -23,6 +23,7 @@ private:
   InitReposOptionSet _initRepoFlags { *this };
   NotInstalledOnlyOptionSet _instFilterFlags { *this };
   std::vector<std::string> _xmlFwdTags;
+  bool _idsOnly = false;
 
   // ZypperBaseCommand interface
 protected:

--- a/src/commands/repos/list.cc
+++ b/src/commands/repos/list.cc
@@ -362,7 +362,7 @@ void ListReposCmd::printRepoList( Zypper & zypper, const std::list<RepoInfo> & r
     if ( !showprio )
     {
       repoPrioSummary( zypper );
-      zypper.out().gap();
+      zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
     }
     // sort
     tbl.sort( sort_index );

--- a/src/commands/repos/list.h
+++ b/src/commands/repos/list.h
@@ -24,10 +24,11 @@ protected:
   zypp::ZyppFlags::CommandGroup cmdOptions() const override;
   void doReset() override;
   int execute(Zypper &zypper, const std::vector<std::string> &positionalArgs_r) override;
-  void printRepoList(Zypper &zypper, const std::list<zypp::RepoInfo> &repos);
+  void printRepoList(Zypper &zypper, const std::list<zypp::RepoInfo> &repos, bool idsOnly);
 
 private:
   std::string _exportFile;
+  bool _idsOnly;
   RSCommonListOptions _listOptions{ OptCommandCtx::RepoContext, *this };
 };
 

--- a/src/commands/search/search.cc
+++ b/src/commands/search/search.cc
@@ -203,7 +203,8 @@ zypp::ZyppFlags::CommandGroup SearchCmd::cmdOptions() const
       {"verbose", 'v', ZyppFlags::NoArgument, ZyppFlags::BoolType( &that._verbose, ZyppFlags::StoreTrue, _caseSensitive ),
         // translators: -v, --verbose
         _("Like --details, with additional information where the search has matched (useful for search in dependencies).")
-      }
+      },
+      CommonFlags::idsOnlyFlag( that._idsOnly, ResKind::nokind )
     },
     {
       { "match-substrings", "match-words", "match-exact" },
@@ -229,6 +230,7 @@ void SearchCmd::doReset()
   _verbose = false;
   _requestedDeps.clear();
   _requestedTypes.clear();
+  _idsOnly = false;
 }
 
 int SearchCmd::execute( Zypper &zypper, const std::vector<std::string> &positionalArgs_r )
@@ -492,8 +494,11 @@ int SearchCmd::execute( Zypper &zypper, const std::vector<std::string> &position
           t.allowAbbrev( 2 );
       }
 
-      //cout << t; //! \todo out().table()?
-      zypper.out().searchResult( t );
+      if ( _idsOnly )
+        printIdTable(t, true, 1);
+      else
+        //cout << t; //! \todo out().table()?
+        zypper.out().searchResult( t );
     }
 
     if ( !_requestedReverseSearch.is_initialized() )

--- a/src/commands/search/search.cc
+++ b/src/commands/search/search.cc
@@ -475,7 +475,7 @@ int SearchCmd::execute( Zypper &zypper, const std::vector<std::string> &position
     }
     else
     {
-      cout << endl; //! \todo  out().separator()?
+      zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
 
       if ( _details )
       {

--- a/src/commands/search/search.h
+++ b/src/commands/search/search.h
@@ -38,6 +38,7 @@ private:
   bool _caseSensitive = false;
   bool _details = false;
   bool _verbose = false;
+  bool _idsOnly = false;
   std::set<zypp::sat::SolvAttr> _requestedDeps;
   boost::optional<zypp::sat::SolvAttr> _requestedReverseSearch;
 

--- a/src/commands/services/list.cc
+++ b/src/commands/services/list.cc
@@ -4,7 +4,9 @@
 #include "common.h"
 #include "Table.h"
 
+#include "commands/commonflags.h"
 #include "utils/flags/flagtypes.h"
+#include "utils/misc.h"
 
 using namespace zypp;
 
@@ -194,7 +196,7 @@ void ListServicesCmd::printServiceList( Zypper &zypper )
       tbl.sort( 5 );
 
     // print
-    cout << tbl;
+    printIdTable(tbl, _idsOnly, 1);
   }
 }
 
@@ -230,11 +232,15 @@ void ListServicesCmd::printXMLServiceList( Zypper &zypper )
 
 ZyppFlags::CommandGroup ListServicesCmd::cmdOptions() const
 {
-  return ZyppFlags::CommandGroup();
+  auto that = const_cast<ListServicesCmd *>(this);
+  return {{
+    CommonFlags::idsOnlyFlag( that->_idsOnly, _("service") )
+  }};
 }
 
 void ListServicesCmd::doReset()
 {
+  _idsOnly = false;
 }
 
 int ListServicesCmd::execute( Zypper &zypper, const std::vector<std::string> &positionalArgs_r )

--- a/src/commands/services/list.h
+++ b/src/commands/services/list.h
@@ -19,6 +19,7 @@ public:
   ListServicesCmd ( std::vector<std::string> &&commandAliases_r );
 
 private:
+  bool _idsOnly = false;
   void printServiceList    ( Zypper &zypper );
   void printXMLServiceList ( Zypper &zypper );
 

--- a/src/commands/utils/purge-kernels.cc
+++ b/src/commands/utils/purge-kernels.cc
@@ -47,12 +47,12 @@ int PurgeKernelsCmd::execute( Zypper &zypper , const std::vector<std::string> & 
 {
   PurgeKernels purger;
 
-  zypper.out().gap();
+  zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
   zypper.out().info( _("Preparing to purge obsolete kernels...") );
   zypper.out().info( str::Format( _("Configuration: %1%") ) % purger.keepSpec() );
   zypper.out().info( str::Format( _("Running kernel release: %1%") ) % purger.unameR() );
   zypper.out().info( str::Format( _("Running kernel arch: %1%") ) % purger.kernelArch().asString() );
-  zypper.out().gap();
+  zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
 
   purger.markObsoleteKernels();
 

--- a/src/locales.cc
+++ b/src/locales.cc
@@ -166,7 +166,7 @@ namespace
     return ret;
   }
 
-  void printLocaleList( Zypper & zypper, const LocaleStateMap & locales_r )
+  void printLocaleList( Zypper & zypper, const LocaleStateMap & locales_r, bool idsOnly )
   {
     Table tbl;
     tbl << ( TableHeader()
@@ -188,10 +188,10 @@ namespace
     }
 
     tbl.sort( 0 );
-    cout << tbl;
+    printIdTable(tbl, idsOnly, 0);
   }
 
-  void printLocalePackages( Zypper & zypper, const zypp::sat::LocaleSupport & myLocale )
+  void printLocalePackages( Zypper & zypper, const zypp::sat::LocaleSupport & myLocale, bool idsOnly )
   {
     Table tbl;
     tbl << ( TableHeader()
@@ -214,7 +214,7 @@ namespace
     }
 
     tbl.sort(1);
-    cout << tbl;
+    printIdTable(tbl, idsOnly, 1);
   }
 
 } // namespace
@@ -222,12 +222,12 @@ namespace
 
 
 
-void listLocales( Zypper & zypper, const std::vector<std::string> &localeArgs, bool showAll )
+void listLocales( Zypper & zypper, const std::vector<std::string> &localeArgs, bool showAll, bool idsOnly )
 {
-  printLocaleList( zypper, argsToLocaleSet( localeArgs, showAll ) );
+  printLocaleList( zypper, argsToLocaleSet( localeArgs, showAll ), idsOnly );
 }
 
-void localePackages( Zypper &zypper, const std::vector<std::string> &localeArgs, bool showAll )
+void localePackages( Zypper &zypper, const std::vector<std::string> &localeArgs, bool showAll, bool idsOnly )
 {
   for ( const auto & el : argsToLocaleSet( localeArgs, showAll ) )
   {
@@ -235,7 +235,7 @@ void localePackages( Zypper &zypper, const std::vector<std::string> &localeArgs,
     zypper.out().info( str::form( _("Packages for %s (locale '%s', requested: %s):"),
                                   el.first.name().c_str(), el.first.code().c_str(), el.second.asString().c_str() ) );
     zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
-    printLocalePackages( zypper, el.first );
+    printLocalePackages( zypper, el.first, idsOnly );
   }
 }
 

--- a/src/locales.cc
+++ b/src/locales.cc
@@ -231,10 +231,10 @@ void localePackages( Zypper &zypper, const std::vector<std::string> &localeArgs,
 {
   for ( const auto & el : argsToLocaleSet( localeArgs, showAll ) )
   {
-    zypper.out().gap();
+    zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
     zypper.out().info( str::form( _("Packages for %s (locale '%s', requested: %s):"),
                                   el.first.name().c_str(), el.first.code().c_str(), el.second.asString().c_str() ) );
-    zypper.out().gap();
+    zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
     printLocalePackages( zypper, el.first );
   }
 }

--- a/src/locales.h
+++ b/src/locales.h
@@ -14,9 +14,9 @@
 
 class Zypper;
 
-void listLocales( Zypper & zypper, const std::vector<std::string> &localeArgs, bool showAll );
+void listLocales( Zypper & zypper, const std::vector<std::string> &localeArgs, bool showAll, bool idsOnly );
 
-void localePackages( Zypper & zypper, const std::vector<std::string> &localeArgs, bool showAll );
+void localePackages( Zypper & zypper, const std::vector<std::string> &localeArgs, bool showAll, bool idsOnly );
 
 void addLocales( Zypper & zypper_r, const std::vector<std::string> &localeArgs_r, bool packages, std::map<std::string, bool> *result = nullptr );
 

--- a/src/repos.cc
+++ b/src/repos.cc
@@ -165,7 +165,7 @@ RepoGpgCheckStrings::RepoGpgCheckStrings(const RepoInfo &repo_r)
 
 void repoPrioSummary( Zypper & zypper )
 {
-  if ( zypper.out().type() != Out::TYPE_NORMAL )
+  if ( zypper.out().type() != Out::TYPE_NORMAL || zypper.out().verbosity() < Out::NORMAL )
     return;
 
   std::map<unsigned,ZeroInit<unsigned>> priomap;
@@ -1837,7 +1837,7 @@ void load_repo_resolvables( Zypper & zypper )
     "Check if 'autorefresh' is turned on (zypper lr), otherwise manually refresh the repository (zypper ref). "
     "If this does not solve the issue, it could be that you are using a broken mirror or "
     "the server has actually discontinued to support the repository." ) );
-    zypper.out().gap();
+    zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
   }
 }
 

--- a/src/search.cc
+++ b/src/search.cc
@@ -247,7 +247,7 @@ static std::string string_weak_status( const ResStatus & rs )
 }
 
 
-void list_patches( Zypper & zypper )
+void list_patches( Zypper & zypper, bool idsOnly )
 {
   MIL << "Pool contains " << God->pool().size() << " items. Checking whether available patches are needed." << std::endl;
 
@@ -264,7 +264,7 @@ void list_patches( Zypper & zypper )
   {
     // display the result, even if --quiet specified
     tbl.sort();	// use default sort
-    cout << tbl;
+    printIdTable(tbl, idsOnly, 1);
   }
 }
 
@@ -293,7 +293,7 @@ static void list_patterns_xml( Zypper & zypper, SolvableFilterMode mode_r )
   cout << "</pattern-list>" << endl;
 }
 
-static void list_pattern_table( Zypper & zypper, SolvableFilterMode mode_r )
+static void list_pattern_table( Zypper & zypper, SolvableFilterMode mode_r, bool idsOnly )
 {
   MIL << "Going to list patterns." << std::endl;
 
@@ -344,15 +344,15 @@ static void list_pattern_table( Zypper & zypper, SolvableFilterMode mode_r )
     zypper.out().info(_("No patterns found.") );
   else
     // display the result, even if --quiet specified
-    cout << tbl;
+    printIdTable(tbl, idsOnly, 1);
 }
 
-void list_patterns(Zypper & zypper , SolvableFilterMode mode_r)
+void list_patterns(Zypper & zypper , SolvableFilterMode mode_r, bool idsOnly)
 {
   if ( zypper.out().type() == Out::TYPE_XML )
     list_patterns_xml( zypper, mode_r );
   else
-    list_pattern_table( zypper, mode_r );
+    list_pattern_table( zypper, mode_r, idsOnly );
 }
 
 void list_packages(Zypper & zypper , ListPackagesFlags flags_r )
@@ -379,6 +379,7 @@ void list_packages(Zypper & zypper , ListPackagesFlags flags_r )
   bool unneeded = flags_r.testFlag( ListPackagesBits::ShowUnneeded );
   bool byAuto = flags_r.testFlag( ListPackagesBits::ShowByAuto );
   bool byUser = flags_r.testFlag( ListPackagesBits::ShowByUser );
+  bool idsOnly = flags_r.testFlag( ListPackagesBits::IdsOnly );
   bool check = ( flags_r & ( maskNeedSolv | ListPackagesBits::ShowSystem | ListPackagesBits::ShowByAuto | ListPackagesBits::ShowByUser ) );
   if ( flags_r & maskNeedSolv ) {
     God->resolver()->resolvePool();
@@ -467,9 +468,9 @@ void list_packages(Zypper & zypper , ListPackagesFlags flags_r )
       tbl.sort( 2 ); // Name
 
     zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
-    cout << tbl;
+    printIdTable(tbl, idsOnly, 2);
 
-    if ( tagOrphaned )
+    if ( tagOrphaned && !idsOnly )
       Zypper::instance().out().notePar( 4, "(o) = orphaned" );
   }
 }
@@ -495,7 +496,7 @@ void list_products_xml( Zypper & zypper, SolvableFilterMode mode_r, const std::v
   cout << "</product-list>" << endl;
 }
 
-void list_product_table(Zypper & zypper , SolvableFilterMode mode_r)
+void list_product_table(Zypper & zypper , SolvableFilterMode mode_r, bool idsOnly )
 {
   MIL << "Going to list products." << std::endl;
 
@@ -548,5 +549,5 @@ void list_product_table(Zypper & zypper , SolvableFilterMode mode_r)
     zypper.out().info(_("No products found.") );
   else
     // display the result, even if --quiet specified
-    cout << tbl;
+    printIdTable(tbl, idsOnly, 2);
 }

--- a/src/search.cc
+++ b/src/search.cc
@@ -257,6 +257,7 @@ void list_patches( Zypper & zypper )
                 God->pool().byKindEnd(ResKind::patch),
                 callback);
 
+  zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
   if ( tbl.empty() )
     zypper.out().info( _("No needed patches found.") );
   else
@@ -338,6 +339,7 @@ static void list_pattern_table( Zypper & zypper, SolvableFilterMode mode_r )
   }
   tbl.sort( 1 ); // Name
 
+  zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
   if ( tbl.empty() )
     zypper.out().info(_("No patterns found.") );
   else
@@ -464,6 +466,7 @@ void list_packages(Zypper & zypper , ListPackagesFlags flags_r )
     else
       tbl.sort( 2 ); // Name
 
+    zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
     cout << tbl;
 
     if ( tagOrphaned )
@@ -540,6 +543,7 @@ void list_product_table(Zypper & zypper , SolvableFilterMode mode_r)
 
   tbl.sort(1); // Name
 
+  zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
   if ( tbl.empty() )
     zypper.out().info(_("No products found.") );
   else

--- a/src/search.h
+++ b/src/search.h
@@ -60,12 +60,13 @@ struct FillSearchTableSelectable
 // struct FillPatchesTableForIssue	in src/utils/misc.h
 
 
-/** List all patches with specific info in specified repos */
-void list_patches(Zypper & zypper);
+/** List all patches with specific info in specified repos,
+ *  (possibly printing only their names) */
+void list_patches(Zypper & zypper, bool idsOnly);
 
-/** List all patterns with specific info in specified repos */
-
-void list_patterns(Zypper & zypper, SolvableFilterMode mode_r );
+/** List all patterns with specific info in specified repos
+  *  (possibly printing only their names) */
+void list_patterns(Zypper & zypper, SolvableFilterMode mode_r, bool idsOnly);
 
 /** List all packages with specific info in specified repos
  *  - currently looks like zypper search -t package -r foorepo */
@@ -80,15 +81,17 @@ enum class ListPackagesBits {
   ShowUnneeded      = 1 << 6,
   ShowByAuto        = 1 << 7,
   ShowByUser        = 1 << 8,
+  IdsOnly           = 1 << 9, // Only ids will be printed
   SortByRepo        = 1 << 20  //< Result will be sorted by repo, not by name
 };
 ZYPP_DECLARE_FLAGS( ListPackagesFlags, ListPackagesBits );
 ZYPP_DECLARE_OPERATORS_FOR_FLAGS(ListPackagesFlags)
 void list_packages(Zypper & zypper, ListPackagesFlags flags_r );
 
-/** List all products with specific info in specified repos */
+/** List all products with specific info in specified repos
+ *  (possibly printing only their internal names) */
 void list_products_xml( Zypper & zypper, SolvableFilterMode mode_r, const std::vector<std::string> &fwdTags );
-void list_product_table( Zypper & zypper, SolvableFilterMode mode_r );
+void list_product_table( Zypper & zypper, SolvableFilterMode mode_r, bool idsOnly );
 
 
 #endif /*ZYPPERSEARCH_H_*/

--- a/src/solve-commit.cc
+++ b/src/solve-commit.cc
@@ -317,7 +317,7 @@ static bool show_problems( Zypper & zypper, SolveAndCommitPolicy & policy )
   }
 
   if ( retry ) {
-    zypper.out().gap();
+    zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
     zypper.out().info(_("Resolving dependencies...") );
     resolver->applySolutions( pendingSolutions );
   }

--- a/src/update.cc
+++ b/src/update.cc
@@ -360,7 +360,7 @@ namespace
                             // translator: Hint displayed right adjusted; %1% is a CLI option
                             // "42 patches optional                  (use --with-optional to include optional patches)"
                             str::Format(_("use '%1%' to include optional patches")) % "--with-optional",
-                            Out::QUIET );
+                            Out::NORMAL );
           }
         }
     }
@@ -585,9 +585,9 @@ static bool list_patch_updates( Zypper & zypper, bool all_r, const PatchSelector
   bool affectpm = !pmTbl.empty();
   if ( affectpm )
   {
-    zypper.out().gap();
     if (!tbl.empty())
     {
+      zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
       // translator: Table headline; 'Needed' refers to patches with status 'needed'
       zypper.out().info(_("Needed software management updates will be installed first:"));
       zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
@@ -605,15 +605,19 @@ static bool list_patch_updates( Zypper & zypper, bool all_r, const PatchSelector
       zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
       // translator: Table headline
       zypper.out().info(_("The following updates are also available:"));
+      zypper.out().gap(); // Print even if the above message wasn't, to seperate the tables
     }
-    zypper.out().info("", Out::QUIET, Out::TYPE_NORMAL);
+    else
+    {
+      zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
+    }
     tbl.sort();	// use default sort
     cout << tbl;
   }
 
-  zypper.out().gap();
   if ( stats.visited() )
   {
+    zypper.out().gap();
     stats.render( zypper.out(), /*withDetails*/false );
     zypper.out().gap();
   }
@@ -833,10 +837,10 @@ void list_updates(Zypper & zypper, const ResKindSet & kinds, bool best_effort, b
 
     if (kind_size > 1)
     {
-      zypper.out().info("", Out::QUIET, Out::TYPE_NORMAL); // visual separator
+      zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL); // visual separator
       zypper.out().info(i18n_kind_updates(*it), Out::QUIET, Out::TYPE_NORMAL);
-      zypper.out().info("", Out::QUIET, Out::TYPE_NORMAL); // visual separator
     }
+    zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL); // visual separator
 
     if (tbl.empty())
       zypper.out().info(_("No updates found."));
@@ -974,21 +978,21 @@ void list_patches_by_issue( Zypper & zypper, bool all_r, const PatchSelector & s
     {
       if ( !issueMatchesTbl.empty() )
       {
-        zypper.out().gap();
+        zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
         zypper.out().info(_("The following matches in issue numbers have been found:"));
+        zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
 
         issueMatchesTbl.sort(); // use default sort
-        zypper.out().gap();
         cout << issueMatchesTbl;
       }
 
       if ( !descrMatchesTbl.empty() )
       {
-        zypper.out().gap();
+        zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
         zypper.out().info(_( "Matches in patch descriptions of the following patches have been found:"));
+        zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
 
         descrMatchesTbl.sort(); // use default sort
-        zypper.out().gap();
         cout << descrMatchesTbl;
       }
     }

--- a/src/update.h
+++ b/src/update.h
@@ -25,8 +25,8 @@ void patch_check(bool updatestackOnly);
  * Lists available updates of installed resolvables of specified \a kind.
  * if repo_alias != "", restrict updates to this repository.
  * if best_effort == true, any version greater than the installed one will do.
+ * if idsOnly == true, only the names of the updates will be printed
  * Prints the table of updates to stdout.
- *
  * \param kind  resolvable type
  * \param best_effort
  */
@@ -34,13 +34,15 @@ void list_updates(Zypper & zypper,
                   const ResKindSet & kinds,
                   bool best_effort,
                   bool all,
+                  bool idsOnly,
                   const PatchSelector &patchSel_r = PatchSelector() );
 
 /**
  * List available fixes to all issues or issues specified in --bugzilla
  * or --cve options, or look for --issue[=str[ in numbers and descriptions
+ * (only printing the names of patches if idsOnly == true)
  */
-void list_patches_by_issue(Zypper & zypper, bool all_r, const PatchSelector &sel );
+void list_patches_by_issue(Zypper & zypper, bool all_r, bool idsOnly, const PatchSelector &sel );
 
 /**
  * Mark patches for installation according to bugzilla or CVE number specified

--- a/src/utils/messages.cc
+++ b/src/utils/messages.cc
@@ -140,7 +140,7 @@ void print_unknown_command_hint( Zypper & zypper, const std::string & cmd_r )
     // zypper shell is running or not
     str::Format(_("Type '%s' to get a list of global options and commands."))
     % (zypper.runningShell() ? "help" : "zypper help") );
-  zypper.out().gap();
+  zypper.out().info("", Out::NORMAL, Out::TYPE_NORMAL);
   zypper.out().info(
     // translators: %1% is the name of an (unknown) command
     // translators: %2% something providing more info (like 'zypper help subcommand')

--- a/src/utils/misc.cc
+++ b/src/utils/misc.cc
@@ -897,3 +897,18 @@ const char * computeStatusIndicator( const ui::Selectable & sel_r, bool tagForei
     return stem[1];
   return stem[0];
 }
+
+// ----------------------------------------------------------------------------
+
+void printIdTable( const Table &table, bool idsOnly, int idCol )
+{
+  if ( idsOnly )
+  {
+    for ( auto &row : table.rows() )
+      cout << row.columns()[idCol] << endl;
+  }
+  else
+  {
+    cout << table;
+  }
+}

--- a/src/utils/misc.h
+++ b/src/utils/misc.h
@@ -252,4 +252,7 @@ bool packagekit_running();
 /** Send suggestion to quit to PackageKit via DBus */
 void packagekit_suggest_quit();
 
+/** Prints a table, or if idsOnly, just print the contents of idCol */
+void printIdTable( const Table &table, bool idsOnly, int idCol );
+
 #endif /*ZYPPER_UTILS_H*/


### PR DESCRIPTION
This ads a new `--ids-only` flag to various subcommands so you can easily send their output back to zypper, (e.g. `zypper install (zypper search fish)`)

See the commit messages for more details.
As a related trivial change (not worth it's own pull request) I slightly modified when blank lines are printed by various commands, see the first commit. My --ids-only flag is written to not print brank lines, so it depends on the specifics of this commit, but I can easily change the details here.
I'm happy to write documentation and test cases for it if you like my changes.

I've tested it with the following:

```fish
build/src/zypper patches --ids-only
build/src/zypper patterns --ids-only
build/src/zypper packages --ids-only repo-non-oss
build/src/zypper repos --ids-only
build/src/zypper search --ids-only zypper
build/src/zypper locales --ids-only -p zu
build/src/zypper locales --ids-only
build/src/zypper list-patches --ids-only -ab
build/src/zypper products --ids-only
build/src/zypper services --ids-only
build/src/zypper list-patches --ids-only -a
build/src/zypper list-patches --ids-only -ab
build/src/zypper list-patches --ids-only -a --issue=Test-update

# For the following to produce any output, I had to make and install my own v1 rpm of 
# 'update-test-affects-package-manager' (I assume there's a better way to do these tests).
build/src/zypper list-updates --ids-only
build/src/zypper list-updates --ids-only --best-effort
build/src/zypper list-patches --ids-only
```