### PR TITLE
Add date filters to zypper search

### DIFF
--- a/src/commands/search/search.cc
+++ b/src/commands/search/search.cc
@@ -29,21 +29,26 @@ namespace zypp
       );
     }
 
+    bool isDigit( char value_r )
+    {
+      return std::isdigit( static_cast<unsigned char>( value_r ) );
+    }
+
     bool isIsoDateString( const std::string &value_r )
     {
       if ( value_r.size() != 10 )
         return false;
 
-      return std::isdigit( value_r[0] )
-          && std::isdigit( value_r[1] )
-          && std::isdigit( value_r[2] )
-          && std::isdigit( value_r[3] )
+      return isDigit( value_r[0] )
+          && isDigit( value_r[1] )
+          && isDigit( value_r[2] )
+          && isDigit( value_r[3] )
           && value_r[4] == '-'
-          && std::isdigit( value_r[5] )
-          && std::isdigit( value_r[6] )
+          && isDigit( value_r[5] )
+          && isDigit( value_r[6] )
           && value_r[7] == '-'
-          && std::isdigit( value_r[8] )
-          && std::isdigit( value_r[9] );
+          && isDigit( value_r[8] )
+          && isDigit( value_r[9] );
     }
 
     Value setDateOptional ( boost::optional<zypp::Date> &target_r )
@@ -257,11 +262,11 @@ zypp::ZyppFlags::CommandGroup SearchCmd::cmdOptions() const
       },
       { "install-after", '\0', ZyppFlags::RequiredArgument, ZyppFlags::setDateOptional( that._installDateRange.after ),
         // translators: --install-after DATE
-        _("Show installed packages installed after DATE. DATE must use the YYYY-MM-DD format.")
+        _("Show packages installed after DATE. DATE must use the YYYY-MM-DD format.")
       },
       { "install-before", '\0', ZyppFlags::RequiredArgument, ZyppFlags::setDateOptional( that._installDateRange.before ),
         // translators: --install-before DATE
-        _("Show installed packages installed before DATE. DATE must use the YYYY-MM-DD format.")
+        _("Show packages installed before DATE. DATE must use the YYYY-MM-DD format.")
       }
     },
     {
@@ -498,9 +503,6 @@ int SearchCmd::execute( Zypper &zypper, const std::vector<std::string> &position
       const auto reqSearchAttrib = _requestedReverseSearch.get();
 
       for ( const auto slv : query ) {
-
-        if ( !matchesDateFilters( slv ) )
-          continue;
 
         bool isInstalled = slv.isSystem();
         if ( isInstalled && _notInstalledOpts._mode == SolvableFilterMode::ShowOnlyNotInstalled )

--- a/src/commands/search/search.cc
+++ b/src/commands/search/search.cc
@@ -1,4 +1,6 @@
 #include "search.h"
+
+#include <cctype>
 #include "src/search.h"
 #include "global-settings.h"
 #include "utils/flags/flagtypes.h"
@@ -8,6 +10,7 @@
 
 #include <zypp/base/Algorithm.h>
 #include <zypp/sat/Solvable.h>
+#include <zypp/Date.h>
 #include <zypp/Capability.h>
 #include <zypp/PoolQueryResult.h>
 
@@ -24,6 +27,47 @@ namespace zypp
             [ &target_r, value_r ] ( const CommandOption &, const boost::optional<std::string> & ) {
               target_r.insert( value_r );
             }
+      );
+    }
+
+    bool isIsoDateString( const std::string &value_r )
+    {
+      if ( value_r.size() != 10 )
+        return false;
+
+      return std::isdigit( value_r[0] )
+          && std::isdigit( value_r[1] )
+          && std::isdigit( value_r[2] )
+          && std::isdigit( value_r[3] )
+          && value_r[4] == '-'
+          && std::isdigit( value_r[5] )
+          && std::isdigit( value_r[6] )
+          && value_r[7] == '-'
+          && std::isdigit( value_r[8] )
+          && std::isdigit( value_r[9] );
+    }
+
+    Value setDateOptional ( boost::optional<zypp::Date> &target_r )
+    {
+      return Value (
+            noDefaultValue,
+            [ &target_r ] ( const CommandOption &opt, const boost::optional<std::string> &in ) {
+              if ( !in )
+                ZYPP_THROW( MissingArgumentException( opt.name ) );
+
+              if ( !isIsoDateString( *in ) )
+                ZYPP_THROW( InvalidValueException( opt.name, *in, _("Expected date format: YYYY-MM-DD") ) );
+
+              try
+              {
+                target_r = zypp::Date( *in, "%Y-%m-%d" );
+              }
+              catch ( const zypp::Exception & )
+              {
+                ZYPP_THROW( InvalidValueException( opt.name, *in, _("Expected date format: YYYY-MM-DD") ) );
+              }
+            },
+            "DATE"
       );
     }
 
@@ -203,6 +247,22 @@ zypp::ZyppFlags::CommandGroup SearchCmd::cmdOptions() const
       {"verbose", 'v', ZyppFlags::NoArgument, ZyppFlags::BoolType( &that._verbose, ZyppFlags::StoreTrue, _caseSensitive ),
         // translators: -v, --verbose
         _("Like --details, with additional information where the search has matched (useful for search in dependencies).")
+      },
+      { "build-after", '\0', ZyppFlags::RequiredArgument, ZyppFlags::setDateOptional( that._buildDateRange.after ),
+        // translators: --build-after DATE
+        _("Show packages built after DATE. DATE must use the YYYY-MM-DD format.")
+      },
+      { "build-before", '\0', ZyppFlags::RequiredArgument, ZyppFlags::setDateOptional( that._buildDateRange.before ),
+        // translators: --build-before DATE
+        _("Show packages built before DATE. DATE must use the YYYY-MM-DD format.")
+      },
+      { "install-after", '\0', ZyppFlags::RequiredArgument, ZyppFlags::setDateOptional( that._installDateRange.after ),
+        // translators: --install-after DATE
+        _("Show installed packages installed after DATE. DATE must use the YYYY-MM-DD format.")
+      },
+      { "install-before", '\0', ZyppFlags::RequiredArgument, ZyppFlags::setDateOptional( that._installDateRange.before ),
+        // translators: --install-before DATE
+        _("Show installed packages installed before DATE. DATE must use the YYYY-MM-DD format.")
       }
     },
     {
@@ -228,7 +288,43 @@ void SearchCmd::doReset()
   _details = false;
   _verbose = false;
   _requestedDeps.clear();
+  _requestedReverseSearch.reset();
+  _buildDateRange = DateRange();
+  _installDateRange = DateRange();
   _requestedTypes.clear();
+}
+
+bool SearchCmd::hasDateFilters() const
+{
+  return _buildDateRange.after || _buildDateRange.before || _installDateRange.after || _installDateRange.before;
+}
+
+bool SearchCmd::matchesDateFilters( const sat::Solvable & solv_r ) const
+{
+  if ( !hasDateFilters() )
+    return true;
+
+  if ( _buildDateRange.after && solv_r.buildtime() < *_buildDateRange.after )
+    return false;
+
+  if ( _buildDateRange.before && solv_r.buildtime() > *_buildDateRange.before )
+    return false;
+
+  if ( _installDateRange.after || _installDateRange.before )
+  {
+    if ( !solv_r.isSystem() )
+      return false;
+
+    const auto installTime = solv_r.installtime();
+
+    if ( _installDateRange.after && installTime < *_installDateRange.after )
+      return false;
+
+    if ( _installDateRange.before && installTime > *_installDateRange.before )
+      return false;
+  }
+
+  return true;
 }
 
 int SearchCmd::execute( Zypper &zypper, const std::vector<std::string> &positionalArgs_r )
@@ -404,6 +500,9 @@ int SearchCmd::execute( Zypper &zypper, const std::vector<std::string> &position
 
       for ( const auto slv : query ) {
 
+        if ( !matchesDateFilters( slv ) )
+          continue;
+
         bool isInstalled = slv.isSystem();
         if ( isInstalled && _notInstalledOpts._mode == SolvableFilterMode::ShowOnlyNotInstalled )
           continue;
@@ -426,7 +525,10 @@ int SearchCmd::execute( Zypper &zypper, const std::vector<std::string> &position
 
       if ( details ) {
         FillSearchTableSolvable callback( t, inst_notinst );
-        std::for_each( matchedSolvables.begin(), matchedSolvables.end(), [&callback, verb = _verbose, &reqSearchAttrib ]( auto elem ){
+        std::for_each( matchedSolvables.begin(), matchedSolvables.end(), [this, &callback, verb = _verbose, &reqSearchAttrib ]( auto elem ){
+          if ( !matchesDateFilters( elem.first ) )
+            return;
+
           if ( verb )
             callback( elem.first, reqSearchAttrib, elem.second );
           else
@@ -435,7 +537,10 @@ int SearchCmd::execute( Zypper &zypper, const std::vector<std::string> &position
       } else {
 
         PoolQueryResult res;
-        std::for_each( matchedSolvables.begin(), matchedSolvables.end(), [ &res ]( const auto &v ){ res+=v.first; } );
+        std::for_each( matchedSolvables.begin(), matchedSolvables.end(), [ this, &res ]( const auto &v ){
+          if ( matchesDateFilters( v.first ) )
+            res += v.first;
+        } );
 
         FillSearchTableSelectable callback( t, inst_notinst );
         std::for_each( res.selectableBegin(), res.selectableEnd(), callback);
@@ -449,19 +554,29 @@ int SearchCmd::execute( Zypper &zypper, const std::vector<std::string> &position
         {
           // Option 'verbose' shows where (e.g. in 'requires', 'name') the search has matched.
           // Info is available from PoolQuery::const_iterator.
-          for_( it, query.begin(), query.end() )
-            callback( it );
+          for_( it, query.begin(), query.end() ) {
+            if ( matchesDateFilters( *it ) )
+              callback( it );
+          }
         }
         else
         {
-          for ( const auto slv : query )
-            callback( slv );
+          for ( const auto slv : query ) {
+            if ( matchesDateFilters( slv ) )
+              callback( slv );
+          }
         }
       }
       else
       {
+        PoolQueryResult res;
+        for ( const auto slv : query ) {
+          if ( matchesDateFilters( slv ) )
+            res += slv;
+        }
+
         FillSearchTableSelectable callback( t, inst_notinst );
-        invokeOnEach( query.selectableBegin(), query.selectableEnd(), callback );
+        invokeOnEach( res.selectableBegin(), res.selectableEnd(), callback );
       }
     }
 

--- a/src/commands/search/search.cc
+++ b/src/commands/search/search.cc
@@ -1,5 +1,4 @@
 #include "search.h"
-
 #include <cctype>
 #include "src/search.h"
 #include "global-settings.h"

--- a/src/commands/search/search.h
+++ b/src/commands/search/search.h
@@ -11,6 +11,7 @@
 #include "commands/optionsets.h"
 #include "utils/flags/zyppflags.h"
 
+#include <zypp/Date.h>
 
 #include <zypp/sat/SolvAttr.h>
 #include <boost/optional.hpp>
@@ -24,6 +25,12 @@ public:
     Substrings,
     Words,
     Exact
+  };
+
+  struct DateRange
+  {
+    boost::optional<zypp::Date> after;
+    boost::optional<zypp::Date> before;
   };
 
   SearchCmd ( std::vector<std::string> &&commandAliases_r );
@@ -40,6 +47,8 @@ private:
   bool _verbose = false;
   std::set<zypp::sat::SolvAttr> _requestedDeps;
   boost::optional<zypp::sat::SolvAttr> _requestedReverseSearch;
+  DateRange _buildDateRange;
+  DateRange _installDateRange;
 
   std::set<ResKind> _requestedTypes;
 
@@ -53,6 +62,9 @@ protected:
   zypp::ZyppFlags::CommandGroup cmdOptions() const override;
   void doReset() override;
   int execute(Zypper &zypper, const std::vector<std::string> &positionalArgs_r) override;
+
+  bool hasDateFilters() const;
+  bool matchesDateFilters( const zypp::sat::Solvable & solv_r ) const;
 
   // ZypperBaseCommand interface
 public:

--- a/tests/Search_104_test.cc
+++ b/tests/Search_104_test.cc
@@ -1,6 +1,7 @@
 #include <tests/lib/TestSetup.h>
 #include "commands/search/search.h"
 #include "commands/query.h"
+#include "utils/flags/flagtypes.h"
 
 using namespace zypp;
 
@@ -46,6 +47,40 @@ void runSearch( ZypperBaseCommand & cmd, const std::vector<std::string> & positi
   BOOST_CHECK_EQUAL( Zypper::instance().exitCode(), 0 );
   BOOST_CHECK_EQUAL( Zypper::instance().exitInfoCode(), exitInfoExpect );
 }
+
+void parseCommandArguments( ZypperBaseCommand & cmd, const std::vector<std::string> & args )
+{
+  std::vector<std::string> rawArgs;
+  rawArgs.push_back( cmd.command().front() );
+  rawArgs.insert( rawArgs.end(), args.begin(), args.end() );
+
+  std::vector<char *> argv;
+  for ( std::string & arg : rawArgs )
+    argv.push_back( const_cast<char *>( arg.c_str() ) );
+
+  cmd.reset();
+  const int firstPositional = cmd.parseArguments( Zypper::instance(), argv.size(), argv.data() );
+
+  std::vector<std::string> positionalArgs;
+  for ( int i = firstPositional; i < static_cast<int>( rawArgs.size() ); ++i )
+    positionalArgs.push_back( rawArgs[i] );
+
+  cmd.setPositionalArguments( positionalArgs );
+}
+
+void runSearchWithArgs( ZypperBaseCommand & cmd, const std::vector<std::string> & args, int exitInfoExpect, int exitInfoPre = 0 )
+{
+  Zypper::instance().clearExitInfoCode();  // The only way to reset! setExitInfoCode remembers the fist code set.
+  if ( exitInfoPre )
+    Zypper::instance().setExitInfoCode( exitInfoPre );
+
+  parseCommandArguments( cmd, args );
+
+  int res = cmd.run( Zypper::instance() );
+  BOOST_CHECK_EQUAL( res, 0 );
+  BOOST_CHECK_EQUAL( Zypper::instance().exitCode(), 0 );
+  BOOST_CHECK_EQUAL( Zypper::instance().exitInfoCode(), exitInfoExpect );
+}
 void runBasiccSearchTest( ZypperBaseCommand && cmd )
 {
   Zypper & zypper { Zypper::instance() };
@@ -66,4 +101,33 @@ BOOST_AUTO_TEST_CASE( basic )
   // search/info should behave similar
   runBasiccSearchTest( SearchCmd({ "search" }) );
   runBasiccSearchTest( InfoCmd({ "info" }) );
+}
+
+
+BOOST_AUTO_TEST_CASE( date_filters )
+{
+  Zypper::instance().configNoConst().ignore_unknown = false;
+
+  {
+    SearchCmd cmd({ "search" });
+    BOOST_REQUIRE_THROW(
+      parseCommandArguments( cmd, { "--build-after", "01-01-2024", "zypper" } ),
+      zypp::ZyppFlags::InvalidValueException
+    );
+  }
+
+  {
+    SearchCmd cmd({ "search" });
+    runSearchWithArgs( cmd, { "--build-after", "1900-01-01", "zypper" }, 0 );
+  }
+
+  {
+    SearchCmd cmd({ "search" });
+    runSearchWithArgs( cmd, { "--build-after", "2999-01-01", "zypper" }, 104 );
+  }
+
+  {
+    SearchCmd cmd({ "search" });
+    runSearchWithArgs( cmd, { "--install-after", "1900-01-01", "zypper" }, 104 );
+  }
 }


### PR DESCRIPTION
Fixes #575

## Summary

Adds date-based filters to `zypper search`:

- `--build-after YYYY-MM-DD`
- `--build-before YYYY-MM-DD`
- `--install-after YYYY-MM-DD`
- `--install-before YYYY-MM-DD`

## Validation

Built successfully in an openSUSE Tumbleweed container using:

```bash
cmake .. -DZYPP_PREFIX=/usr -DCMAKE_INSTALL_PREFIX=/usr -DLIB=lib64
make -j1
```

Manually validated:

```bash
./src/zypper search --help | grep -E "build-after|build-before|install-after|install-before"
./src/zypper search --build-after 01-01-2024 zypper
./src/zypper search --build-after 2024-01-01 zypper
```

## Notes

This PR intentionally limits the initial scope to filtering results only. It does not add new table columns or XML output fields, keeping the change small and easier to review.