### PR TITLE
Add --show-file-lists and --show-file-lists-save flags to search, implementing the first part of issue 633 feature request: https://github.com/openSUSE/zypper/issues/633

### DIFF
--- a/src/commands/search/search.cc
+++ b/src/commands/search/search.cc
@@ -1,226 +1,392 @@
 #include "search.h"
-#include "src/search.h"
-#include "global-settings.h"
-#include "utils/flags/flagtypes.h"
-#include "commands/commonflags.h"
 #include "commands/commandhelpformatter.h"
+#include "commands/commonflags.h"
 #include "commands/search/search-packages-hinthack.h"
+#include "global-settings.h"
+#include "src/search.h"
+#include "utils/flags/flagtypes.h"
 
-#include <zypp/base/Algorithm.h>
-#include <zypp/sat/Solvable.h>
+#include <iostream>
+#include <locale>
 #include <zypp/Capability.h>
 #include <zypp/PoolQueryResult.h>
+#include <zypp/base/Algorithm.h>
+#include <zypp/sat/Solvable.h>
+
+/// ISSUE #633 FEATURE REQUEST: Imports -> S.A.T
+#include <libxml/xmlreader.h>
+#include <vector>
+#include <zypp/Fetcher.h>
+#include <zypp/MediaSetAccess.h>
+#include <zypp/OnMediaLocation.h>
+#include <zypp/PathInfo.h>
+#include <zypp/TmpPath.h>
+#include <zypp/base/StrMatcher.h>
+/// END Imports.
 
 #include <unordered_map>
 
-namespace zypp
-{
-  namespace ZyppFlags
-  {
-    Value appendSolvAttrToSet ( std::set<zypp::sat::SolvAttr> &target_r, zypp::sat::SolvAttr value_r )
-    {
-      return Value (
-            noDefaultValue,
-            [ &target_r, value_r ] ( const CommandOption &, const boost::optional<std::string> & ) {
-              target_r.insert( value_r );
-            }
-      );
+namespace zypp {
+namespace ZyppFlags {
+Value appendSolvAttrToSet(std::set<zypp::sat::SolvAttr> &target_r,
+                          zypp::sat::SolvAttr value_r) {
+  return Value(noDefaultValue,
+               [&target_r, value_r](const CommandOption &,
+                                    const boost::optional<std::string> &) {
+                 target_r.insert(value_r);
+               });
+}
+
+Value setSolvAttrOptional(boost::optional<zypp::sat::SolvAttr> &target_r,
+                          zypp::sat::SolvAttr value_r) {
+  return Value(noDefaultValue,
+               [&target_r, value_r](const CommandOption &,
+                                    const boost::optional<std::string> &) {
+                 target_r = value_r;
+               });
+}
+} // namespace ZyppFlags
+} // namespace zypp
+
+namespace {
+// search helper
+inline bool poolExpectMatchFor(const std::string &name_r,
+                               const Edition &edition_r) {
+  for (const auto &pi : ResPool::instance().byName(name_r)) {
+    if (Edition::match(pi.edition(), edition_r) == 0)
+      return true;
+  }
+  return false;
+}
+} // namespace
+
+SearchCmd::SearchCmd(std::vector<std::string> &&commandAliases_r)
+    : ZypperBaseCommand(std::move(commandAliases_r), std::string(),
+                        std::string(), std::string(), ResetRepoManager) {
+  _sortOpts.setCompatibilityMode(CompatModeBits::EnableNewOpt);
+  _initReposOpts.setCompatibilityMode(CompatModeBits::EnableNewOpt);
+}
+
+void SearchCmd::setMode(const MatchMode &mode_r) { _mode = mode_r; }
+
+void SearchCmd::addRequestedDependency(const sat::SolvAttr &dep_r) {
+  _requestedDeps.insert(dep_r);
+}
+
+/// ISSUE #633 FEATURE REQUEST: HELPER FUNCTION TO ITERATE THROUGH FILES IN A
+/// DirEntry (void IterateDir)
+void IterateDir(std::vector<zypp::Pathname> &files,
+                const zypp::Pathname &targetDir) {
+  zypp::filesystem::DirContent entries;
+  zypp::filesystem::readdir(entries, targetDir, true);
+
+  for (const zypp::filesystem::DirEntry &entry : entries) {
+    std::string entry_name = entry.name;
+
+    /// Ignore current and parent directory markers if any exist
+    /// NOTE: I believe the 'true' in readdir should automatically handle this
+    /// but I'll still keep this check cause you can never be too safe.
+    if (entry_name == "." || entry_name == "..") {
+      continue;
     }
 
-    Value setSolvAttrOptional ( boost::optional<zypp::sat::SolvAttr> &target_r, zypp::sat::SolvAttr value_r ) {
-      return Value (
-          noDefaultValue,
-          [ &target_r, value_r ] ( const CommandOption &, const boost::optional<std::string> & ) {
-            target_r = value_r;
-          }
-        );
+    if (entry.type == zypp::filesystem::FT_FILE) {
+      files.push_back(targetDir / entry.name);
+    }
+    /// Explicity check if a directory before recursing
+    else if (entry.type == zypp::filesystem::FT_DIR) {
+      zypp::Pathname entry_dir = targetDir / entry_name;
+      IterateDir(files, entry_dir);
+    } else {
+      /// Catch unhandled types like symlinks, sockets, etc
+      std::clog << "Skipping non-file/non-dir entry: " << entry_name << "\n";
     }
   }
 }
 
-namespace
-{
-  // search helper
-  inline bool poolExpectMatchFor( const std::string & name_r, const Edition & edition_r )
-  {
-    for ( const auto & pi : ResPool::instance().byName( name_r ) )
-    {
-      if ( Edition::match( pi.edition(), edition_r ) == 0 )
-        return true;
+/// ISSUE #633 FEATURE REQUEST: HELPER FUNCTION TO READ XML DOCUMENT USING
+/// libxml2
+
+static std::string getFileListsUrl(const zypp::Pathname &repomdPath) {
+  std::string href = "";
+  xmlTextReaderPtr reader = xmlReaderForFile(repomdPath.c_str(), nullptr, 0);
+  if (!reader)
+    return href;
+
+  bool inFileListsBlock = false;
+  while (xmlTextReaderRead(reader) == 1) {
+    const char *name = (const char *)xmlTextReaderConstName(reader);
+    if (!name)
+      continue;
+
+    int nodeType = xmlTextReaderNodeType(reader);
+
+    if (nodeType == XML_READER_TYPE_ELEMENT && strcmp(name, "data") == 0) {
+      xmlChar *typeAttr = xmlTextReaderGetAttribute(reader, BAD_CAST "type");
+      if (typeAttr) {
+        if (strcmp((char *)typeAttr, "filelists") == 0) {
+          inFileListsBlock = true;
+        }
+        xmlFree(typeAttr);
+      }
+    } else if (nodeType == XML_READER_TYPE_END_ELEMENT &&
+               strcmp(name, "data") == 0) {
+      inFileListsBlock = false;
+    } else if (inFileListsBlock && nodeType == XML_READER_TYPE_ELEMENT &&
+               strcmp(name, "location") == 0) {
+      xmlChar *hrefAttr = xmlTextReaderGetAttribute(reader, BAD_CAST "href");
+
+      if (hrefAttr) {
+        href = (char *)hrefAttr;
+        xmlFree(hrefAttr);
+        break;
+      }
     }
-    return false;
   }
+
+  xmlFreeTextReader(reader);
+  return href;
 }
 
+/// ISSUE #633 FEATURE REQUEST: HELPER FUNCTION TO READ XML DOCUMENT USING
+/// libxml2
 
-SearchCmd::SearchCmd( std::vector<std::string> &&commandAliases_r )
-: ZypperBaseCommand( std::move( commandAliases_r ), std::string(), std::string(), std::string(), ResetRepoManager )
-{
-  _sortOpts.setCompatibilityMode( CompatModeBits::EnableNewOpt );
-  _initReposOpts.setCompatibilityMode( CompatModeBits::EnableNewOpt );
+static void extractPackageFiles(const zypp::Pathname &filelistPath,
+                                const std::string &targetName,
+                                const std::string &targetArch) {
+  xmlTextReaderPtr reader = xmlReaderForFile(filelistPath.c_str(), nullptr, 0);
+  if (!reader) {
+    std::cerr << "Failed to parse downloaded filelists archive.\n";
+    return;
+  }
+
+  bool inTargetPackage = false;
+
+  while (xmlTextReaderRead(reader) == 1) {
+    const char *name = (const char *)xmlTextReaderConstName(reader);
+    if (!name)
+      continue;
+
+    int nodeType = xmlTextReaderNodeType(reader);
+
+    if (nodeType == XML_READER_TYPE_ELEMENT && strcmp(name, "package") == 0) {
+      xmlChar *pkgName = xmlTextReaderGetAttribute(reader, BAD_CAST "name");
+      xmlChar *pkgArch = xmlTextReaderGetAttribute(reader, BAD_CAST "arch");
+
+      inTargetPackage =
+          (pkgName && strcmp((char *)pkgName, targetName.c_str()) == 0 &&
+           pkgArch && strcmp((char *)pkgArch, targetArch.c_str()) == 0);
+
+      if (pkgName)
+        xmlFree(pkgName);
+      if (pkgArch)
+        xmlFree(pkgArch);
+    } else if (nodeType == XML_READER_TYPE_END_ELEMENT &&
+               strcmp(name, "package") == 0) {
+      if (inTargetPackage)
+        break;
+      inTargetPackage = false;
+    } else if (inTargetPackage && nodeType == XML_READER_TYPE_ELEMENT &&
+               strcmp(name, "file") == 0) {
+      xmlChar *filePath = xmlTextReaderReadString(reader);
+      if (filePath) {
+        std::clog << " - " << (char *)filePath << "\n";
+        xmlFree(filePath);
+      }
+    }
+  }
+
+  xmlFreeTextReader(reader);
 }
 
-void SearchCmd::setMode(const MatchMode &mode_r)
-{
-  _mode = mode_r;
-}
+/// INFO: I used libxml for getFileListsUrl() instead of the
+/// zypp::parser::yum::RepomdFileReader beacuse of reference linker errors same
+/// issue as zypp::StrMatcher, as for extractPackageFiles() I didn't find a zypp
+/// native method or class that handled the parsing, the documentation is really
+/// hard to navigate. -> S.A.T
 
-void SearchCmd::addRequestedDependency(const sat::SolvAttr &dep_r)
-{
-  _requestedDeps.insert( dep_r );
-}
-
-std::string SearchCmd::summary() const
-{
+std::string SearchCmd::summary() const {
   // translators: command summary: search, se
   return _("Search for packages matching a pattern.");
 }
 
-std::vector<std::string> SearchCmd::synopsis() const
-{
-  return {
-    // translators: command synopsis; do not translate lowercase words
-    _("search (se) [OPTIONS] [QUERYSTRING] ...")
-  };
+std::vector<std::string> SearchCmd::synopsis() const {
+  return {// translators: command synopsis; do not translate lowercase words
+          _("search (se) [OPTIONS] [QUERYSTRING] ...")};
 }
 
-std::string SearchCmd::description() const
-{
+std::string SearchCmd::description() const {
   return (
-    // translators: command description
-    std::string( _("Search for packages matching any of the given search strings.") ) + "\n\n"
-    // translators: command description
-    + _("* and ? wildcards can also be used within search strings. If a search string is enclosed in '/', it's interpreted as a regular expression.")
-  );
+      // translators: command description
+      std::string(
+          _("Search for packages matching any of the given search strings.")) +
+      "\n\n"
+      // translators: command description
+      + _("* and ? wildcards can also be used within search strings. If a "
+          "search string is enclosed in '/', it's interpreted as a regular "
+          "expression."));
 }
 
-zypp::ZyppFlags::CommandGroup SearchCmd::cmdOptions() const
-{
+zypp::ZyppFlags::CommandGroup SearchCmd::cmdOptions() const {
 
   auto &that = *const_cast<SearchCmd *>(this);
   zypp::ZyppFlags::CommandGroup grp = {
-    {
-      { "match-substrings", 0, ZyppFlags::NoArgument, ZyppFlags::WriteFixedValueType( that._mode, MatchMode::Substrings ),
-            // translators: --match-substrings
-            _("Search for a match to partial words (default).")
-      },
-      { "match-words", 0, ZyppFlags::NoArgument, ZyppFlags::WriteFixedValueType( that._mode, MatchMode::Words ),
-            // translators: --match-words
-            _("Search for a match to whole words only.")
-      },
-      { "match-exact", 'x', ZyppFlags::NoArgument, ZyppFlags::WriteFixedValueType( that._mode, MatchMode::Exact ),
-            // translators: -x, --match-exact
-            _("Searches for an exact match of the search strings.")
-      },
-      { "provides", '\0', ZyppFlags::NoArgument, ZyppFlags::appendSolvAttrToSet( that._requestedDeps, sat::SolvAttr::dep_provides ),
+      {{"match-substrings", 0, ZyppFlags::NoArgument,
+        ZyppFlags::WriteFixedValueType(that._mode, MatchMode::Substrings),
+        // translators: --match-substrings
+        _("Search for a match to partial words (default).")},
+       {"match-words", 0, ZyppFlags::NoArgument,
+        ZyppFlags::WriteFixedValueType(that._mode, MatchMode::Words),
+        // translators: --match-words
+        _("Search for a match to whole words only.")},
+       {"match-exact", 'x', ZyppFlags::NoArgument,
+        ZyppFlags::WriteFixedValueType(that._mode, MatchMode::Exact),
+        // translators: -x, --match-exact
+        _("Searches for an exact match of the search strings.")},
+       {"provides", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::appendSolvAttrToSet(that._requestedDeps,
+                                       sat::SolvAttr::dep_provides),
         // translators: --provides
-        _("Search for packages which provide the search strings.")
-      },
-      { "requires", '\0', ZyppFlags::NoArgument, ZyppFlags::appendSolvAttrToSet( that._requestedDeps, sat::SolvAttr::dep_requires ),
+        _("Search for packages which provide the search strings.")},
+       {"requires", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::appendSolvAttrToSet(that._requestedDeps,
+                                       sat::SolvAttr::dep_requires),
         // translators: --requires
-        _("Search for packages which require the search strings.")
-      },
-      { "recommends", '\0', ZyppFlags::NoArgument, ZyppFlags::appendSolvAttrToSet( that._requestedDeps, sat::SolvAttr::dep_recommends ),
+        _("Search for packages which require the search strings.")},
+       {"recommends", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::appendSolvAttrToSet(that._requestedDeps,
+                                       sat::SolvAttr::dep_recommends),
         // translators: --recommends
-        _("Search for packages which recommend the search strings.")
-      },
-      { "supplements", '\0', ZyppFlags::NoArgument, ZyppFlags::appendSolvAttrToSet( that._requestedDeps, sat::SolvAttr::dep_supplements ),
+        _("Search for packages which recommend the search strings.")},
+       {"supplements", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::appendSolvAttrToSet(that._requestedDeps,
+                                       sat::SolvAttr::dep_supplements),
         // translators: --supplements
-        _("Search for packages which supplement the search strings.")
-      },
-      { "conflicts", '\0', ZyppFlags::NoArgument, ZyppFlags::appendSolvAttrToSet( that._requestedDeps, sat::SolvAttr::dep_conflicts ),
+        _("Search for packages which supplement the search strings.")},
+       {"conflicts", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::appendSolvAttrToSet(that._requestedDeps,
+                                       sat::SolvAttr::dep_conflicts),
         // translators: --conflicts
-        _("Search packages conflicting with search strings.")
-      },
-      { "obsoletes", '\0', ZyppFlags::NoArgument, ZyppFlags::appendSolvAttrToSet( that._requestedDeps, sat::SolvAttr::dep_obsoletes ),
+        _("Search packages conflicting with search strings.")},
+       {"obsoletes", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::appendSolvAttrToSet(that._requestedDeps,
+                                       sat::SolvAttr::dep_obsoletes),
         // translators: --obsoletes
-        _("Search for packages which obsolete the search strings.")
-      },
-      { "suggests", '\0', ZyppFlags::NoArgument, ZyppFlags::appendSolvAttrToSet( that._requestedDeps, sat::SolvAttr::dep_suggests ),
+        _("Search for packages which obsolete the search strings.")},
+       {"suggests", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::appendSolvAttrToSet(that._requestedDeps,
+                                       sat::SolvAttr::dep_suggests),
         // translators: --suggests
-        _("Search for packages which suggest the search strings.")
-      },
-      { "enhances", '\0', ZyppFlags::NoArgument, ZyppFlags::appendSolvAttrToSet( that._requestedDeps, sat::SolvAttr::dep_enhances ),
+        _("Search for packages which suggest the search strings.")},
+       {"enhances", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::appendSolvAttrToSet(that._requestedDeps,
+                                       sat::SolvAttr::dep_enhances),
         // translators: --enhances
-        _("Search for packages which enhance the search strings.")
-      },
-      { "provides-pkg", '\0', ZyppFlags::NoArgument, ZyppFlags::setSolvAttrOptional( that._requestedReverseSearch, sat::SolvAttr::dep_provides ),
+        _("Search for packages which enhance the search strings.")},
+       {"provides-pkg", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::setSolvAttrOptional(that._requestedReverseSearch,
+                                       sat::SolvAttr::dep_provides),
         // translators: --provides-pkg
-        _("Search for all packages that provide any of the provides of the package(s) matched by the input parameters.")
-      },
-      { "requires-pkg", '\0', ZyppFlags::NoArgument, ZyppFlags::setSolvAttrOptional( that._requestedReverseSearch, sat::SolvAttr::dep_requires ),
+        _("Search for all packages that provide any of the provides of the "
+          "package(s) matched by the input parameters.")},
+       {"requires-pkg", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::setSolvAttrOptional(that._requestedReverseSearch,
+                                       sat::SolvAttr::dep_requires),
         // translators: --requires-pkg
-        _("Search for all packages that require any of the provides of the package(s) matched by the input parameters.")
-      },
-      { "recommends-pkg", '\0', ZyppFlags::NoArgument, ZyppFlags::setSolvAttrOptional( that._requestedReverseSearch, sat::SolvAttr::dep_recommends ),
+        _("Search for all packages that require any of the provides of the "
+          "package(s) matched by the input parameters.")},
+       {"recommends-pkg", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::setSolvAttrOptional(that._requestedReverseSearch,
+                                       sat::SolvAttr::dep_recommends),
         // translators: --recommends-pkg
-        _("Search for all packages that recommend any of the provides of the package(s) matched by the input parameters.")
-      },
-      { "supplements-pkg", '\0', ZyppFlags::NoArgument, ZyppFlags::setSolvAttrOptional( that._requestedReverseSearch, sat::SolvAttr::dep_supplements ),
+        _("Search for all packages that recommend any of the provides of the "
+          "package(s) matched by the input parameters.")},
+       {"supplements-pkg", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::setSolvAttrOptional(that._requestedReverseSearch,
+                                       sat::SolvAttr::dep_supplements),
         // translators: --supplements-pkg
-        _("Search for all packages that supplement any of the provides of the package(s) matched by the input parameters.")
-      },
-      { "conflicts-pkg", '\0', ZyppFlags::NoArgument, ZyppFlags::setSolvAttrOptional( that._requestedReverseSearch, sat::SolvAttr::dep_conflicts ),
+        _("Search for all packages that supplement any of the provides of the "
+          "package(s) matched by the input parameters.")},
+       {"conflicts-pkg", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::setSolvAttrOptional(that._requestedReverseSearch,
+                                       sat::SolvAttr::dep_conflicts),
         // translators: --conflicts-pkg
-        _("Search for all packages that conflict with any of the package(s) matched by the input parameters.")
-      },
-      { "obsoletes-pkg", '\0', ZyppFlags::NoArgument, ZyppFlags::setSolvAttrOptional( that._requestedReverseSearch, sat::SolvAttr::dep_obsoletes ),
+        _("Search for all packages that conflict with any of the package(s) "
+          "matched by the input parameters.")},
+       {"obsoletes-pkg", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::setSolvAttrOptional(that._requestedReverseSearch,
+                                       sat::SolvAttr::dep_obsoletes),
         // translators: --obsoletes-pkg
-        _("Search for all packages that obsolete any of the package(s) matched by the input parameters.")
-      },
-      { "suggests-pkg", '\0', ZyppFlags::NoArgument, ZyppFlags::setSolvAttrOptional( that._requestedReverseSearch, sat::SolvAttr::dep_suggests ),
+        _("Search for all packages that obsolete any of the package(s) matched "
+          "by the input parameters.")},
+       {"suggests-pkg", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::setSolvAttrOptional(that._requestedReverseSearch,
+                                       sat::SolvAttr::dep_suggests),
         // translators: --suggests-pkg
-        _("Search for all packages that suggest any of the provides of the package(s) matched by the input parameters.")
-      },
-      { "enhances-pkg", '\0', ZyppFlags::NoArgument, ZyppFlags::setSolvAttrOptional( that._requestedReverseSearch, sat::SolvAttr::dep_enhances ),
+        _("Search for all packages that suggest any of the provides of the "
+          "package(s) matched by the input parameters.")},
+       {"enhances-pkg", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::setSolvAttrOptional(that._requestedReverseSearch,
+                                       sat::SolvAttr::dep_enhances),
         // translators: --enhances-pkg
-        _("Search for all packages that enhance any of the provides of the package(s) matched by the input parameters.")
-      },
-      CommonFlags::resKindSetFlag( that._requestedTypes,
-                                   // translators: -t, --type <TYPE>
-                                   _("Search only for packages of the specified type.")
-      ),
-      { "name", 'n', ZyppFlags::NoArgument, ZyppFlags::BoolType( &that._forceNameAttr, ZyppFlags::StoreTrue ),
+        _("Search for all packages that enhance any of the provides of the "
+          "package(s) matched by the input parameters.")},
+       CommonFlags::resKindSetFlag(
+           that._requestedTypes,
+           // translators: -t, --type <TYPE>
+           _("Search only for packages of the specified type.")),
+       {"name", 'n', ZyppFlags::NoArgument,
+        ZyppFlags::BoolType(&that._forceNameAttr, ZyppFlags::StoreTrue),
         // translators: -n, --name
-        _("Useful together with dependency options, otherwise searching in package name is default.")
-      },
-      { "file-list", 'f', ZyppFlags::NoArgument, ZyppFlags::appendSolvAttrToSet( that._requestedDeps, sat::SolvAttr::filelist ),
+        _("Useful together with dependency options, otherwise searching in "
+          "package name is default.")},
+       {"file-list", 'f', ZyppFlags::NoArgument,
+        ZyppFlags::appendSolvAttrToSet(that._requestedDeps,
+                                       sat::SolvAttr::filelist),
         // translators: -f, --file-list
-        _("Search for a match in the file list of packages.")
-      },
-      { "search-descriptions", 'd', ZyppFlags::NoArgument, ZyppFlags::BoolType( &that._searchDesc, ZyppFlags::StoreTrue, _searchDesc ),
+        _("Search for a match in the file list of packages.")},
+       {/// ISSUE #633 FEATURE REQUEST -> S.A.T
+        "show-file-lists", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::BoolType(&that._showFileLists, ZyppFlags::StoreTrue),
+        // translators: --show-file-lists
+        _("Download and display the complete secondary filelist metadata for "
+          "the package.")},
+       {/// ISSUE #633 FEATURE REQUEST -> S.A.T
+        "show-file-lists-save", '\0', ZyppFlags::NoArgument,
+        ZyppFlags::BoolType(&that._showFileListsSave, ZyppFlags::StoreTrue),
+        // translators: --show-file-lists-save
+        _("Download, display, and save the complete secondary filelist "
+          "metadata.")},
+       {"search-descriptions", 'd', ZyppFlags::NoArgument,
+        ZyppFlags::BoolType(&that._searchDesc, ZyppFlags::StoreTrue,
+                            _searchDesc),
         // translators: -d, --search-descriptions
-        _("Search also in package summaries and descriptions.")
-      },
-      {"case-sensitive", 'C', ZyppFlags::NoArgument, ZyppFlags::BoolType( &that._caseSensitive, ZyppFlags::StoreTrue, _caseSensitive ),
+        _("Search also in package summaries and descriptions.")},
+       {"case-sensitive", 'C', ZyppFlags::NoArgument,
+        ZyppFlags::BoolType(&that._caseSensitive, ZyppFlags::StoreTrue,
+                            _caseSensitive),
         // translators: -C, --case-sensitive
-        _("Perform case-sensitive search.")
-      },
-      CommonFlags::detailsFlag( that._details, 's',
+        _("Perform case-sensitive search.")},
+       CommonFlags::detailsFlag(that._details, 's',
                                 // translators: -s, --details
-                                _("Show each available version in each repository on a separate line.")
-      ),
-      {"verbose", 'v', ZyppFlags::NoArgument, ZyppFlags::BoolType( &that._verbose, ZyppFlags::StoreTrue, _caseSensitive ),
+                                _("Show each available version in each "
+                                  "repository on a separate line.")),
+       {"verbose", 'v', ZyppFlags::NoArgument,
+        ZyppFlags::BoolType(&that._verbose, ZyppFlags::StoreTrue,
+                            _caseSensitive),
         // translators: -v, --verbose
-        _("Like --details, with additional information where the search has matched (useful for search in dependencies).")
-      }
-    },
-    {
-      { "match-substrings", "match-words", "match-exact" },
-      { "provides-pkg", "requires-pkg", "recommends-pkg", "supplements-pkg", "conflicts-pkg", "obsoletes-pkg", "suggests-pkg"  }
-    }
-  };
+        _("Like --details, with additional information where the search has "
+          "matched (useful for search in dependencies).")}},
+      {{"match-substrings", "match-words", "match-exact"},
+       {"provides-pkg", "requires-pkg", "recommends-pkg", "supplements-pkg",
+        "conflicts-pkg", "obsoletes-pkg", "suggests-pkg"}}};
 
   return grp;
 }
 
-std::string SearchCmd::help()
-{
-  return ZypperBaseCommand::help();
-}
+std::string SearchCmd::help() { return ZypperBaseCommand::help(); }
 
-void SearchCmd::doReset()
-{
+void SearchCmd::doReset() {
   _mode = MatchMode::Default;
   _forceNameAttr = false;
   _searchDesc = false;
@@ -231,19 +397,20 @@ void SearchCmd::doReset()
   _requestedTypes.clear();
 }
 
-int SearchCmd::execute( Zypper &zypper, const std::vector<std::string> &positionalArgs_r )
-{
+int SearchCmd::execute(Zypper &zypper,
+                       const std::vector<std::string> &positionalArgs_r) {
   // check args...
   PoolQuery query;
   TriBool inst_notinst = indeterminate;
 
-  if ( zypper.config().disable_system_resolvables || _notInstalledOpts._mode == SolvableFilterMode::ShowOnlyNotInstalled )
-  {
-    query.setUninstalledOnly(); // beware: this is not all to it, look at zypper-search, _only_not_installed
+  if (zypper.config().disable_system_resolvables ||
+      _notInstalledOpts._mode == SolvableFilterMode::ShowOnlyNotInstalled) {
+    query.setUninstalledOnly(); // beware: this is not all to it, look at
+                                // zypper-search, _only_not_installed
     inst_notinst = false;
   }
 
-  if ( _notInstalledOpts._mode == SolvableFilterMode::ShowOnlyInstalled ) {
+  if (_notInstalledOpts._mode == SolvableFilterMode::ShowOnlyInstalled) {
     inst_notinst = true;
     zypper.configNoConst().no_refresh = true;
     //  query.setInstalledOnly();
@@ -252,258 +419,441 @@ int SearchCmd::execute( Zypper &zypper, const std::vector<std::string> &position
     // discards an installed item if an identicalAvailable is present, expecting
     // that the query will deliver this too (even if inst_notinst == true).
     // Maybe done to print the correct repo (rather than @System), but if that's
-    // all, the overhead of processing all available (and discarding most of them)
-    // is bigger than chacking for an identicalAvailable when printing the installed.
+    // all, the overhead of processing all available (and discarding most of
+    // them) is bigger than chacking for an identicalAvailable when printing the
+    // installed.
   }
 
-  switch ( _mode  ) {
-    case MatchMode::Substrings:
-      query.setMatchSubstring();	// this is also the PoolQuery default
-      break;
-    case MatchMode::Words:
-      query.setMatchWord();
-      break;
-    case MatchMode::Exact:
-      query.setMatchExact();
-      break;
-    case MatchMode::Default:
+  switch (_mode) {
+  case MatchMode::Substrings:
+    query.setMatchSubstring(); // this is also the PoolQuery default
+    break;
+  case MatchMode::Words:
+    query.setMatchWord();
+    break;
+  case MatchMode::Exact:
+    query.setMatchExact();
+    break;
+  case MatchMode::Default:
     break;
   }
 
-  if ( _caseSensitive )
+  if (_caseSensitive)
     query.setCaseSensitive();
 
-  if ( _requestedTypes.size() > 0 )
-  {
-    for ( const ResKind &knd : _requestedTypes )
-      query.addKind( knd );
+  if (_requestedTypes.size() > 0) {
+    for (const ResKind &knd : _requestedTypes)
+      query.addKind(knd);
   }
 
   // load system data...
-  int code = defaultSystemSetup(  zypper, InitTarget | InitRepos | LoadResolvables | Resolve  );
-  if ( code != ZYPPER_EXIT_OK )
+  int code = defaultSystemSetup(zypper, InitTarget | InitRepos |
+                                            LoadResolvables | Resolve);
+  if (code != ZYPPER_EXIT_OK)
     return code;
 
   // build query...
 
   // add available repos to query
-  if ( InitRepoSettings::instance()._repoFilter.size() )
-  {
+  if (InitRepoSettings::instance()._repoFilter.size()) {
     auto &rData = zypper.runtimeData();
-    for_(repo_it, rData.repos.begin(), rData.repos.end() )
-    {
-      query.addRepo( repo_it->alias() );
-      if ( !repo_it->enabled() )
-      {
-        zypper.out().warning( str::Format(_("Specified repository '%s' is disabled.")) % repo_it->asUserString() );
+    for_(repo_it, rData.repos.begin(), rData.repos.end()) {
+      query.addRepo(repo_it->alias());
+      if (!repo_it->enabled()) {
+        zypper.out().warning(
+            str::Format(_("Specified repository '%s' is disabled.")) %
+            repo_it->asUserString());
       }
     }
   }
 
-  // make sure we search by name if the user explicitely forced it or if no deps where requested
-  if ( _requestedDeps.empty() || _forceNameAttr )
-    _requestedDeps.insert( sat::SolvAttr::name );
+  // make sure we search by name if the user explicitely forced it or if no deps
+  // where requested
+  if (_requestedDeps.empty() || _forceNameAttr)
+    _requestedDeps.insert(sat::SolvAttr::name);
 
   bool details = _details || _verbose;
   // add argument strings and attributes to query
-  for_( it, positionalArgs_r.begin(), positionalArgs_r.end() )
-  {
-    Capability cap( *it );
+  for_(it, positionalArgs_r.begin(), positionalArgs_r.end()) {
+    Capability cap(*it);
     std::string name = cap.detail().name().asString();
 
-    // bsc#1119873 zypper search: inconsistent results for `-t package kernel-default` vs `package:kernel-default`
-    // Capability parser strips 'package:' prefix from name, because ident for package and srcpackage does not contain
-    // the prefix but instead is only differentiated by arch.
-    // We need to add package prefix again, the srcpackage is correctly matched since the srcpackage: prefix is not stripped
-    ResKind explicitBuildin = ResKind::explicitBuiltin( *it );
-    if ( explicitBuildin == ResKind::package )
+    // bsc#1119873 zypper search: inconsistent results for `-t package
+    // kernel-default` vs `package:kernel-default` Capability parser strips
+    // 'package:' prefix from name, because ident for package and srcpackage
+    // does not contain the prefix but instead is only differentiated by arch.
+    // We need to add package prefix again, the srcpackage is correctly matched
+    // since the srcpackage: prefix is not stripped
+    ResKind explicitBuildin = ResKind::explicitBuiltin(*it);
+    if (explicitBuildin == ResKind::package)
       name = explicitBuildin.asString() + ":" + name;
 
-    if ( cap.detail().isVersioned() )
-      details = true;	// show details if any search string includes an edition
+    if (cap.detail().isVersioned())
+      details = true; // show details if any search string includes an edition
 
-    // Default Match::OTHER indicates to merge name into the global search string and mode.
+    // Default Match::OTHER indicates to merge name into the global search
+    // string and mode.
     Match::Mode matchmode = Match::OTHER;
-    if ( _mode == MatchMode::Default )
-    {
-      if ( name.size() >= 2 && *name.begin() == '/' && *name.rbegin() == '/' )
-      {
-        name = name.substr( 1, name.size()-2 );
+    if (_mode == MatchMode::Default) {
+      if (name.size() >= 2 && *name.begin() == '/' && *name.rbegin() == '/') {
+        name = name.substr(1, name.size() - 2);
         matchmode = Match::REGEX;
-      }
-      else if ( name.find_first_of("?*") != std::string::npos )
+      } else if (name.find_first_of("?*") != std::string::npos)
         matchmode = Match::GLOB;
     }
     // else: match mode explicitly requested by cli arg
 
-    // NOTE: We use the  addDependency  overload taking a  matchmode  argument for ALL
-    // kinds of attributes, not only for dependencies. A constraint on 'op version'
-    // will automatically be applied to match a matching dependency or to match
-    // the matching solvables version, depending on the kind of attribute.
-    for ( const zypp::sat::SolvAttr &attr : _requestedDeps ) {
+    // NOTE: We use the  addDependency  overload taking a  matchmode  argument
+    // for ALL kinds of attributes, not only for dependencies. A constraint on
+    // 'op version' will automatically be applied to match a matching dependency
+    // or to match the matching solvables version, depending on the kind of
+    // attribute.
+    for (const zypp::sat::SolvAttr &attr : _requestedDeps) {
 
-      //add the basic dependency
-      query.addDependency( attr , name, cap.detail().op(), cap.detail().ed(), Arch(cap.detail().arch()), matchmode );
+      // add the basic dependency
+      query.addDependency(attr, name, cap.detail().op(), cap.detail().ed(),
+                          Arch(cap.detail().arch()), matchmode);
 
-      //handle special cases
-      if ( attr == sat::SolvAttr::dep_provides && str::regex_match( name.c_str(), std::string("^/") ) ) {
+      // handle special cases
+      if (attr == sat::SolvAttr::dep_provides &&
+          str::regex_match(name.c_str(), std::string("^/"))) {
         // in case of path names also search in file list
-        query.setFilesMatchFullPath( true );
-        query.addDependency( sat::SolvAttr::filelist , name, cap.detail().op(), cap.detail().ed(), Arch(cap.detail().arch()), matchmode );
+        query.setFilesMatchFullPath(true);
+        query.addDependency(sat::SolvAttr::filelist, name, cap.detail().op(),
+                            cap.detail().ed(), Arch(cap.detail().arch()),
+                            matchmode);
 
-      } else if ( attr == sat::SolvAttr::filelist ) {
+      } else if (attr == sat::SolvAttr::filelist) {
 
-        query.setFilesMatchFullPath( true );
+        query.setFilesMatchFullPath(true);
 
-      } else if ( attr == sat::SolvAttr::name ) {
+      } else if (attr == sat::SolvAttr::name) {
 
-        if ( matchmode == Match::OTHER && cap.detail().isNamed() )
-        {
+        if (matchmode == Match::OTHER && cap.detail().isNamed()) {
           // ARG did not require a specific matchmode.
           // Handle "N-V" and "N-V-R" cases. Name must match exact,
           // Version/Release must not be empty. If versioned matches are
           // found, don't forget to show details.
-          std::string::size_type pos = name.find_last_of( "-" );
-          if ( pos != std::string::npos && pos != 0 && pos != name.size()-1 )
-          {
-            std::string n( name.substr(0,pos) );
-            std::string r( name.substr(pos+1) );
-            Edition e( r );
-            query.addDependency( sat::SolvAttr::name, n, Rel::EQ, e, Arch(cap.detail().arch()), Match::STRING );
-            if ( poolExpectMatchFor( n, e ) )
-              details = true;	// show details if any search string includes an edition
+          std::string::size_type pos = name.find_last_of("-");
+          if (pos != std::string::npos && pos != 0 && pos != name.size() - 1) {
+            std::string n(name.substr(0, pos));
+            std::string r(name.substr(pos + 1));
+            Edition e(r);
+            query.addDependency(sat::SolvAttr::name, n, Rel::EQ, e,
+                                Arch(cap.detail().arch()), Match::STRING);
+            if (poolExpectMatchFor(n, e))
+              details =
+                  true; // show details if any search string includes an edition
 
-            std::string::size_type pos2 = name.find_last_of( "-", pos-1 );
-            if ( pos2 != std::string::npos && pos2 != 0 &&  pos2 != pos-1)
-            {
-              n = name.substr(0,pos2);
-              e = Edition( name.substr(pos2+1,pos-pos2-1), r );
-              query.addDependency( sat::SolvAttr::name, n, Rel::EQ, e, Arch(cap.detail().arch()), Match::STRING );
-              if ( poolExpectMatchFor( n, e ) )
-                details = true;	// show details if any search string includes an edition
+            std::string::size_type pos2 = name.find_last_of("-", pos - 1);
+            if (pos2 != std::string::npos && pos2 != 0 && pos2 != pos - 1) {
+              n = name.substr(0, pos2);
+              e = Edition(name.substr(pos2 + 1, pos - pos2 - 1), r);
+              query.addDependency(sat::SolvAttr::name, n, Rel::EQ, e,
+                                  Arch(cap.detail().arch()), Match::STRING);
+              if (poolExpectMatchFor(n, e))
+                details = true; // show details if any search string includes an
+                                // edition
             }
           }
         }
       }
     }
 
-    if ( _searchDesc )
-    {
-      query.addDependency( sat::SolvAttr::summary, name, cap.detail().op(), cap.detail().ed(), Arch(cap.detail().arch()), matchmode );
-      query.addDependency( sat::SolvAttr::description, name, cap.detail().op(), cap.detail().ed(), Arch(cap.detail().arch()), matchmode );
+    if (_searchDesc) {
+      query.addDependency(sat::SolvAttr::summary, name, cap.detail().op(),
+                          cap.detail().ed(), Arch(cap.detail().arch()),
+                          matchmode);
+      query.addDependency(sat::SolvAttr::description, name, cap.detail().op(),
+                          cap.detail().ed(), Arch(cap.detail().arch()),
+                          matchmode);
     }
   }
 
   Table t;
-  try
-  {
-    if ( _requestedReverseSearch.is_initialized() ) {
+  try {
+    if (_requestedReverseSearch.is_initialized()) {
 
-      std::unordered_map< sat::Solvable, CapabilitySet > matchedSolvables;
+      std::unordered_map<sat::Solvable, CapabilitySet> matchedSolvables;
       const auto reqSearchAttrib = _requestedReverseSearch.get();
 
-      for ( const auto slv : query ) {
+      for (const auto slv : query) {
 
         bool isInstalled = slv.isSystem();
-        if ( isInstalled && _notInstalledOpts._mode == SolvableFilterMode::ShowOnlyNotInstalled )
+        if (isInstalled &&
+            _notInstalledOpts._mode == SolvableFilterMode::ShowOnlyNotInstalled)
           continue;
-        if ( !isInstalled && _notInstalledOpts._mode == SolvableFilterMode::ShowOnlyInstalled )
+        if (!isInstalled &&
+            _notInstalledOpts._mode == SolvableFilterMode::ShowOnlyInstalled)
           continue;
 
-        sat::Queue q = sat::Pool::instance().whatMatchesSolvable( reqSearchAttrib, slv  );
+        sat::Queue q =
+            sat::Pool::instance().whatMatchesSolvable(reqSearchAttrib, slv);
 
-        for ( auto matchedSolvId : q ) {
+        for (auto matchedSolvId : q) {
 
-          sat::Solvable matchedSolv ( static_cast<sat::Solvable::IdType>(matchedSolvId) );
-          auto p = matchedSolvables.insert( make_pair( std::move(matchedSolv), CapabilitySet()) );
+          sat::Solvable matchedSolv(
+              static_cast<sat::Solvable::IdType>(matchedSolvId));
+          auto p = matchedSolvables.insert(
+              make_pair(std::move(matchedSolv), CapabilitySet()));
 
-          if ( _verbose ) {
-            CapabilitySet matchedCaps = matchedSolv.matchesSolvable( reqSearchAttrib, slv).second;
-            p.first->second.insert( matchedCaps.begin(), matchedCaps.end() );
+          if (_verbose) {
+            CapabilitySet matchedCaps =
+                matchedSolv.matchesSolvable(reqSearchAttrib, slv).second;
+            p.first->second.insert(matchedCaps.begin(), matchedCaps.end());
           }
         }
       }
 
-      if ( details ) {
-        FillSearchTableSolvable callback( t, inst_notinst );
-        std::for_each( matchedSolvables.begin(), matchedSolvables.end(), [&callback, verb = _verbose, &reqSearchAttrib ]( auto elem ){
-          if ( verb )
-            callback( elem.first, reqSearchAttrib, elem.second );
-          else
-            callback( elem.first, reqSearchAttrib, {} );
-        } );
+      if (details) {
+        FillSearchTableSolvable callback(t, inst_notinst);
+        std::for_each(
+            matchedSolvables.begin(), matchedSolvables.end(),
+            [&callback, verb = _verbose, &reqSearchAttrib](auto elem) {
+              if (verb)
+                callback(elem.first, reqSearchAttrib, elem.second);
+              else
+                callback(elem.first, reqSearchAttrib, {});
+            });
       } else {
 
         PoolQueryResult res;
-        std::for_each( matchedSolvables.begin(), matchedSolvables.end(), [ &res ]( const auto &v ){ res+=v.first; } );
+        std::for_each(matchedSolvables.begin(), matchedSolvables.end(),
+                      [&res](const auto &v) { res += v.first; });
 
-        FillSearchTableSelectable callback( t, inst_notinst );
-        std::for_each( res.selectableBegin(), res.selectableEnd(), callback);
+        FillSearchTableSelectable callback(t, inst_notinst);
+        std::for_each(res.selectableBegin(), res.selectableEnd(), callback);
       }
 
     } else {
-      if ( details )
-      {
-        FillSearchTableSolvable callback( t, inst_notinst );
-        if ( _verbose )
-        {
-          // Option 'verbose' shows where (e.g. in 'requires', 'name') the search has matched.
-          // Info is available from PoolQuery::const_iterator.
-          for_( it, query.begin(), query.end() )
-            callback( it );
+      if (details) {
+        FillSearchTableSolvable callback(t, inst_notinst);
+        if (_verbose) {
+          // Option 'verbose' shows where (e.g. in 'requires', 'name') the
+          // search has matched. Info is available from
+          // PoolQuery::const_iterator.
+          for_(it, query.begin(), query.end()) callback(it);
+        } else {
+          for (const auto slv : query)
+            callback(slv);
         }
-        else
-        {
-          for ( const auto slv : query )
-            callback( slv );
-        }
-      }
-      else
-      {
-        FillSearchTableSelectable callback( t, inst_notinst );
-        invokeOnEach( query.selectableBegin(), query.selectableEnd(), callback );
+      } else {
+        /// ISSUE #633 FEATURE REQUEST: Code Implementation -> S.A.T
+        if (_showFileLists && _showFileListsSave) {
+          zypper.out().error(_("You can't use --show-file-lists and "
+                               "--show-file-lists-save at the same time."));
+          zypper.setExitCode(ZYPPER_EXIT_ERR_INVALID_ARGS);
+          return zypper.exitCode();
+        } else if (_showFileLists || _showFileListsSave) {
+          if (query.empty()) {
+            zypper.out().info(_("No matching packages found"), Out::QUIET);
+            return zypper.exitCode();
+          }
+
+          zypp::sat::Solvable firstResult = *query.begin();
+          zypp::sat::Solvable finalPackage = firstResult;
+          std::string targetName = firstResult.name();
+
+          bool multipleNamesFound = false;
+          for (const zypp::sat::Solvable slv : query) {
+            if (slv.name() != targetName) {
+              multipleNamesFound = true;
+              break;
+            }
+
+            if (!slv.isSystem() && slv.isKind(zypp::ResKind::package)) {
+              finalPackage = slv;
+              break;
+            }
+          }
+
+          if (multipleNamesFound) {
+            std::string ERROR_MESSAGE_FLAG =
+                _showFileLists ? "--show-file-lists" : "--show-file-lists-save";
+            zypper.out().error(
+                str::Format(_("The %s flag can only be used on a single "
+                              "package name. Please refine your search. "
+                              "Consider using tags like '-x' or '-C'. Run "
+                              "'zypper search --help' for more help.")) %
+                ERROR_MESSAGE_FLAG);
+            zypper.setExitCode(ZYPPER_EXIT_ERR_INVALID_ARGS);
+            return zypper.exitCode();
+          }
+
+          /// INFO: The reason behind this approach to get the package
+          /// was because when trying to implement this initially, I added
+          /// some debug statements to test the output for a test package like
+          /// bash, I got two results for that search,and I needed to use the
+          /// right package, I don't know how relevant this info will be but I
+          /// just wanted to clarify.
+
+          /// Get the single matched package
+          zypp::sat::Solvable targetPackage = finalPackage;
+          zypp::Repository repo = targetPackage.repository();
+
+          if (!repo) {
+            zypper.out().error(
+                _("Package does not belong to a valid repository."));
+            return zypper.exitCode();
+          }
+
+          std::vector<zypp::Pathname> files;
+          zypp::Pathname targetDir = repo.info().metadataPath() / "repodata";
+
+          std::clog << "Searching locally for repomd.xml..." << std::endl;
+
+          IterateDir(files, targetDir);
+
+          bool fileListExistsLocally = false;
+          std::string localFileListDir = "";
+          const std::string suffix = "-filelists.xml.gz";
+
+          for (const zypp::Pathname &entry : files) {
+            std::string entryStr = entry.asString();
+
+            /// INFO: I use a manual string comparison here instead of
+            /// zypp::StrMatcher because there were some reference linker errors
+            /// during the build.
+            if (entryStr.size() >= suffix.size() &&
+                entryStr.compare(entryStr.size() - suffix.size(), suffix.size(),
+                                 suffix) == 0) {
+              fileListExistsLocally = true;
+              localFileListDir = entryStr;
+              break;
+            }
+          }
+
+          if (!fileListExistsLocally) {
+            zypp::Pathname repomdPath =
+                repo.info().metadataPath() / "repodata/repomd.xml";
+
+            if (!zypp::filesystem::PathInfo(repomdPath).isExist()) {
+              zypper.out().error(_("Repository metadata not found locally. Try "
+                                   "running 'zypper refresh' first."));
+              zypper.setExitCode(ZYPPER_EXIT_ERR_ZYPP);
+              return zypper.exitCode();
+            }
+
+            zypp::filesystem::TmpDir tmpDownloadDir;
+            zypp::Pathname destPath = _showFileListsSave
+                                          ? repo.info().metadataPath()
+                                          : tmpDownloadDir.path();
+
+            std::string fileListsUrl = getFileListsUrl(repomdPath);
+
+            if (fileListsUrl.empty()) {
+              zypper.out().error(
+                  "Failed to extract filelists URL from repomd.xml.");
+              zypper.setExitCode(ZYPPER_EXIT_ERR_ZYPP);
+              return zypper.exitCode();
+            }
+
+            zypp::Fetcher fetcher;
+            zypp::OnMediaLocation filelistLoc(fileListsUrl);
+            fetcher.enqueue(filelistLoc);
+            zypp::MediaSetAccess access(repo.info().url(), "/");
+
+            try {
+              fetcher.start(destPath, access, [](const ProgressData &pd) {
+                std::clog << "\r⠋ Downloading file list... " << pd.val() << "%"
+                          << std::flush;
+                return true;
+              });
+
+              std::clog << "\r\033[K" << "Downloading file list... [done]\n";
+            } catch (const zypp::Exception &e) {
+              std::string errorMessage = e.asUserHistory();
+              zypper.out().error(errorMessage);
+
+              if (errorMessage.find("not found") != std::string::npos ||
+                  errorMessage.find("404") != std::string::npos ||
+                  errorMessage.find("Not Found") != std::string::npos) {
+                zypper.out().info(
+                    "Hint: The remote server may have updated its packages "
+                    "and deleted this specific archive.");
+                zypper.out().info("Please run 'zypper refresh' to update your "
+                                  "local cache and try again.");
+              } else if (errorMessage.find("Permission denied") !=
+                             std::string::npos ||
+                         errorMessage.find("Can't hardlink/copy") !=
+                             std::string::npos) {
+
+                zypper.out().info("Hint: Saving file lists to the system cache "
+                                  "requires administrative privileges.");
+                zypper.out().info("Please run the command again using 'sudo'.");
+              }
+
+              zypper.setExitCode(ZYPPER_EXIT_ERR_ZYPP);
+              return zypper.exitCode();
+            }
+
+            zypp::Pathname remotePath(fileListsUrl);
+            zypp::Pathname downloadedFilePath = destPath / remotePath;
+
+            if (!zypp::filesystem::PathInfo(downloadedFilePath).isExist()) {
+              zypper.out().error(
+                  "Downloaded file not found at expected path: " +
+                  downloadedFilePath.asString());
+              zypper.setExitCode(ZYPPER_EXIT_ERR_ZYPP);
+              return zypper.exitCode();
+            }
+
+            std::clog << "Extracted package files: " << std::endl;
+            std::string targetArch = targetPackage.arch().asString();
+            extractPackageFiles(downloadedFilePath, targetName, targetArch);
+
+          } else if (fileListExistsLocally) {
+            std::clog << "Using local resource in: " << localFileListDir
+                      << std::endl;
+            std::clog << "Extracted package files: " << std::endl;
+            std::string targetArch = targetPackage.arch().asString();
+            extractPackageFiles(localFileListDir, targetName, targetArch);
+          }
+
+          return zypper.exitCode();
+        } /// ISSUE 633 FEATURE IMPLEMENTATION END.
+
+        FillSearchTableSelectable callback(t, inst_notinst);
+        invokeOnEach(query.selectableBegin(), query.selectableEnd(), callback);
       }
     }
 
-    if ( t.empty() )
-    {
+    if (t.empty()) {
       // translators: empty search result message
-      zypper.out().info(_("No matching items found."), Out::QUIET );
-      if ( !zypper.config().ignore_unknown ) {
-        zypper.setExitInfoCode( ZYPPER_EXIT_INF_CAP_NOT_FOUND );
+      zypper.out().info(_("No matching items found."), Out::QUIET);
+      if (!zypper.config().ignore_unknown) {
+        zypper.setExitInfoCode(ZYPPER_EXIT_INF_CAP_NOT_FOUND);
       }
-    }
-    else
-    {
+    } else {
       cout << endl; //! \todo  out().separator()?
 
-      if ( _details )
-      {
-        if ( _sortOpts._mode == SortResultOptionSet::ByRepo )
-          t.sort( { 5, 1, Table::UserData } );
+      if (_details) {
+        if (_sortOpts._mode == SortResultOptionSet::ByRepo)
+          t.sort({5, 1, Table::UserData});
         else
-          t.sort( { 1, Table::UserData } ); // sort by name
-      }
-      else
-      {
+          t.sort({1, Table::UserData}); // sort by name
+      } else {
         // sort by name (can't sort by repo)
-        t.sort( 1 );
-        if ( !zypper.config().no_abbrev )
-          t.allowAbbrev( 2 );
+        t.sort(1);
+        if (!zypper.config().no_abbrev)
+          t.allowAbbrev(2);
       }
 
-      //cout << t; //! \todo out().table()?
-      zypper.out().searchResult( t );
+      // cout << t; //! \todo out().table()?
+      zypper.out().searchResult(t);
     }
 
-    if ( !_requestedReverseSearch.is_initialized() )
-      searchPackagesHintHack::callOrNotify( zypper );
+    if (!_requestedReverseSearch.is_initialized())
+      searchPackagesHintHack::callOrNotify(zypper);
 
-  } catch ( const Exception & e )  {
-    zypper.out().error( e, _("Problem occurred initializing or executing the search query") + std::string(":"),
-      std::string(_("See the above message for a hint.")) + " "
-        + _("Running 'zypper refresh' as root might resolve the problem.") );
-    zypper.setExitCode( ZYPPER_EXIT_ERR_ZYPP );
+  } catch (const Exception &e) {
+    zypper.out().error(
+        e,
+        _("Problem occurred initializing or executing the search query") +
+            std::string(":"),
+        std::string(_("See the above message for a hint.")) + " " +
+            _("Running 'zypper refresh' as root might resolve the problem."));
+    zypper.setExitCode(ZYPPER_EXIT_ERR_ZYPP);
   }
 
   return zypper.exitCode();

--- a/src/commands/search/search.h
+++ b/src/commands/search/search.h
@@ -11,25 +11,17 @@
 #include "commands/optionsets.h"
 #include "utils/flags/zyppflags.h"
 
-
-#include <zypp/sat/SolvAttr.h>
 #include <boost/optional.hpp>
+#include <zypp/sat/SolvAttr.h>
 
-class SearchCmd : public ZypperBaseCommand
-{
+class SearchCmd : public ZypperBaseCommand {
 public:
+  enum MatchMode { Default, Substrings, Words, Exact };
 
-  enum MatchMode {
-    Default,
-    Substrings,
-    Words,
-    Exact
-  };
+  SearchCmd(std::vector<std::string> &&commandAliases_r);
 
-  SearchCmd ( std::vector<std::string> &&commandAliases_r );
-
-  void setMode(const MatchMode &mode_r );
-  void addRequestedDependency ( const zypp::sat::SolvAttr &dep_r );
+  void setMode(const MatchMode &mode_r);
+  void addRequestedDependency(const zypp::sat::SolvAttr &dep_r);
 
 private:
   MatchMode _mode = MatchMode::Default;
@@ -38,21 +30,27 @@ private:
   bool _caseSensitive = false;
   bool _details = false;
   bool _verbose = false;
+
+  bool _showFileLists = false;     /// ISSUE #633 FEATURE REQUEST -> S.A.T
+  bool _showFileListsSave = false; /// ISSUE #633 FEATURE REQUEST -> S.A.T
+
   std::set<zypp::sat::SolvAttr> _requestedDeps;
   boost::optional<zypp::sat::SolvAttr> _requestedReverseSearch;
 
   std::set<ResKind> _requestedTypes;
 
-  //careful when adding new optionsets, only enable them for the right command mode
-  NotInstalledOnlyOptionSet _notInstalledOpts { *this };
-  SortResultOptionSet _sortOpts { *this };
-  InitReposOptionSet _initReposOpts { *this };
+  // careful when adding new optionsets, only enable them for the right command
+  // mode
+  NotInstalledOnlyOptionSet _notInstalledOpts{*this};
+  SortResultOptionSet _sortOpts{*this};
+  InitReposOptionSet _initReposOpts{*this};
 
   // ZypperBaseCommand interface
 protected:
   zypp::ZyppFlags::CommandGroup cmdOptions() const override;
   void doReset() override;
-  int execute(Zypper &zypper, const std::vector<std::string> &positionalArgs_r) override;
+  int execute(Zypper &zypper,
+              const std::vector<std::string> &positionalArgs_r) override;
 
   // ZypperBaseCommand interface
 public:
@@ -61,7 +59,5 @@ public:
   std::string description() const override;
   std::string help() override;
 };
-
-
 
 #endif


### PR DESCRIPTION
Details:
New Flags: I added the --show-file-lists and --show-file-lists-save flags to the zypper search command. I included a safety check to stop the program if a user tries to pass both flags at the same time. XML Parsing: I built two custom libxml2 parsers to handle the metadata. The first parser reads the local repomd.xml to find the exact dynamic URL for the file lists. The second parser reads the filelists.xml.gz archive to extract just the files belonging to the specific package and architecture requested. Downloading and Caching: I connected Zypper's native fetcher, complete with a loading spinner, to handle the download. I also added a check to search the local /var/cache/zypp/raw directory first. If the file is already cached, it skips the network download entirely to save time. Error Handling: I added specific error handling to catch network exceptions, like a missing file on the remote server. If the fetcher fails to find the archive, the program explicitly tells the user to run zypper refresh to fix their local cache.