### PR TITLE
Add --filter-version-change to zypper lu

### DIFF
--- a/doc/zypper.8.txt
+++ b/doc/zypper.8.txt
@@ -548,6 +548,15 @@ If *patch* is specified, zypper acts as if the *list-patches* command was execut
 	*--best-effort*::
 		See the *update* command for description.
 
+	*--filter-version-change* _LEVEL_::
+		Filter updates by version change significance to reduce noise. _LEVEL_ is one of:
++
+*none*;; Show all available updates. This is the default.
+*rebuild*;; Hide updates where only the rebuild counter changed (last dot-segment of the release string). The packaging checkin and upstream version are identical.
+*package*;; Hide updates where only the release changed (checkin and/or rebuild). The upstream version is identical. This is more aggressive than *rebuild*.
++
+Epoch changes are never filtered. This option does not apply to patches (use *list-patches* filtering instead).
+
 	Expert Options: :: Don't use them unless you know you need them.
 
 include::{incdir}/option_Solver_Flags_Installs.txt[]

--- a/src/commands/listupdates.cc
+++ b/src/commands/listupdates.cc
@@ -33,6 +33,24 @@ zypp::ZyppFlags::CommandGroup ListUpdatesCmd::cmdOptions() const
     { "all", 'a', ZyppFlags::NoArgument, ZyppFlags::BoolType( &that._all, ZyppFlags::StoreTrue, _all ),
           // translators: -a, --all
           _("List all packages for which newer versions are available, regardless whether they are installable or not.")
+    },
+    { "filter-version-change", '\0', ZyppFlags::RequiredArgument,
+      ZyppFlags::Value(
+        []() -> boost::optional<std::string> { return std::string("none"); },
+        [&that]( const ZyppFlags::CommandOption &opt, const boost::optional<std::string> &in ) {
+          if ( !in )
+            ZYPP_THROW( ZyppFlags::MissingArgumentException( opt.name ) );
+          if ( *in == "none" )         that._vcFilter = VCF_None;
+          else if ( *in == "rebuild" ) that._vcFilter = VCF_Rebuild;
+          else if ( *in == "package" ) that._vcFilter = VCF_Package;
+          else
+            ZYPP_THROW( ZyppFlags::InvalidValueException( opt.name, *in,
+              str::Format(_("Valid values: %1%")) % "none, rebuild, package" ) );
+        },
+        _("LEVEL")
+      ),
+      // translators: --filter-version-change
+      _("Filter updates by version change significance. LEVEL: 'none' (default, show all), 'rebuild' (hide rebuild-only changes), 'package' (hide packaging-only changes, i.e. same upstream version).")
     }
   }};
 }
@@ -42,6 +60,7 @@ void ListUpdatesCmd::doReset()
   _kinds.clear();
   _all = false;
   _bestEffort = false;
+  _vcFilter = VCF_None;
 }
 
 int ListUpdatesCmd::execute( Zypper &zypper, const std::vector<std::string> &positionalArgs_r )
@@ -59,6 +78,6 @@ int ListUpdatesCmd::execute( Zypper &zypper, const std::vector<std::string> &pos
   if ( code != ZYPPER_EXIT_OK )
     return code;
 
-  list_updates( zypper, _kinds, _bestEffort, _all );
+  list_updates( zypper, _kinds, _bestEffort, _all, PatchSelector(), _vcFilter );
   return zypper.exitCode();
 }

--- a/src/commands/listupdates.h
+++ b/src/commands/listupdates.h
@@ -11,6 +11,7 @@
 #include "utils/flags/zyppflags.h"
 #include "optionsets.h"
 #include "solveroptionset.h"
+#include "src/update.h"
 
 #include <zypp/ResKind.h>
 
@@ -23,6 +24,7 @@ private:
   std::set<ResKind> _kinds;
   bool _all = false;
   bool _bestEffort = false;
+  VersionChangeFilter _vcFilter = VCF_None;
   InitReposOptionSet _initReposOpts { *this };
   SolverInstallsOptionSet _solverOpts { *this };
 

--- a/src/update.cc
+++ b/src/update.cc
@@ -49,6 +49,29 @@ namespace
     && pi->asKind<Patch>()->restartSuggested();
   }
 
+  std::string stripLastDotSegment( const std::string & rel )
+  {
+    auto pos = rel.rfind( '.' );
+    if ( pos == std::string::npos || pos == 0 )
+      return rel;
+    return rel.substr( 0, pos );
+  }
+
+  bool versionChangeFiltered( const Edition & installed, const Edition & candidate, VersionChangeFilter filter )
+  {
+    if ( filter == VCF_None )
+      return false;
+    if ( installed.epoch() != candidate.epoch() )
+      return false;
+    if ( installed.version() != candidate.version() )
+      return false;
+    // upstream version identical — at most a release (checkin/rebuild) change
+    if ( filter >= VCF_Package )
+      return true;
+    // VCF_Rebuild: filter only if the checkin is the same (releases differ only in rebuild counter)
+    return stripLastDotSegment( installed.release() ) == stripLastDotSegment( candidate.release() );
+  }
+
   /** RNC: Print other-update element */
   inline std::ostream & xmlPrintOtherUpdateOn( std::ostream & str, const PoolItem & pi_r )
   {
@@ -533,13 +556,20 @@ static bool xml_list_patches (Zypper & zypper, bool all_r, const PatchHistoryDat
 
 // ----------------------------------------------------------------------------
 
-static void xml_list_updates(const ResKindSet & kinds, bool all_r )
+static void xml_list_updates(const ResKindSet & kinds, bool all_r, VersionChangeFilter vcFilter_r )
 {
   Candidates candidates;
   find_updates( kinds, candidates, all_r );
 
   for( const PoolItem & pi : candidates )
   {
+    if ( vcFilter_r != VCF_None )
+    {
+      ui::Selectable::Ptr sel( ui::Selectable::get(pi) );
+      if ( sel && sel->hasInstalledObj()
+           && versionChangeFiltered( sel->installedObj()->edition(), pi.edition(), vcFilter_r ) )
+        continue;
+    }
     xmlPrintOtherUpdateOn( cout, pi );
   }
 }
@@ -712,7 +742,7 @@ std::string i18n_kind_updates(const ResKind & kind)
 
 // FIXME rewrite this function so that first the list of updates is collected and later correctly presented (bnc #523573)
 
-void list_updates(Zypper & zypper, const ResKindSet & kinds, bool best_effort, bool all_r, const PatchSelector &patchSel_r )
+void list_updates(Zypper & zypper, const ResKindSet & kinds, bool best_effort, bool all_r, const PatchSelector &patchSel_r, VersionChangeFilter vcFilter_r )
 {
   PatchHistoryData patchHistoryData;	// commonly used by all tables
 
@@ -758,7 +788,7 @@ void list_updates(Zypper & zypper, const ResKindSet & kinds, bool best_effort, b
   {
     if (!affects_pkgmgr)
     {
-      xml_list_updates( localkinds, all_r );
+      xml_list_updates( localkinds, all_r, vcFilter_r );
       cout << "</update-list>" << endl;		// otherwise closed in xml_list_patches
     }
     cout << "</update-status>" << endl;
@@ -806,6 +836,12 @@ void list_updates(Zypper & zypper, const ResKindSet & kinds, bool best_effort, b
 
     for ( const PoolItem & pi : candidates )
     {
+      ui::Selectable::Ptr sel( uipool.lookup( pi ) );
+
+      if ( vcFilter_r != VCF_None && sel && sel->hasInstalledObj()
+           && versionChangeFiltered( sel->installedObj()->edition(), pi.edition(), vcFilter_r ) )
+        continue;
+
       TableRow tr (cols);
       tr << computeStatusIndicator( pi );
       if (!hide_repo) {
@@ -820,7 +856,6 @@ void list_updates(Zypper & zypper, const ResKindSet & kinds, bool best_effort, b
         // for packages show also the current installed version (bnc #466599)
         if (*it == ResKind::package)
         {
-          ui::Selectable::Ptr sel( uipool.lookup( pi ) );
           if ( sel->hasInstalledObj() )
             tr << sel->installedObj()->edition();
         }

--- a/src/update.h
+++ b/src/update.h
@@ -9,6 +9,12 @@
 #include "utils/misc.h"
 #include "SolverRequester.h"
 
+enum VersionChangeFilter {
+  VCF_None    = 0,
+  VCF_Rebuild = 1,
+  VCF_Package = 2,
+};
+
 struct PatchSelector {
   std::set<Issue> _requestedIssues;
   std::set<std::string> _requestedPatchCategories;
@@ -34,7 +40,8 @@ void list_updates(Zypper & zypper,
                   const ResKindSet & kinds,
                   bool best_effort,
                   bool all,
-                  const PatchSelector &patchSel_r = PatchSelector() );
+                  const PatchSelector &patchSel_r = PatchSelector(),
+                  VersionChangeFilter vcFilter_r = VCF_None );
 
 /**
  * List available fixes to all issues or issues specified in --bugzilla


### PR DESCRIPTION
Adds filtering by version change significance to reduce noise in update listings. Supports levels: rebuild (hides rebuild-only changes) and package (hides all release-only changes).

*Rationale*: I've often wanted to see just changes that are more likely to change actual code, not "mere" rebuilds triggered by dependencies. I've previously filtered this via a script from zypper lu output, but I think this is cleaner.

Local testing suggests this is working fine, and the code looks clean enough. I made a guess at an acceptable name for the option.