### PR TITLE
Fixup change zypper ref  -s to be the default

### DIFF
--- a/doc/zypper.8.txt
+++ b/doc/zypper.8.txt
@@ -1381,10 +1381,7 @@ include::{incdir}/option_Repo_Aggregates.txt[]
 		Multi-Arch repos: Download raw metadata for all offered architectures even if the repo supports filtering. Otherwise we'd download only the metadata for architectures compatible with the local system. You do not need this unless you want zypper to provide the full metadata for the purpose of mirroring the repository.
 
 	*-s*, *--services*::
-	    Refresh also services before refreshing repositories. This is the default behaviour.
-
-    *-S*, *--no-services*::
-	    Do not refresh services also before refreshing repos.
+		Refresh also services before refreshing repositories.
 --
 
 *clean* (*cc*) [_options_] [_alias_|_name_|_#_|_URI_]...::

--- a/src/Zypper.h
+++ b/src/Zypper.h
@@ -127,8 +127,6 @@ struct RuntimeData
   Pathname tmpdir;
 };
 
-typedef shared_ptr<RepoManager> RepoManager_Ptr;
-
 class Zypper : public ztui::Application
 {
 public:
@@ -148,10 +146,13 @@ public:
   RuntimeData & runtimeData()			{ return _rdata; }
 
   void initRepoManager()
-  { _rm.reset( new RepoManager( _config.rm_options ) ); }
+  { _rm = RepoManagerWrapper( _config.rm_options ); }
 
   RepoManager & repoManager()
-  { if ( !_rm ) _rm.reset( new RepoManager( _config.rm_options ) ); return *_rm; }
+  { if ( !_rm ) initRepoManager(); return _rm->get(); }
+
+  std::string repoManagerInitialAlias( unsigned argnum ) const
+  { return _rm ? _rm->initialAlias( argnum ) : std::string(); }
 
   int exitInfoCode() const			{ return _exitInfoCode; }
   void setExitInfoCode( int exit )		{
@@ -249,7 +250,50 @@ private:
 
   RuntimeData _rdata;
 
-  RepoManager_Ptr   _rm;
+private:
+  // Many commands allow a repository argument to be specified by a number.
+  // In \ref match_repo the arguments are evaluated and numbers are mapped
+  // to RepoInfo. Those are the numbers the user saw in a preceding 'lr'.
+  // But the next command may evaluate it's arguments after an service
+  // (auto-)refresh happened. If the service refresh adds or removes repos,
+  // the number may no longer match the repo the user saw.
+  // So we store the initial mapping and let \ref match_repo refer to this
+  // rather than counting in the actual repo list.
+  struct RepoManagerWrapper
+  {
+    RepoManagerWrapper(const RepoManagerWrapper&) = delete;
+    RepoManagerWrapper& operator=(const RepoManagerWrapper&) = delete;
+    RepoManagerWrapper(RepoManagerWrapper&&) = default;
+    RepoManagerWrapper& operator=(RepoManagerWrapper&&) = default;
+
+    RepoManagerWrapper( const RepoManagerOptions & options_r )
+    : _rm { options_r }
+    {
+      for ( const RepoInfo & ri : _rm.knownRepositories() ) {
+        _rm_initialaliases.push_back( ri.alias() );
+      }
+    }
+
+    RepoManager & get()
+    { return _rm; }
+
+    const RepoManager & get() const
+    { return _rm; }
+
+    std::string initialAlias( unsigned argnum ) const
+    {
+      // BEWARE: argnum starts by 1 !
+      if ( argnum >= 1 && argnum <= _rm_initialaliases.size() )
+        return _rm_initialaliases[argnum-1];
+      return "";
+    }
+
+  private:
+
+    RepoManager _rm;
+    std::vector<std::string> _rm_initialaliases;
+  };
+  std::optional<RepoManagerWrapper> _rm;
 };
 
 void print_unknown_command_hint( Zypper & zypper );

--- a/src/commands/repos/list.cc
+++ b/src/commands/repos/list.cc
@@ -106,7 +106,7 @@ void ListReposCmd::doReset()
 
 int ListReposCmd::execute( Zypper &zypper, const std::vector<std::string> &positionalArgs_r )
 {
-  checkIfToRefreshPluginServices( zypper );
+  checkIfToAutoRefreshServices( zypper );
 
   RepoManager & manager = zypper.repoManager();
   RuntimeData & gData = zypper.runtimeData();

--- a/src/commands/repos/refresh.cc
+++ b/src/commands/repos/refresh.cc
@@ -164,7 +164,7 @@ int RefreshRepoCmd::execute( Zypper &zypper , const std::vector<std::string> &po
     if ( force )
       opts |= RepoManager::RefreshService_forceRefresh;
 
-    checkIfToRefreshPluginServices( zypper, opts );
+    checkIfToAutoRefreshServices( zypper, opts );
   }
 
   MIL << "going to refresh repositories" << endl;

--- a/src/commands/repos/refresh.cc
+++ b/src/commands/repos/refresh.cc
@@ -117,11 +117,6 @@ zypp::ZyppFlags::CommandGroup RefreshRepoCmd::cmdOptions() const
             // translators: -s, --services
             _("Refresh also services before refreshing repos.")
       },
-      {"no-services", 'S', ZyppFlags::NoArgument,
-            ZyppFlags::BoolType( &that->_services, ZyppFlags::StoreFalse, _services ),
-            // translators: -S, --no-services
-            _("Do not refresh services also before refreshing repos.")
-      },
   }};
 }
 
@@ -129,7 +124,7 @@ void RefreshRepoCmd::doReset()
 {
   _flags = Default;
   _repos.clear();
-  _services = true;
+  _services = false;
 }
 
 int RefreshRepoCmd::execute( Zypper &zypper , const std::vector<std::string> &positionalArgs_r )

--- a/src/commands/repos/refresh.h
+++ b/src/commands/repos/refresh.h
@@ -44,7 +44,7 @@ protected:
 private:
   RefreshFlags _flags;
   std::vector<std::string> _repos;
-  bool _services = true;
+  bool _services = false;
 };
 ZYPP_DECLARE_OPERATORS_FOR_FLAGS(RefreshRepoCmd::RefreshFlags);
 

--- a/src/commands/services/list.cc
+++ b/src/commands/services/list.cc
@@ -298,7 +298,7 @@ int ListServicesCmd::execute( Zypper &zypper, const std::vector<std::string> &po
   }
 
   if ( _listOptions._flags.testFlag( RSCommonListOptions::ShowWithRepos) )
-    checkIfToRefreshPluginServices( zypper );
+    checkIfToAutoRefreshServices( zypper );
 
   if ( zypper.out().type() == Out::TYPE_XML ) {
     printXMLServiceList( zypper );

--- a/src/repos.cc
+++ b/src/repos.cc
@@ -480,12 +480,24 @@ bool match_repo( Zypper & zypper, std::string str, RepoInfo *repo, bool looseQue
   // Quick check for alias/reponumber/name first.
   // Name can be ambiguous, in which case the first match found will be returned
   {
-    unsigned number = 1; // repo number
-    unsigned tmp    = 0;
+    unsigned tmp = 0;
     safe_lexical_cast( str, tmp ); // try to make an int out of the string
-    for ( RepoManager::RepoConstIterator known_it = manager.repoBegin(); known_it != manager.repoEnd(); ++known_it, ++number )
+    std::optional<std::string> aliasFromNumber;
+    if ( tmp ) {
+      // Number CLI arguments referring to repos start by 1 and must be
+      // compared against the initial known repos list. In case a service
+      // refresh already happened the current known repos list may have
+      // changed already.
+      std::string res = zypper.repoManagerInitialAlias( tmp );
+      if ( not res.empty() ) {
+        DBG << "Repo #" << tmp << " refers to alias " << res << endl;
+        aliasFromNumber = res;
+      }
+    }
+
+    for ( RepoManager::RepoConstIterator known_it = manager.repoBegin(); known_it != manager.repoEnd(); ++known_it )
     {
-      if ( known_it->alias() == str || tmp == number || known_it->name() == str )
+      if ( known_it->alias() == str || ( aliasFromNumber &&  known_it->alias() == *aliasFromNumber ) || known_it->name() == str )
       {
         if ( repo )
           *repo = *known_it;

--- a/src/repos.cc
+++ b/src/repos.cc
@@ -1697,7 +1697,7 @@ ZYPP_DECLARE_OPERATORS_FOR_FLAGS( ServiceListFlags );
 
 
 
-void checkIfToRefreshPluginServices(Zypper & zypper, RepoManager::RefreshServiceFlags flags_r)
+void checkIfToAutoRefreshServices(Zypper & zypper, RepoManager::RefreshServiceFlags flags_r)
 {
   // check root user
   if ( geteuid() != 0 )
@@ -1706,8 +1706,6 @@ void checkIfToRefreshPluginServices(Zypper & zypper, RepoManager::RefreshService
   RepoManager & repoManager = zypper.repoManager();
   for ( const auto & service : repoManager.knownServices() )
   {
-    if ( service.type() != repo::ServiceType::PLUGIN )
-      continue;
     if ( ! service.enabled() )
       continue;
     if ( ! service.autorefresh() )

--- a/src/repos.h
+++ b/src/repos.h
@@ -178,7 +178,7 @@ void remove_service( Zypper & zypper, const ServiceInfo & service );
 void modify_service( Zypper & zypper, const std::string & alias );
 
 /** If root, refresh any plugin services before lr/ls/ref (bnc#893294) */
-void checkIfToRefreshPluginServices( Zypper & zypper, RepoManager::RefreshServiceFlags flags_r =  RepoManager::RefreshServiceFlags() );
+void checkIfToAutoRefreshServices( Zypper & zypper, RepoManager::RefreshServiceFlags flags_r =  RepoManager::RefreshServiceFlags() );
 
 void modify_services_by_option( Zypper & zypper );
 


### PR DESCRIPTION
[bsc#1246504] (https://bugzilla.suse.com/show_bug.cgi?id=1246504)

This reverts commit 8a746bd01a5447a7929a514121259c9bf3fed875.
    
    The fix is too simple and breaks 'zypper ref REPO' because 'ref -s',
    the new default, does not accept arguments.
    
    Furthermore 'ref REPO' misbehaves if REPO is specified by number
    and a service auto-refresh adds or removes repos. Many commands
    evaluate their repo arguments after refresh. So this is actually
    not a new issue.

To fix bsc#1246504 we actually treat ris-services the same way as plugin-services.
    
    It's actually wrong to treat service refreshes different depending
    on the service type. For the purpose of a service it makes no
    difference how the data about the repos to use are acquired.

plugin-services are auto-refreshed correctly (before `lr` or `ref`), so this is the path for all services.